### PR TITLE
radio: remove RATE_250KBIT

### DIFF
--- a/typeshed/stdlib/radio.pyi
+++ b/typeshed/stdlib/radio.pyi
@@ -4,11 +4,6 @@
 from _typeshed import WriteableBuffer
 from typing import Optional, Tuple
 
-RATE_250KBIT: int
-"""Constant used to indicate a throughput of 256 Kbit a second. 
-
-Not available on V2."""
-
 RATE_1MBIT: int
 """Constant used to indicate a throughput of 1 MBit a second."""
 


### PR DESCRIPTION
This isn't supported on V2. On balance we think we should remove from
the stubs as it'll be little used.

Closes https://github.com/microbit-foundation/micropython-microbit-stubs/issues/26