### PR TITLE
Explicitly list which modules to translate/export.

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -38,7 +38,7 @@ def module_name_for_path(file_path: str):
     return os.path.splitext(name)[0]
 
 
-def get_stub_files() -> list[TypeshedFile]:
+def get_stub_files(approved_modules: list[str]) -> list[TypeshedFile]:
     top = os.path.join(DIR, "..", "lang/en/typeshed/stdlib")
     files_to_process: list[TypeshedFile] = []
     for root, dirs, files in os.walk(top):
@@ -47,26 +47,25 @@ def get_stub_files() -> list[TypeshedFile]:
             # Skip audio stubs file that imports from microbit audio
             # (so we don't include its docstring)
             if (
-                os.path.basename(os.path.dirname(file_path)) != "microbit"
-                and name == "audio.pyi"
+                os.path.basename(os.path.dirname(file_path)) in approved_modules
+                or os.path.splitext(name)[0] in approved_modules
             ):
-                continue
-            if name.endswith(".pyi"):
-                files_to_process.append(
-                    TypeshedFile(
-                        file_path=file_path,
-                        module_name=module_name_for_path(file_path),
-                        python_file=True,
+                if name.endswith(".pyi"):
+                    files_to_process.append(
+                        TypeshedFile(
+                            file_path=file_path,
+                            module_name=module_name_for_path(file_path),
+                            python_file=True,
+                        )
                     )
-                )
-            else:
-                files_to_process.append(
-                    TypeshedFile(
-                        file_path=file_path,
-                        module_name="",
-                        python_file=False,
+                else:
+                    files_to_process.append(
+                        TypeshedFile(
+                            file_path=file_path,
+                            module_name="",
+                            python_file=False,
+                        )
                     )
-                )
     return sorted(files_to_process, key=lambda x: x.file_path)
 
 

--- a/scripts/crowdin_convert.py
+++ b/scripts/crowdin_convert.py
@@ -18,11 +18,29 @@ NODE_TYPES_WITH_DOCSTRINGS = (ast.FunctionDef, ast.Module, ast.ClassDef)
 EN_JSON_PATH = os.path.join(DIR, "../crowdin/api.en.json")
 TRANSLATED_JSON_DIR = os.path.join(DIR, "../crowdin/translated")
 
+modules = [
+    "gc",
+    "log",
+    "machine",
+    "math",
+    "microbit",
+    "micropython",
+    "music",
+    "neopixel",
+    "os",
+    "radio",
+    "random",
+    "speech",
+    "struct",
+    "sys",
+    "time",
+]
+
 
 def typeshed_to_crowdin():
     """Entrypoint to convert from English typeshed files to a JSON file for Crowdin translation."""
     data = {}
-    files_to_process = get_stub_files()
+    files_to_process = get_stub_files(modules)
     for ts_file in files_to_process:
         if not ts_file.python_file:
             continue
@@ -231,7 +249,7 @@ def crowdin_to_typeshed():
     """Entrypoint to convert from Crowdin (translated) JSON to individual typeshed files."""
     en_json = read_json(EN_JSON_PATH)
     translations_to_process = get_translated_json_files()
-    stubs_to_process = get_stub_files()
+    stubs_to_process = get_stub_files(modules)
     for translated in translations_to_process:
         translated_json = read_json(translated)
         lang = os.path.basename(translated).split(".")[1]

--- a/scripts/export_api_ids.py
+++ b/scripts/export_api_ids.py
@@ -38,7 +38,7 @@ modules = [
 
 def export_api_ids():
     data_list = []
-    files_to_process = get_stub_files()
+    files_to_process = get_stub_files(modules)
     for ts_file in files_to_process:
         if ts_file.python_file:
             data_list = data_list + get_api_ids(ts_file)
@@ -51,14 +51,6 @@ def export_api_ids():
 def save_api_ids(data):
     with open(os.path.join(DIR, "../", "api-ids.json"), "w") as file:
         file.write(json.dumps(data, indent=2))
-
-
-def checkModuleRequired(module_name):
-    if module_name in modules:
-        return True
-    if "microbit" in module_name:
-        return True
-    return False
 
 
 def get_api_ids(ts_file: TypeshedFile):
@@ -83,8 +75,7 @@ def get_api_ids(ts_file: TypeshedFile):
                                 suffix += 1
                                 key = f"{key_root}-{suffix}"
             self.used_keys.add(key)
-            if checkModuleRequired(ts_file.module_name):
-                self.data.append(key)
+            self.data.append(key)
 
     collector = DocStringCollector()
     collector.visit(tree)


### PR DESCRIPTION
This moves away from just putting anything with a docstring into Crowdin for translation. We instead use a curated list of modules which are shown in the Python Editor API sidebar section.