### PR TITLE
Avoid unintended rexports.

### DIFF
--- a/typeshed/stdlib/microbit/audio.pyi
+++ b/typeshed/stdlib/microbit/audio.pyi
@@ -1,7 +1,7 @@
 """Play sounds using the micro:bit (import ``audio`` for V1 compatibility).
 """
 
-from . import MicroBitDigitalPin, Sound, pin0
+from ..microbit import MicroBitDigitalPin, Sound, pin0
 from typing import Iterable, Union
 
 def play(

--- a/typeshed/stdlib/microbit/display.pyi
+++ b/typeshed/stdlib/microbit/display.pyi
@@ -1,7 +1,7 @@
 """Show text, images and animations on the 5×5 LED display.
 """
 
-from . import Image
+from ..microbit import Image
 from typing import Union, overload, Iterable
 
 def get_pixel(x: int, y: int) -> int:

--- a/typeshed/stdlib/microbit/i2c.pyi
+++ b/typeshed/stdlib/microbit/i2c.pyi
@@ -2,9 +2,8 @@
 """
 
 from _typeshed import ReadableBuffer
-from . import MicroBitDigitalPin, pin19, pin20
-from typing import List, Union
-from . import pin19, pin20
+from ..microbit import MicroBitDigitalPin, pin19, pin20
+from typing import List
 
 def init(
     freq: int = 100000, sda: MicroBitDigitalPin = pin20, scl: MicroBitDigitalPin = pin19

--- a/typeshed/stdlib/microbit/microphone.pyi
+++ b/typeshed/stdlib/microbit/microphone.pyi
@@ -2,7 +2,7 @@
 """
 
 from typing import Optional, Tuple
-from . import SoundEvent
+from ..microbit import SoundEvent
 
 def current_event() -> Optional[SoundEvent]:
     """Get the last recorded sound event

--- a/typeshed/stdlib/microbit/spi.pyi
+++ b/typeshed/stdlib/microbit/spi.pyi
@@ -2,8 +2,7 @@
 """
 
 from _typeshed import ReadableBuffer, WriteableBuffer
-from . import pin13, pin14, pin15, MicroBitDigitalPin
-from typing import Union
+from ..microbit import pin13, pin14, pin15, MicroBitDigitalPin
 
 def init(
     baudrate: int = 1000000,

--- a/typeshed/stdlib/microbit/uart.pyi
+++ b/typeshed/stdlib/microbit/uart.pyi
@@ -1,8 +1,8 @@
 """Communicate with a device using a serial interface.
 """
 
-from _typeshed import ReadableBuffer, WriteableBuffer
-from . import MicroBitDigitalPin
+from _typeshed import WriteableBuffer
+from ..microbit import MicroBitDigitalPin
 from typing import Optional, Union
 
 ODD: int


### PR DESCRIPTION
Feels like a bit of a hack, but `from . import X` is defined to make X
available to Pyright so we need to avoid that pattern when importing
from `__init__`. We don't have the freedom to restructure so avoid it
with ..microbit.