### PR TITLE
Replace microbit with micro:bit when not API name.

### DIFF
--- a/typeshed/stdlib/neopixel.pyi
+++ b/typeshed/stdlib/neopixel.pyi
@@ -33,7 +33,7 @@ class NeoPixel:
         """
         ...
     def write(self) -> None:
-        """Show the pixels (microbit V2 only).
+        """Show the pixels (micro:bit V2 only).
 
         Example: ``np.write()``
 

--- a/typeshed/stdlib/speech.pyi
+++ b/typeshed/stdlib/speech.pyi
@@ -39,7 +39,7 @@ def pronounce(
     :param mouth: A number representing the mouth of the voice
     :param throat: A number representing the throat of the voice
     :param pin: Optional argument to specify the output pin can be used to override the default of ``pin0``.
-    If we do not want any sound to play out of the pins can use ``pin=None``. microbit V2 only.
+    If we do not want any sound to play out of the pins can use ``pin=None``. micro:bit V2 only.
 
     Override the optional pitch, speed, mouth and throat settings to change the
     timbre (quality) of the voice.
@@ -66,7 +66,7 @@ def say(
     :param mouth: A number representing the mouth of the voice
     :param throat: A number representing the throat of the voice
     :param pin: Optional argument to specify the output pin can be used to override the default of ``pin0``.
-    If we do not want any sound to play out of the pins can use ``pin=None``. microbit V2 only.
+    If we do not want any sound to play out of the pins can use ``pin=None``. micro:bit V2 only.
 
     The result is semi-accurate for English. Override the optional pitch, speed,
     mouth and throat settings to change the timbre (quality) of the voice.
@@ -96,7 +96,7 @@ def sing(
     :param mouth: A number representing the mouth of the voice
     :param throat: A number representing the throat of the voice
     :param pin: Optional argument to specify the output pin can be used to override the default of ``pin0``.
-    If we do not want any sound to play out of the pins can use ``pin=None``. microbit V2 only.
+    If we do not want any sound to play out of the pins can use ``pin=None``. micro:bit V2 only.
 
     Override the optional pitch, speed, mouth and throat settings to change
     the timbre (quality) of the voice.


### PR DESCRIPTION
Closes #46.