### PR TITLE
Format param docs for Pyright.

### DIFF
--- a/typeshed/stdlib/log.pyi
+++ b/typeshed/stdlib/log.pyi
@@ -34,10 +34,7 @@ def set_labels(
 
     :param *args: A positional argument for each log header.
     :param timestamp: The timestamp unit that will be automatically added as the first column in every row.
-    Setting this argument to `None` disables the timestamp.
-    Pass the ``log.MILLISECONDS``, ``log.SECONDS``, , ``log.MINUTES``,
-    ``log.HOURS`` or ``log.DAYS`` values defined by this module.
-    An invalid value will throw an exception.
+    Setting this argument to `None` disables the timestamp. Pass the ``log.MILLISECONDS``, ``log.SECONDS``, , ``log.MINUTES``, ``log.HOURS`` or ``log.DAYS`` values defined by this module. An invalid value will throw an exception.
     """
     ...
 

--- a/typeshed/stdlib/radio.pyi
+++ b/typeshed/stdlib/radio.pyi
@@ -42,40 +42,20 @@ def config(
 
     The default configuration is suitable for most use.
 
-    :param length: (default=32) defines the maximum length, in bytes, of a
-    message sent via the radio. It can be up to 251 bytes long (254 - 3 bytes
-    for S0, LENGTH and S1 preamble).
-
-    :param queue: (default=3) specifies the number of messages that can be
-    stored on the incoming message queue. If there are no spaces left on the
-    queue for incoming messages, then the incoming message is dropped.
-
-    :param channel: (default=7) an integer value from 0 to 83
-    (inclusive) that defines an arbitrary "channel" to which the radio is
-    tuned. Messages will be sent via this channel and only messages received
-    via this channel will be put onto the incoming message queue. Each step is
-    1MHz wide, based at 2400MHz.
-
-    :param power: (default=6) is an integer value from 0 to 7 (inclusive) to
-    indicate the strength of signal used when broadcasting a message. The
-    higher the value the stronger the signal, but the more power is consumed
-    by the device. The numbering translates to positions in the following list
-    of dBm (decibel milliwatt) values: -30, -20, -16, -12, -8, -4, 0, 4.
-
-    :param address: (default=0x75626974) an arbitrary name, expressed as a
-    32-bit address, that's used to filter incoming packets at the hardware
-    level, keeping only those that match the address you set. The default used
-    by other micro:bit related platforms is the default setting used here.
-
-    :param group: (default=0) an 8-bit value (0-255) used with the
-    ``address`` when filtering messages. Conceptually, "address" is like a
-    house/office address and "group" is like the person at that address to
-    which you want to send your message.
-
-    :param data_rate: (default=radio.RATE_1MBIT) indicates the speed at which
-    data throughput takes place. Can be one of the following constants defined
-    in the ``radio`` module:
-    ``RATE_250KBIT``, ``RATE_1MBIT`` or ``RATE_2MBIT``.
+    :param length: (default=32) defines the maximum length, in bytes, of a message sent via the radio.
+    It can be up to 251 bytes long (254 - 3 bytes for S0, LENGTH and S1 preamble).
+    :param queue: (default=3) specifies the number of messages that can be stored on the incoming message queue.
+    If there are no spaces left on the queue for incoming messages, then the incoming message is dropped.
+    :param channel: (default=7) an integer value from 0 to 83 (inclusive) that defines an arbitrary "channel" to which the radio is tuned.
+    Messages will be sent via this channel and only messages received via this channel will be put onto the incoming message queue. Each step is 1MHz wide, based at 2400MHz.
+    :param power: (default=6) is an integer value from 0 to 7 (inclusive) to indicate the strength of signal used when broadcasting a message.
+    The higher the value the stronger the signal, but the more power is consumed by the device. The numbering translates to positions in the following list of dBm (decibel milliwatt) values: -30, -20, -16, -12, -8, -4, 0, 4.
+    :param address: (default=0x75626974) an arbitrary name, expressed as a 32-bit address, that's used to filter incoming packets at the hardware level, keeping only those that match the address you set.
+    The default used by other micro:bit related platforms is the default setting used here.
+    :param group: (default=0) an 8-bit value (0-255) used with the ``address`` when filtering messages.
+    Conceptually, "address" is like a house/office address and "group" is like the person at that address to which you want to send your message.
+    :param data_rate: (default=radio.RATE_1MBIT) indicates the speed at which data throughput takes place.
+    Can be one of the following constants defined in the ``radio`` module: ``RATE_250KBIT``, ``RATE_1MBIT`` or ``RATE_2MBIT``.
 
     If ``config`` is not called then the defaults described above are assumed.
     """

--- a/typeshed/stdlib/speech.pyi
+++ b/typeshed/stdlib/speech.pyi
@@ -38,9 +38,8 @@ def pronounce(
     :param speed: A number representing the speed of the voice
     :param mouth: A number representing the mouth of the voice
     :param throat: A number representing the throat of the voice
-    :param pin: Optional argument to specify the output pin can be
-    used to override the default of ``pin0``. If we do not want any sound to
-    play out of the pins can use ``pin=None``. microbit V2 only.
+    :param pin: Optional argument to specify the output pin can be used to override the default of ``pin0``.
+    If we do not want any sound to play out of the pins can use ``pin=None``. microbit V2 only.
 
     Override the optional pitch, speed, mouth and throat settings to change the
     timbre (quality) of the voice.
@@ -66,9 +65,8 @@ def say(
     :param speed: A number representing the speed of the voice
     :param mouth: A number representing the mouth of the voice
     :param throat: A number representing the throat of the voice
-    :param pin: Optional argument to specify the output pin can be
-    used to override the default of ``pin0``. If we do not want any sound to
-    play out of the pins can use ``pin=None``. microbit V2 only.
+    :param pin: Optional argument to specify the output pin can be used to override the default of ``pin0``.
+    If we do not want any sound to play out of the pins can use ``pin=None``. microbit V2 only.
 
     The result is semi-accurate for English. Override the optional pitch, speed,
     mouth and throat settings to change the timbre (quality) of the voice.
@@ -97,9 +95,8 @@ def sing(
     :param speed: A number representing the speed of the voice
     :param mouth: A number representing the mouth of the voice
     :param throat: A number representing the throat of the voice
-    :param pin: Optional argument to specify the output pin can be
-    used to override the default of ``pin0``. If we do not want any sound to
-    play out of the pins can use ``pin=None``. microbit V2 only.
+    :param pin: Optional argument to specify the output pin can be used to override the default of ``pin0``.
+    If we do not want any sound to play out of the pins can use ``pin=None``. microbit V2 only.
 
     Override the optional pitch, speed, mouth and throat settings to change
     the timbre (quality) of the voice.

--- a/typeshed/stdlib/utime.pyi
+++ b/typeshed/stdlib/utime.pyi
@@ -9,8 +9,8 @@ def sleep(seconds: Union[int, float]) -> None:
 
     Example: ``utime.sleep(1)``
 
-    :param seconds: The number of seconds to sleep for. Use a floating-point
-    number to sleep for a fractional number of seconds.
+    :param seconds: The number of seconds to sleep for.
+    Use a floating-point number to sleep for a fractional number of seconds.
     """
     ...
 


### PR DESCRIPTION
Pyright takes the first line of the param docs for signature help. Re-order some param docs to make the first line also the first sentence to avoid mid-sentence breaks.

See [#760](https://github.com/microbit-foundation/python-editor-next/issues/760).