### PR TITLE
Add backticks to default values for formatting.

### DIFF
--- a/typeshed/stdlib/microbit/__init__.pyi
+++ b/typeshed/stdlib/microbit/__init__.pyi
@@ -152,7 +152,7 @@ class MicroBitDigitalPin:
 
         Example: ``pin0.write_digital(1)``
 
-        :param value: ``1`` to set the pin high or ``0`` to set the pin low"""
+        :param value: 1 to set the pin high or 0 to set the pin low"""
         ...
     def set_pull(self, value: int) -> None:
         """Set the pull state to one of three possible values: ``PULL_UP``, ``PULL_DOWN`` or ``NO_PULL``.

--- a/typeshed/stdlib/microbit/i2c.pyi
+++ b/typeshed/stdlib/microbit/i2c.pyi
@@ -13,8 +13,8 @@ def init(
     Example: ``i2c.init()``
 
     :param freq: clock frequency
-    :param sda: ``sda`` pin (default ``20``)
-    :param scl: ``scl`` pin (default ``19``)
+    :param sda: ``sda`` pin (default 20)
+    :param scl: ``scl`` pin (default 19)
 
     On a micro:bit V1 board, changing the I²C pins from defaults will make
     the accelerometer and compass stop working, as they are connected

--- a/typeshed/stdlib/microbit/spi.pyi
+++ b/typeshed/stdlib/microbit/spi.pyi
@@ -21,9 +21,9 @@ def init(
     :param baudrate: The speed of communication.
     :param bits: The size of bytes being transmitted. Currently only ``bits=8`` is supported. However, this may change in the future.
     :param mode: Determines the combination of clock polarity and phase - `see online table <https://microbit-micropython.readthedocs.io/en/v2-docs/spi.html#microbit.spi.init>`_.
-    :param sclk: sclk pin (default ``13``)
-    :param mosi: mosi pin (default ``15``)
-    :param miso: miso pin (default ``14``)
+    :param sclk: sclk pin (default 13)
+    :param mosi: mosi pin (default 15)
+    :param miso: miso pin (default 14)
     """
     ...
 

--- a/typeshed/stdlib/neopixel.pyi
+++ b/typeshed/stdlib/neopixel.pyi
@@ -15,7 +15,7 @@ class NeoPixel:
 
         :param pin: The pin controlling the neopixel strip.
         :param n: The number of neopixels in the strip.
-        :param bpp: Bytes per pixel. For micro:bit V2 RGBW neopixel support, pass ``4`` rather than the default of ``3`` for RGB and GRB.
+        :param bpp: Bytes per pixel. For micro:bit V2 RGBW neopixel support, pass 4 rather than the default of 3 for RGB and GRB.
         """
         ...
     def clear(self) -> None:

--- a/typeshed/stdlib/radio.pyi
+++ b/typeshed/stdlib/radio.pyi
@@ -42,17 +42,17 @@ def config(
 
     The default configuration is suitable for most use.
 
-    :param length: (default=``32``) defines the maximum length, in bytes, of a message sent via the radio.
+    :param length: (default=32) defines the maximum length, in bytes, of a message sent via the radio.
     It can be up to 251 bytes long (254 - 3 bytes for S0, LENGTH and S1 preamble).
-    :param queue: (default=``3``) specifies the number of messages that can be stored on the incoming message queue.
+    :param queue: (default=3) specifies the number of messages that can be stored on the incoming message queue.
     If there are no spaces left on the queue for incoming messages, then the incoming message is dropped.
-    :param channel: (default=``7``) an integer value from 0 to 83 (inclusive) that defines an arbitrary "channel" to which the radio is tuned.
+    :param channel: (default=7) an integer value from 0 to 83 (inclusive) that defines an arbitrary "channel" to which the radio is tuned.
     Messages will be sent via this channel and only messages received via this channel will be put onto the incoming message queue. Each step is 1MHz wide, based at 2400MHz.
-    :param power: (default=``6``) is an integer value from 0 to 7 (inclusive) to indicate the strength of signal used when broadcasting a message.
+    :param power: (default=6) is an integer value from 0 to 7 (inclusive) to indicate the strength of signal used when broadcasting a message.
     The higher the value the stronger the signal, but the more power is consumed by the device. The numbering translates to positions in the following list of dBm (decibel milliwatt) values: -30, -20, -16, -12, -8, -4, 0, 4.
-    :param address: (default=``0x75626974``) an arbitrary name, expressed as a 32-bit address, that's used to filter incoming packets at the hardware level, keeping only those that match the address you set.
+    :param address: (default=0x75626974) an arbitrary name, expressed as a 32-bit address, that's used to filter incoming packets at the hardware level, keeping only those that match the address you set.
     The default used by other micro:bit related platforms is the default setting used here.
-    :param group: (default=``0``) an 8-bit value (0-255) used with the ``address`` when filtering messages.
+    :param group: (default=0) an 8-bit value (0-255) used with the ``address`` when filtering messages.
     Conceptually, "address" is like a house/office address and "group" is like the person at that address to which you want to send your message.
     :param data_rate: (default=``radio.RATE_1MBIT``) indicates the speed at which data throughput takes place.
     Can be one of the following constants defined in the ``radio`` module: ``RATE_250KBIT``, ``RATE_1MBIT`` or ``RATE_2MBIT``.


### PR DESCRIPTION
This also makes converting these values to placeholders for translation easier.