### PR TITLE
Don't duplicate non-translated func/param names.

### DIFF
--- a/lang/es-es/typeshed/stdlib/log.pyi
+++ b/lang/es-es/typeshed/stdlib/log.pyi
@@ -24,7 +24,7 @@ labels set up by this function call to the last headers declared in the
 file. If the headers are different it will add a new header entry at the
 end of the file.
 
-:param *args: (*args) Un argumento posicional para cada cabecera de registro.
+:param *args: Un argumento posicional para cada cabecera de registro.
 :param timestamp: (marca de tiempo) La unidad de marca temporal que se añadirá automáticamente como la primera columna en cada fila.
 Establecer este argumento a ``None`` desactiva la marca temporal. Se le pueden pasar los valores ``log.MILLISECONDS``, ``log.SECONDS``, ``log.MINUTES``, ``log.HOURS`` o ``log.DAYS`` definidos en este módulo. Un valor no válido lanzará una excepción."""
     ...

--- a/lang/es-es/typeshed/stdlib/machine.pyi
+++ b/lang/es-es/typeshed/stdlib/machine.pyi
@@ -54,14 +54,14 @@ function first waits until the pin input becomes equal to
 ``pulse_level``. If the pin is already equal to ``pulse_level`` then timing
 starts straight away.
 
-:param pin: (pin) Pin a usar
+:param pin: Pin a usar
 :param pulse_level: (nivel de estado) 0 para cronometrar un estado bajo o 1 para un estado alto
 :param timeout_us: (tiempo de espera us) Tiempo de espera en microsegundos
 :return: The duration of the pulse in microseconds, or -1 for a timeout waiting for the level to match ``pulse_level``, or -2 on timeout waiting for the pulse to end"""
     ...
 
 class mem:
-    """Clase para las vistas de memoria ``mem8``, ``mem16`` y ``mem32``. (mem)"""
+    """Clase para las vistas de memoria ``mem8``, ``mem16`` y ``mem32``."""
 
     def __getitem__(self, address: int) -> int:
         """Accede a un valor de la memoria. (obtener elemento)
@@ -77,8 +77,8 @@ class mem:
 :param value: (valor) El valor entero a establecer."""
         ...
 mem8: mem
-"""Vista de memoria de 8 bits (byte). (mem8)"""
+"""Vista de memoria de 8 bits (byte)."""
 mem16: mem
-"""Vista de memoria de 16 bits. (mem16)"""
+"""Vista de memoria de 16 bits."""
 mem32: mem
-"""Vista de memoria de 32 bits. (mem32)"""
+"""Vista de memoria de 32 bits."""

--- a/lang/es-es/typeshed/stdlib/math.pyi
+++ b/lang/es-es/typeshed/stdlib/math.pyi
@@ -2,11 +2,11 @@
 from typing import Tuple
 
 def acos(x: float) -> float:
-    """Calcula el inverso del coseno. (acos)
+    """Calcula el inverso del coseno.
 
 Example: ``math.acos(1)``
 
-:param x: (x) Un número
+:param x: Un número
 :return: The inverse cosine of ``x``"""
     ...
 
@@ -15,26 +15,26 @@ def asin(x: float) -> float:
 
 Example: ``math.asin(0)``
 
-:param x: (x) Un número
+:param x: Un número
 :return: The inverse sine of ``x``"""
     ...
 
 def atan(x: float) -> float:
-    """Calcula el inverso de la tangente. (atan)
+    """Calcula el inverso de la tangente.
 
 Example: ``math.atan(0)``
 
-:param x: (x) Un número
+:param x: Un número
 :return: The inverse tangent of ``x``"""
     ...
 
 def atan2(y: float, x: float) -> float:
-    """Calcula el valor principal del inverso de la tangente de ``y/x``. (atan2)
+    """Calcula el valor principal del inverso de la tangente de ``y/x``.
 
 Example: ``math.atan2(0, -1)``
 
-:param y: (x) Un número
-:param x: (x) Un número
+:param y: Un número
+:param x: Un número
 :return: The principal value of the inverse tangent of ``y/x``"""
     ...
 
@@ -43,26 +43,26 @@ def ceil(x: float) -> float:
 
 Example: ``math.ceil(0.1)``
 
-:param x: (x) Un número
+:param x: Un número
 :return: ``x`` rounded towards positive infinity."""
     ...
 
 def copysign(x: float, y: float) -> float:
-    """Calcula ``x`` con el signo de ``y``. (copysign)
+    """Calcula ``x`` con el signo de ``y``.
 
 Example: ``math.copysign(1, -1)``
 
-:param x: (x) Un número
-:param y: (y) Procedencia del signo para el valor que devuelve
+:param x: Un número
+:param y: Procedencia del signo para el valor que devuelve
 :return: ``x`` with the sign of ``y``"""
     ...
 
 def cos(x: float) -> float:
-    """Calcula el coseno de ``x``. (cos)
+    """Calcula el coseno de ``x``.
 
 Example: ``math.cos(0)``
 
-:param x: (x) Un número
+:param x: Un número
 :return: The cosine of ``x``"""
     ...
 
@@ -71,25 +71,25 @@ def degrees(x: float) -> float:
 
 Example: ``math.degrees(2 * math.pi)``
 
-:param x: (x) Un valor en radianes
+:param x: Un valor en radianes
 :return: The value converted to degrees"""
     ...
 
 def exp(x: float) -> float:
-    """Calcular el exponencial de ``x``. (exp)
+    """Calcular el exponencial de ``x``.
 
 Example: ``math.exp(1)``
 
-:param x: (x) Un número
+:param x: Un número
 :return: The exponential of ``x``."""
     ...
 
 def fabs(x: float) -> float:
-    """Devuelve el valor absoluto de ``x``. (fabs)
+    """Devuelve el valor absoluto de ``x``.
 
 Example: ``math.fabs(-0.1)``
 
-:param x: (x) Un número
+:param x: Un número
 :return: The absolute value of ``x``"""
     ...
 
@@ -98,21 +98,21 @@ def floor(x: float) -> int:
 
 Example: ``math.floor(0.9)``
 
-:param x: (x) Un número
+:param x: Un número
 :return: ``x`` rounded towards negative infinity."""
     ...
 
 def fmod(x: float, y: float) -> float:
-    """Calcula el resto de ``x/y``. (fmod)
+    """Calcula el resto de ``x/y``.
 
 Example: ``math.fmod(10, 3)``
 
-:param x: (x) El numerador
-:param y: (y) El denominador"""
+:param x: El numerador
+:param y: El denominador"""
     ...
 
 def frexp(x: float) -> Tuple[float, int]:
-    """Descompone un número de coma flotante en su mantisa y exponente. (frexp)
+    """Descompone un número de coma flotante en su mantisa y exponente.
 
 Example: ``mantissa, exponent = math.frexp(2)``
 
@@ -120,7 +120,7 @@ The returned value is the tuple ``(m, e)`` such that ``x == m * 2**e``
 exactly.  If ``x == 0`` then the function returns ``(0.0, 0)``, otherwise
 the relation ``0.5 <= abs(m) < 1`` holds.
 
-:param x: (x) Un número de coma flotante
+:param x: Un número de coma flotante
 :return: A tuple of length two containing its mantissa then exponent"""
     ...
 
@@ -129,7 +129,7 @@ def isfinite(x: float) -> bool:
 
 Example: ``math.isfinite(float('inf'))``
 
-:param x: (x) Un número.
+:param x: Un número.
 :return: ``True`` if ``x`` is finite, ``False`` otherwise."""
     ...
 
@@ -138,7 +138,7 @@ def isinf(x: float) -> bool:
 
 Example: ``math.isinf(float('-inf'))``
 
-:param x: (x) Un número.
+:param x: Un número.
 :return: ``True`` if ``x`` is infinite, ``False`` otherwise."""
     ...
 
@@ -147,17 +147,17 @@ def isnan(x: float) -> bool:
 
 Example: ``math.isnan(float('nan'))``
 
-:param x: (x) Un número
+:param x: Un número
 :return: ``True`` if ``x`` is not-a-number (NaN), ``False`` otherwise."""
     ...
 
 def ldexp(x: float, exp: int) -> float:
-    """Calcula ``x * (2**exp)``. (ldexp)
+    """Calcula ``x * (2**exp)``.
 
 Example: ``math.ldexp(0.5, 2)``
 
-:param x: (x) Un número
-:param exp: (exp) Exponente entero
+:param x: Un número
+:param exp: Exponente entero
 :return: ``x * (2**exp)``"""
     ...
 
@@ -170,29 +170,29 @@ With one argument, return the natural logarithm of x (to base e).
 
 With two arguments, return the logarithm of x to the given base, calculated as ``log(x)/log(base)``.
 
-:param x: (x) Un número
-:param base: (base) La base a usar
+:param x: Un número
+:param base: La base a usar
 :return: The natural logarithm of ``x``"""
     ...
 
 def modf(x: float) -> Tuple[float, float]:
-    """Calcula la parte fraccionaria y entera de ``x``. (modf)
+    """Calcula la parte fraccionaria y entera de ``x``.
 
 Example: ``fractional, integral = math.modf(1.5)``
 
-:param x: (x) Un número
+:param x: Un número
 :return: A tuple of two floats representing the fractional then integral parts of ``x``.
 
 Both the fractional and integral values have the same sign as ``x``."""
     ...
 
 def pow(x: float, y: float) -> float:
-    """Devuelve ``x`` elevado a ``y``. (pow)
+    """Devuelve ``x`` elevado a ``y``.
 
 Example: ``math.pow(4, 0.5)``
 
-:param x: (x) Un número
-:param y: (y) El exponente
+:param x: Un número
+:param y: El exponente
 :return: ``x`` to the power of ``y``"""
     ...
 
@@ -201,7 +201,7 @@ def radians(x: float) -> float:
 
 Example: ``math.radians(360)``
 
-:param x: (x) Un valor en grados
+:param x: Un valor en grados
 :return: The value converted to radians"""
     ...
 
@@ -210,37 +210,37 @@ def sin(x: float) -> float:
 
 Example: ``math.sin(math.pi/2)``
 
-:param x: (x) Un número
+:param x: Un número
 :return: The sine of ``x``"""
     ...
 
 def sqrt(x: float) -> float:
-    """Calcula la raíz cuadrada de ``x``. (sqrt)
+    """Calcula la raíz cuadrada de ``x``.
 
 Example: ``math.sqrt(4)``
 
-:param x: (x) Un número
+:param x: Un número
 :return: The square root of ``x``"""
     ...
 
 def tan(x: float) -> float:
-    """Calcula la tangente de ``x``. (tan)
+    """Calcula la tangente de ``x``.
 
 Example: ``math.tan(0)``
 
-:param x: (x) Un número
+:param x: Un número
 :return: The tangent of ``x``."""
     ...
 
 def trunc(x: float) -> int:
-    """Redondea un número hacia 0. (trunc)
+    """Redondea un número hacia 0.
 
 Example: ``math.trunc(-0.9)``
 
-:param x: (x) Un número
+:param x: Un número
 :return: ``x`` rounded towards zero."""
     ...
 e: float
-"""Base del logaritmo natural (e)"""
+"""Base del logaritmo natural"""
 pi: float
-"""La relación entre la longitud de una circunferencia y su diámetro (pi)"""
+"""La relación entre la longitud de una circunferencia y su diámetro"""

--- a/lang/es-es/typeshed/stdlib/microbit/__init__.pyi
+++ b/lang/es-es/typeshed/stdlib/microbit/__init__.pyi
@@ -1,4 +1,4 @@
-"""Pines, imágenes, sonidos, temperatura y volumen. (microbit)"""
+"""Pines, imágenes, sonidos, temperatura y volumen."""
 from _typeshed import ReadableBuffer
 from typing import Any, Callable, List, Optional, overload
 from . import accelerometer as accelerometer
@@ -28,19 +28,19 @@ or used as a decorator::
 
 Arguments with different time units are additive.
 
-:param callback: (callback) La función "callback" (devolución de llamada) que se llama; omitir si se usa en un patrón "Decorator"
+:param callback: La función "callback" (devolución de llamada) que se llama; omitir si se usa en un patrón "Decorator"
 :param days: (días) El intervalo en días.
-:param h: (h) El intervalo en horas.
-:param min: (min) El intervalo en minutos.
-:param s: (s) El intervalo en segundos.
-:param ms: (ms) El intervalo en milisegundos."""
+:param h: El intervalo en horas.
+:param min: El intervalo en minutos.
+:param s: El intervalo en segundos.
+:param ms: El intervalo en milisegundos."""
 
 def panic(n: int) -> None:
     """Entra en modo pánico (pánico)
 
 Example: ``panic(127)``
 
-:param n: (n) Un entero arbitrario <= 255 para indicar un estado.
+:param n: Un entero arbitrario <= 255 para indicar un estado.
 
 Requires restart."""
 
@@ -52,7 +52,7 @@ def sleep(n: float) -> None:
 
 Example: ``sleep(1000)``
 
-:param n: (n) El número de milisegundos a esperar
+:param n: El número de milisegundos a esperar
 
 One second is 1000 milliseconds, so::
 
@@ -73,7 +73,7 @@ def set_volume(v: int) -> None:
 
 Example: ``set_volume(127)``
 
-:param v: (v) un valor entre 0 (bajo) y 255 (alto).
+:param v: un valor entre 0 (bajo) y 255 (alto).
 
 Out of range values will be clamped to 0 or 255.
 
@@ -235,43 +235,43 @@ The default touch mode for the pins on the edge connector is
 :param value: (valor) ``CAPACITIVE`` o ``RESISTIVE`` del pin correspondiente."""
         ...
 pin0: MicroBitTouchPin
-"""Pin con funciones digitales, analógicas y táctiles. (pin0)"""
+"""Pin con funciones digitales, analógicas y táctiles."""
 pin1: MicroBitTouchPin
-"""Pin con funciones digitales, analógicas y táctiles. (pin1)"""
+"""Pin con funciones digitales, analógicas y táctiles."""
 pin2: MicroBitTouchPin
-"""Pin con funciones digitales, analógicas y táctiles. (pin2)"""
+"""Pin con funciones digitales, analógicas y táctiles."""
 pin3: MicroBitAnalogDigitalPin
-"""Pin con funciones digitales y analógicas. (pin3)"""
+"""Pin con funciones digitales y analógicas."""
 pin4: MicroBitAnalogDigitalPin
-"""Pin con funciones digitales y analógicas. (pin4)"""
+"""Pin con funciones digitales y analógicas."""
 pin5: MicroBitDigitalPin
-"""Pin con funciones digitales. (pin5)"""
+"""Pin con funciones digitales."""
 pin6: MicroBitDigitalPin
-"""Pin con funciones digitales. (pin6)"""
+"""Pin con funciones digitales."""
 pin7: MicroBitDigitalPin
-"""Pin con funciones digitales. (pin7)"""
+"""Pin con funciones digitales."""
 pin8: MicroBitDigitalPin
-"""Pin con funciones digitales. (pin8)"""
+"""Pin con funciones digitales."""
 pin9: MicroBitDigitalPin
-"""Pin con funciones digitales. (pin9)"""
+"""Pin con funciones digitales."""
 pin10: MicroBitAnalogDigitalPin
-"""Pin con funciones digitales y analógicas. (pin10)"""
+"""Pin con funciones digitales y analógicas."""
 pin11: MicroBitDigitalPin
-"""Pin con funciones digitales. (pin11)"""
+"""Pin con funciones digitales."""
 pin12: MicroBitDigitalPin
-"""Pin con funciones digitales. (pin12)"""
+"""Pin con funciones digitales."""
 pin13: MicroBitDigitalPin
-"""Pin con funciones digitales. (pin13)"""
+"""Pin con funciones digitales."""
 pin14: MicroBitDigitalPin
-"""Pin con funciones digitales. (pin14)"""
+"""Pin con funciones digitales."""
 pin15: MicroBitDigitalPin
-"""Pin con funciones digitales. (pin15)"""
+"""Pin con funciones digitales."""
 pin16: MicroBitDigitalPin
-"""Pin con funciones digitales. (pin16)"""
+"""Pin con funciones digitales."""
 pin19: MicroBitDigitalPin
-"""Pin con funciones digitales. (pin19)"""
+"""Pin con funciones digitales."""
 pin20: MicroBitDigitalPin
-"""Pin con funciones digitales. (pin20)"""
+"""Pin con funciones digitales."""
 pin_logo: MicroBitTouchPin
 """Un pin táctil sensible en la parte frontal del micro:bit que por defecto está configurado en modo táctil capacitivo. (pin de logo)"""
 pin_speaker: MicroBitAnalogDigitalPin
@@ -313,7 +313,7 @@ Given an image object it's possible to display it via the ``display`` API::
     YES: Image
     """Imagen de verificación. (sí)"""
     NO: Image
-    """Imagen de cruz. (no)"""
+    """Imagen de cruz."""
     CLOCK12: Image
     """Imagen de una línea apuntando a las 12:00. (reloj12)"""
     CLOCK11: Image
@@ -383,7 +383,7 @@ Given an image object it's possible to display it via the ``display`` API::
     XMAS: Image
     """Imagen de un árbol de Navidad. (navidad)"""
     PACMAN: Image
-    """Imagen del personaje de videojuegos Pac-Man. (pacman)"""
+    """Imagen del personaje de videojuegos Pac-Man."""
     TARGET: Image
     """Imagen de un objetivo. (diana)"""
     TSHIRT: Image
@@ -419,7 +419,7 @@ Given an image object it's possible to display it via the ``display`` API::
 
     @overload
     def __init__(self, string: str) -> None:
-        """Crea una imagen a partir de una cadena que describe los LED que están encendidos. (init)
+        """Crea una imagen a partir de una cadena que describe los LED que están encendidos.
 
 ``string`` has to consist of digits 0-9 arranged into lines,
 describing the image, for example::
@@ -438,7 +438,7 @@ colon. It's also possible to use newlines (\\n) insead of the colons.
 
     @overload
     def __init__(self, width: int=5, height: int=5, buffer: ReadableBuffer=None) -> None:
-        """Crea una imagen vacía con ``width`` columnas y ``height`` filas. (init)
+        """Crea una imagen vacía con ``width`` columnas y ``height`` filas.
 
 :param width: (ancho) Ancho opcional de la imagen
 :param height: (altura) Altura opcional de la imagen
@@ -469,8 +469,8 @@ These create 2 x 2 pixel images at full brightness."""
 
 Example: ``my_image.set_pixel(0, 0, 9)``
 
-:param x: (x) El número de columna
-:param y: (y) El número de fila
+:param x: El número de columna
+:param y: El número de fila
 :param value: (valor) El brillo expresado como un entero entre 0 (oscuro) y 9 (brillante)
 
 This method will raise an exception when called on any of the built-in
@@ -482,8 +482,8 @@ read-only images, like ``Image.HEART``."""
 
 Example: ``my_image.get_pixel(0, 0)``
 
-:param x: (x) El número de columna
-:param y: (y) El número de fila
+:param x: El número de columna
+:param y: El número de fila
 :return: The brightness as an integer between 0 and 9."""
         ...
 
@@ -492,7 +492,7 @@ Example: ``my_image.get_pixel(0, 0)``
 
 Example: ``Image.HEART_SMALL.shift_left(1)``
 
-:param n: (n) El número de columnas a desplazar
+:param n: El número de columnas a desplazar
 :return: The shifted image"""
         ...
 
@@ -501,7 +501,7 @@ Example: ``Image.HEART_SMALL.shift_left(1)``
 
 Example: ``Image.HEART_SMALL.shift_right(1)``
 
-:param n: (n) El número de columnas a desplazar
+:param n: El número de columnas a desplazar
 :return: The shifted image"""
         ...
 
@@ -510,7 +510,7 @@ Example: ``Image.HEART_SMALL.shift_right(1)``
 
 Example: ``Image.HEART_SMALL.shift_up(1)``
 
-:param n: (n) El número de filas a desplazar
+:param n: El número de filas a desplazar
 :return: The shifted image"""
         ...
 
@@ -519,7 +519,7 @@ Example: ``Image.HEART_SMALL.shift_up(1)``
 
 Example: ``Image.HEART_SMALL.shift_down(1)``
 
-:param n: (n) El número de filas a desplazar
+:param n: El número de filas a desplazar
 :return: The shifted image"""
         ...
 
@@ -528,10 +528,10 @@ Example: ``Image.HEART_SMALL.shift_down(1)``
 
 Example: ``Image.HEART.crop(1, 1, 3, 3)``
 
-:param x: (x) La columna de desplazamiento del recorte
-:param y: (y) La fila de desplazamiento del recorte
+:param x: La columna de desplazamiento del recorte
+:param y: La fila de desplazamiento del recorte
 :param w: (a) El ancho del recorte
-:param h: (h) La altura del recorte
+:param h: La altura del recorte
 :return: The new image"""
         ...
 
@@ -564,17 +564,17 @@ read-only images, like ``Image.HEART``."""
         ...
 
     def blit(self, src: Image, x: int, y: int, w: int, h: int, xdest: int=0, ydest: int=0) -> None:
-        """Copia un área de otra imagen en esta imagen. (blit)
+        """Copia un área de otra imagen en esta imagen.
 
 Example: ``my_image.blit(Image.HEART, 1, 1, 3, 3, 1, 1)``
 
 :param src: (org) La imagen de origen
-:param x: (x) El desplazamiento de columna inicial en la imagen de origen
-:param y: (y) El desplazamiento de fila inicial en la imagen de origen
+:param x: El desplazamiento de columna inicial en la imagen de origen
+:param y: El desplazamiento de fila inicial en la imagen de origen
 :param w: (a) El número de columnas a copiar
-:param h: (h) El número de filas a copiar
-:param xdest: (xdest) El desplazamiento de columna a modificar en esta imagen
-:param ydest: (ydest) El desplazamiento de fila a modificar en esta imagen
+:param h: El número de filas a copiar
+:param xdest: El desplazamiento de columna a modificar en esta imagen
+:param ydest: El desplazamiento de fila a modificar en esta imagen
 
 Pixels outside the source image are treated as having a brightness of 0.
 
@@ -590,7 +590,7 @@ For example, img.crop(x, y, w, h) can be implemented as::
         ...
 
     def __repr__(self) -> str:
-        """Obtiene una representación en cadena compacta de la imagen. (repr)"""
+        """Obtiene una representación en cadena compacta de la imagen."""
         ...
 
     def __str__(self) -> str:
@@ -615,19 +615,19 @@ Example: ``Image.HEART - Image.HEART_SMALL``
         ...
 
     def __mul__(self, n: float) -> Image:
-        """Crea una nueva imagen multiplicando el brillo de cada píxel por ``n``. (mul)
+        """Crea una nueva imagen multiplicando el brillo de cada píxel por ``n``.
 
 Example: ``Image.HEART * 0.5``
 
-:param n: (n) El valor por el que multiplicar."""
+:param n: El valor por el que multiplicar."""
         ...
 
     def __truediv__(self, n: float) -> Image:
-        """Crea una nueva imagen dividiendo el brillo de cada píxel entre ``n``. (truediv)
+        """Crea una nueva imagen dividiendo el brillo de cada píxel entre ``n``.
 
 Example: ``Image.HEART / 2``
 
-:param n: (n) El valor entre el que dividir."""
+:param n: El valor entre el que dividir."""
         ...
 
 class SoundEvent:

--- a/lang/es-es/typeshed/stdlib/microbit/audio.pyi
+++ b/lang/es-es/typeshed/stdlib/microbit/audio.pyi
@@ -1,4 +1,4 @@
-"""Reproducir sonidos usando el micro:bit (importar ``audio`` para compatibilidad con V1). (audio)"""
+"""Reproducir sonidos usando el micro:bit (importar ``audio`` para compatibilidad con V1)."""
 from ..microbit import MicroBitDigitalPin, Sound, pin0
 from typing import Iterable, Union
 
@@ -9,7 +9,7 @@ Example: ``audio.play(Sound.GIGGLE)``
 
 :param source: (origen) Un ``Sound`` predefinido como ``Sound.GIGGLE`` o datos de muestra como un iterable de objetos ``AudioFrame``.
 :param wait: (esperar) Si ``wait`` es ``True`` (verdadero), la función se bloqueará hasta que el sonido finalice.
-:param pin: (pin) Se puede usar un argumento opcional para especificar el pin de salida, reemplazando el valor predeterminado de ``pin0``. Si no queremos que se reproduzca ningún sonido, podemos usar ``pin=None``.
+:param pin: Se puede usar un argumento opcional para especificar el pin de salida, reemplazando el valor predeterminado de ``pin0``. Si no queremos que se reproduzca ningún sonido, podemos usar ``pin=None``.
 :param return_pin: (devolver pin) Especifica un pin de conector de borde diferencial para conectarse a un altavoz externo en lugar de tierra. Esto se ignora para la revisión **V2**."""
 
 def is_playing() -> bool:
@@ -28,7 +28,7 @@ Example: ``audio.stop()``"""
 
 class AudioFrame:
     """Un objeto ``AudioFrame`` es una lista de 32 muestras, cada una de las cuales es un byte
-sin signo (número entero entre 0 y 255). (audioframe)
+sin signo (número entero entre 0 y 255).
 
 It takes just over 4 ms to play a single frame.
 

--- a/lang/es-es/typeshed/stdlib/microbit/display.pyi
+++ b/lang/es-es/typeshed/stdlib/microbit/display.pyi
@@ -7,8 +7,8 @@ def get_pixel(x: int, y: int) -> int:
 
 Example: ``display.get_pixel(0, 0)``
 
-:param x: (x) La columna de la pantalla (0..4)
-:param y: (y) La fila de la pantalla (0..4)
+:param x: La columna de la pantalla (0..4)
+:param y: La fila de la pantalla (0..4)
 :return: A number between 0 (off) and 9 (bright)"""
     ...
 
@@ -17,8 +17,8 @@ def set_pixel(x: int, y: int, value: int) -> None:
 
 Example: ``display.set_pixel(0, 0, 9)``
 
-:param x: (x) La columna de la pantalla (0..4)
-:param y: (y) La fila de la pantalla (0..4)
+:param x: La columna de la pantalla (0..4)
+:param y: La fila de la pantalla (0..4)
 :param value: (valor) El brillo entre 0 (apagado) y 9 (brillante)"""
     ...
 
@@ -54,7 +54,7 @@ Example: ``display.scroll('micro:bit')``
 :param delay: (retardo) El parámetro ``delay`` controla la velocidad de desplazamiento del texto.
 :param wait: (esperar) Si ``wait`` es ``True`` (verdadero), la función se bloqueará hasta que finalice la animación; de lo contrario, la animación se ejecutará en segundo plano.
 :param loop: (bucle) Si ``loop`` es ``True`` (verdadero), la animación se repetirá para siempre.
-:param monospace: (monospace) Si ``monospace`` es ``True`` (verdadero), todos los caracteres ocuparán columnas de 5 píxeles de ancho; de lo contrario, habrá exactamente 1 columna de píxeles vacíos entre cada carácter a medida que se desplazan.
+:param monospace: Si ``monospace`` es ``True`` (verdadero), todos los caracteres ocuparán columnas de 5 píxeles de ancho; de lo contrario, habrá exactamente 1 columna de píxeles vacíos entre cada carácter a medida que se desplazan.
 
 The ``wait``, ``loop`` and ``monospace`` arguments must be specified
 using their keyword."""

--- a/lang/es-es/typeshed/stdlib/microbit/i2c.pyi
+++ b/lang/es-es/typeshed/stdlib/microbit/i2c.pyi
@@ -1,4 +1,4 @@
-"""Comunicarse con dispositivos que usan el protocolo de bus I²C. (i2c)"""
+"""Comunicarse con dispositivos que usan el protocolo de bus I²C."""
 from _typeshed import ReadableBuffer
 from ..microbit import MicroBitDigitalPin, pin19, pin20
 from typing import List
@@ -9,8 +9,8 @@ def init(freq: int=100000, sda: MicroBitDigitalPin=pin20, scl: MicroBitDigitalPi
 Example: ``i2c.init()``
 
 :param freq: (frec) frecuencia del reloj
-:param sda: (sda) pin ``sda`` (por defecto, 20)
-:param scl: (scl) pin ``scl`` (por defecto, 19)
+:param sda: pin ``sda`` (por defecto, 20)
+:param scl: pin ``scl`` (por defecto, 19)
 
 On a micro:bit V1 board, changing the I²C pins from defaults will make
 the accelerometer and compass stop working, as they are connected
@@ -33,7 +33,7 @@ def read(addr: int, n: int, repeat: bool=False) -> bytes:
 Example: ``i2c.read(0x50, 64)``
 
 :param addr: (dir) La dirección de 7 bits del dispositivo
-:param n: (n) El número de bytes a leer
+:param n: El número de bytes a leer
 :param repeat: (repetir) Si es ``True`` (verdadero), no se enviará ningún bit de parada
 :return: The bytes read"""
     ...

--- a/lang/es-es/typeshed/stdlib/microbit/spi.pyi
+++ b/lang/es-es/typeshed/stdlib/microbit/spi.pyi
@@ -1,20 +1,20 @@
-"""Comunicarse con dispositivos que usan el bus de interfaz de periféricos serie (SPI, por sus siglas en inglés). (spi)"""
+"""Comunicarse con dispositivos que usan el bus de interfaz de periféricos serie (SPI, por sus siglas en inglés)."""
 from _typeshed import ReadableBuffer, WriteableBuffer
 from ..microbit import pin13, pin14, pin15, MicroBitDigitalPin
 
 def init(baudrate: int=1000000, bits: int=8, mode: int=0, sclk: MicroBitDigitalPin=pin13, mosi: MicroBitDigitalPin=pin15, miso: MicroBitDigitalPin=pin14) -> None:
-    """Inicializa la comunicación SPI. (init)
+    """Inicializa la comunicación SPI.
 
 Example: ``spi.init()``
 
 For correct communication, the parameters have to be the same on both communicating devices.
 
 :param baudrate: (tasa de baudios) La velocidad de comunicación.
-:param bits: (bits) El ancho en bits de cada transferencia. Actualmente solo se admite ``bits=8}, pero esto puede cambiar en el futuro.
+:param bits: El ancho en bits de cada transferencia. Actualmente solo se admite ``bits=8}, pero esto puede cambiar en el futuro.
 :param mode: (modo) Determina la combinación de fase y polaridad del reloj - `ver tabla en línea <https://microbit-micropython.readthedocs.io/en/v2-docs/spi.html#microbit.spi.init>`_.
-:param sclk: (sclk) pin SCLK (por defecto, 13)
-:param mosi: (mosi) pin MOSI (por defecto, 15)
-:param miso: (miso) pin MISO (por defecto, 14)"""
+:param sclk: pin SCLK (por defecto, 13)
+:param mosi: pin MOSI (por defecto, 15)
+:param miso: pin MISO (por defecto, 14)"""
     ...
 
 def read(nbytes: int) -> bytes:
@@ -22,7 +22,7 @@ def read(nbytes: int) -> bytes:
 
 Example: ``spi.read(64)``
 
-:param nbytes: (nbytes) Número máximo de bytes a leer.
+:param nbytes: Número máximo de bytes a leer.
 :return: The bytes read."""
     ...
 

--- a/lang/es-es/typeshed/stdlib/microbit/uart.pyi
+++ b/lang/es-es/typeshed/stdlib/microbit/uart.pyi
@@ -1,4 +1,4 @@
-"""Comunicarse con un dispositivo usando una interfaz serie. (uart)"""
+"""Comunicarse con un dispositivo usando una interfaz serie."""
 from _typeshed import WriteableBuffer
 from ..microbit import MicroBitDigitalPin
 from typing import Optional, Union
@@ -8,16 +8,16 @@ EVEN: int
 """Paridad par (par)"""
 
 def init(baudrate: int=9600, bits: int=8, parity: Optional[int]=None, stop: int=1, tx: Optional[MicroBitDigitalPin]=None, rx: Optional[MicroBitDigitalPin]=None) -> None:
-    """Inicializa la comunicación serie. (init)
+    """Inicializa la comunicación serie.
 
 Example: ``uart.init(115200, tx=pin0, rx=pin1)``
 
 :param baudrate: (tasa de baudios) La velocidad de comunicación.
-:param bits: (bits) El tamaño de bytes transmitidos; micro:bit solo admite 8.
+:param bits: El tamaño de bytes transmitidos; micro:bit solo admite 8.
 :param parity: (paridad) Cómo se comprueba la paridad: ``None``, ``uart.ODD`` o ``uart.EVEN``.
 :param stop: (detener) El número de bits de parada; tiene que ser 1 para el micro:bit.
-:param tx: (tx) Pin transmisor.
-:param rx: (rx) Pin receptor.
+:param tx: Pin transmisor.
+:param rx: Pin receptor.
 
 Initializing the UART on external pins will cause the Python console on
 USB to become unaccessible, as it uses the same hardware. To bring the
@@ -41,7 +41,7 @@ def read(nbytes: Optional[int]=None) -> Optional[bytes]:
 
 Example: ``uart.read()``
 
-:param nbytes: (nbytes) Si se especifica ``nbytes``, lee como máximo ese número de bytes; si no, lee tantos bytes como sea posible
+:param nbytes: Si se especifica ``nbytes``, lee como máximo ese número de bytes; si no, lee tantos bytes como sea posible
 :return: A bytes object or ``None`` on timeout"""
     ...
 
@@ -51,7 +51,7 @@ def readinto(buf: WriteableBuffer, nbytes: Optional[int]=None) -> Optional[int]:
 Example: ``uart.readinto(input_buffer)``
 
 :param buf: (búf) El búfer en el que escribir.
-:param nbytes: (nbytes) Si se especifica ``nbytes``, lee como máximo ese número de bytes; si no, lee ``len(buf)`` bytes.
+:param nbytes: Si se especifica ``nbytes``, lee como máximo ese número de bytes; si no, lee ``len(buf)`` bytes.
 :return: number of bytes read and stored into ``buf`` or ``None`` on timeout."""
     ...
 

--- a/lang/es-es/typeshed/stdlib/micropython.pyi
+++ b/lang/es-es/typeshed/stdlib/micropython.pyi
@@ -1,10 +1,10 @@
-"""Componentes internos de MicroPython. (micropython)"""
+"""Componentes internos de MicroPython."""
 from typing import Any, TypeVar, overload
 _T = TypeVar('_T')
 
 def const(expr: _T) -> _T:
     """Se usa para declarar que la expresión es una constante para que el compilador pueda
-optimizarla. (const)
+optimizarla.
 
 The use of this function should be as follows::
 
@@ -17,7 +17,7 @@ outside the module they are declared in. On the other hand, if a constant
 begins with an underscore then it is hidden, it is not available as a
 global variable, and does not take up any memory during execution.
 
-:param expr: (expr) Una expresión constante."""
+:param expr: Una expresión constante."""
     ...
 
 @overload
@@ -71,7 +71,7 @@ def mem_info(verbose: Any=None) -> None:
 
 Example: ``micropython.mem_info()``
 
-:param verbose: (verbose) Si se pasa el argumento ``verbose``, se imprime información adicional."""
+:param verbose: Si se pasa el argumento ``verbose``, se imprime información adicional."""
     ...
 
 def qstr_info(verbose: Any=None) -> None:
@@ -79,7 +79,7 @@ def qstr_info(verbose: Any=None) -> None:
 
 Example: ``micropython.qstr_info()``
 
-:param verbose: (verbose) Si se pasa el argumento ``verbose``, se imprime información adicional.
+:param verbose: Si se pasa el argumento ``verbose``, se imprime información adicional.
 
 The information that is printed is implementation dependent, but currently
 includes the number of interned strings and the amount of RAM they use.  In

--- a/lang/es-es/typeshed/stdlib/music.pyi
+++ b/lang/es-es/typeshed/stdlib/music.pyi
@@ -2,15 +2,15 @@
 from typing import Tuple, Union, List
 from .microbit import MicroBitDigitalPin, pin0
 DADADADUM: Tuple[str, ...]
-"""Melodía: apertura de la "Sinfonía n.º 5 en do menor" de Beethoven. (dadadadum)"""
+"""Melodía: apertura de la "Sinfonía n.º 5 en do menor" de Beethoven."""
 ENTERTAINER: Tuple[str, ...]
-"""Melodía: fragmento inicial del clásico Ragtime de Scott Joplin “The Entertainer”. (entertainer)"""
+"""Melodía: fragmento inicial del clásico Ragtime de Scott Joplin “The Entertainer”."""
 PRELUDE: Tuple[str, ...]
 """Melodía: apertura del primer "Preludio en do mayor" de los 48 Preludios y Fugas de J. S. Bach. (preludio)"""
 ODE: Tuple[str, ...]
 """Melodía: tema “Oda a la alegría” de la "Sinfonía n.º 9 en re menor" de Beethoven. (oda)"""
 NYAN: Tuple[str, ...]
-"""Melodía: el tema de Nyan Cat (http://www.nyan.cat/). (nyan)
+"""Melodía: el tema de Nyan Cat (http://www.nyan.cat/).
 
 The composer is unknown. This is fair use for educational porpoises (as they say in New York)."""
 RINGTONE: Tuple[str, ...]
@@ -19,9 +19,9 @@ RINGTONE: Tuple[str, ...]
 To be used to indicate an incoming message.
 """
 FUNK: Tuple[str, ...]
-"""Melodía: una línea de bajo funky para agentes secretos y maestros criminales. (funk)"""
+"""Melodía: una línea de bajo funky para agentes secretos y maestros criminales."""
 BLUES: Tuple[str, ...]
-"""Melodía: "walking bass" con un blues boogie-woogie de 12 compases. (blues)"""
+"""Melodía: "walking bass" con un blues boogie-woogie de 12 compases."""
 BIRTHDAY: Tuple[str, ...]
 """Melodía: “Cumpleaños feliz” (cumpleaños)
 
@@ -30,19 +30,19 @@ For copyright status see: http://www.bbc.co.uk/news/world-us-canada-34332853
 WEDDING: Tuple[str, ...]
 """Melodía: coro nupcial de la ópera de Wagner "Lohengrin". (boda)"""
 FUNERAL: Tuple[str, ...]
-"""Melodía: “Marcha fúnebre”, conocida también como "Sonata para piano n.º 2 en si bemol menor, Op. 35" de Frédéric Chopin. (funeral)"""
+"""Melodía: “Marcha fúnebre”, conocida también como "Sonata para piano n.º 2 en si bemol menor, Op. 35" de Frédéric Chopin."""
 PUNCHLINE: Tuple[str, ...]
 """Melodía: un fragmento divertido que representa que se ha hecho un chiste. (remate)"""
 PYTHON: Tuple[str, ...]
-"""Melodía: la marcha de John Philip Sousa “Liberty Bell”, también conocida por ser el tema del “Monty Python Flying Circus” (de donde obtiene su nombre el lenguaje de programación Python). (python)"""
+"""Melodía: la marcha de John Philip Sousa “Liberty Bell”, también conocida por ser el tema del “Monty Python Flying Circus” (de donde obtiene su nombre el lenguaje de programación Python)."""
 BADDY: Tuple[str, ...]
 """Melodía: entrada de un malote en la época del cine mudo. (malote)"""
 CHASE: Tuple[str, ...]
 """Melodía: escena de persecución en la época del cine mudo. (persecución)"""
 BA_DING: Tuple[str, ...]
-"""Melodía: una señal corta para indicar que algo ha pasado. (ba ding)"""
+"""Melodía: una señal corta para indicar que algo ha pasado."""
 WAWAWAWAA: Tuple[str, ...]
-"""Melodía: un trombón muy triste. (wawawawaa)"""
+"""Melodía: un trombón muy triste."""
 JUMP_UP: Tuple[str, ...]
 """Melodía: para usar en un juego, indicando un movimiento ascendente. (saltar arriba)"""
 JUMP_DOWN: Tuple[str, ...]
@@ -58,7 +58,7 @@ def set_tempo(ticks: int=4, bpm: int=120) -> None:
 Example: ``music.set_tempo(bpm=120)``
 
 :param ticks: (tics) El número de tics que constituyen un ritmo.
-:param bpm: (bpm) Un entero que determina el número de compases por minuto.
+:param bpm: Un entero que determina el número de compases por minuto.
 
 Suggested default values allow the following useful behaviour:
 
@@ -85,7 +85,7 @@ def play(music: Union[str, List[str], Tuple[str, ...]], pin: Union[MicroBitDigit
 Example: ``music.play(music.NYAN)``
 
 :param music: (música) música especificada en `una notación especial <https://microbit-micropython.readthedocs.io/en/v2-docs/music.html#musical-notation>`_
-:param pin: (pin) pin de salida para usar con un altavoz externo (por defecto ``pin0``), ``None`` para que no haya sonido.
+:param pin: pin de salida para usar con un altavoz externo (por defecto ``pin0``), ``None`` para que no haya sonido.
 :param wait: (esperar) Si ``wait`` se configura como ``True`` (verdadero), esta función estará bloqueando.
 :param loop: (bucle) Si ``loop`` se configura como ``True`` (verdadero), la melodía se repite hasta que se llama a ``stop`` o se interrumpe la llamada de bloqueo.
 
@@ -99,7 +99,7 @@ Example: ``music.pitch(185, 1000)``
 
 :param frequency: (frecuencia) Una frecuencia entera
 :param duration: (duración) La duración en milisegundos. Si es negativa, el sonido continuará hasta la siguiente llamada o una llamada a ``stop``.
-:param pin: (pin) Pin de salida opcional (por defecto, ``pin0``).
+:param pin: Pin de salida opcional (por defecto, ``pin0``).
 :param wait: (esperar) Si ``wait`` se configura como ``True`` (verdadero), esta función estará bloqueando.
 
 For example, if the frequency is set to 440 and the length to
@@ -113,7 +113,7 @@ def stop(pin: MicroBitDigitalPin=pin0) -> None:
 
 Example: ``music.stop()``
 
-:param pin: (pin) Se puede proporcionar un argumento opcional para especificar un pin; por ejemplo, ``music.stop(pin1)``."""
+:param pin: Se puede proporcionar un argumento opcional para especificar un pin; por ejemplo, ``music.stop(pin1)``."""
 
 def reset() -> None:
     """Restablece los valores de "ticks", "bpm", "duration" y "octave" a sus valores por defecto. (restablecer)

--- a/lang/es-es/typeshed/stdlib/neopixel.pyi
+++ b/lang/es-es/typeshed/stdlib/neopixel.pyi
@@ -1,11 +1,11 @@
-"""Tiras de LED RGB y RGBW accesibles individualmente. (neopixel)"""
+"""Tiras de LED RGB y RGBW accesibles individualmente."""
 from .microbit import MicroBitDigitalPin
 from typing import Tuple
 
 class NeoPixel:
 
     def __init__(self, pin: MicroBitDigitalPin, n: int, bpp: int=3) -> None:
-        """Inicializa una nueva tira de LED NeoPixel controlada a través de un pin. (init)
+        """Inicializa una nueva tira de LED NeoPixel controlada a través de un pin.
 
 Example: ``np = neopixel.NeoPixel(pin0, 8)``
 
@@ -13,9 +13,9 @@ RGBW neopixels are only supported by micro:bit V2.
 
 See `the online docs <https://microbit-micropython.readthedocs.io/en/v2-docs/neopixel.html>`_ for warnings and other advice.
 
-:param pin: (pin) El pin que controla la tira NeoPixel.
-:param n: (n) El número de LED NeoPixel de la tira.
-:param bpp: (bpp) Bytes por píxel. Para compatibilidad con NeoPixel RGBW de micro:bit V2, pasa 4 en lugar del valor predeterminado 3 para RGB y GRB."""
+:param pin: El pin que controla la tira NeoPixel.
+:param n: El número de LED NeoPixel de la tira.
+:param bpp: Bytes por píxel. Para compatibilidad con NeoPixel RGBW de micro:bit V2, pasa 4 en lugar del valor predeterminado 3 para RGB y GRB."""
         ...
 
     def clear(self) -> None:

--- a/lang/es-es/typeshed/stdlib/os.pyi
+++ b/lang/es-es/typeshed/stdlib/os.pyi
@@ -3,7 +3,7 @@ from typing import Tuple
 from typing import List
 
 def listdir() -> List[str]:
-    """Lista los archivos. (listdir)
+    """Lista los archivos.
 
 Example: ``os.listdir()``
 

--- a/lang/es-es/typeshed/stdlib/radio.pyi
+++ b/lang/es-es/typeshed/stdlib/radio.pyi
@@ -1,4 +1,4 @@
-"""Comunicarse entre micro:bits con la radio incorporada. (radio)"""
+"""Comunicarse entre micro:bits con la radio incorporada."""
 from _typeshed import WriteableBuffer
 from typing import Optional, Tuple
 RATE_1MBIT: int
@@ -22,7 +22,7 @@ Example: ``radio.off()``"""
     ...
 
 def config(length: int=32, queue: int=3, channel: int=7, power: int=6, address: int=1969383796, group: int=0, data_rate: int=RATE_1MBIT) -> None:
-    """Configura la radio. (config)
+    """Configura la radio.
 
 Example: ``radio.config(group=42)``
 

--- a/lang/es-es/typeshed/stdlib/random.pyi
+++ b/lang/es-es/typeshed/stdlib/random.pyi
@@ -2,11 +2,11 @@
 from typing import TypeVar, Sequence, Union, overload
 
 def getrandbits(n: int) -> int:
-    """Genera un entero con ``n`` bits aleatorios. (getrandbits)
+    """Genera un entero con ``n`` bits aleatorios.
 
 Example: ``random.getrandbits(1)``
 
-:param n: (n) Un valor entre 1 - 30 (inclusive)."""
+:param n: Un valor entre 1 - 30 (inclusive)."""
     ...
 
 def seed(n: int) -> None:
@@ -14,7 +14,7 @@ def seed(n: int) -> None:
 
 Example: ``random.seed(0)``
 
-:param n: (n) La semilla como un número entero
+:param n: La semilla como un número entero
 
 This will give you reproducibly deterministic randomness from a given starting
 state (``n``)."""
@@ -25,8 +25,8 @@ def randint(a: int, b: int) -> int:
 
 Example: ``random.randint(0, 9)``
 
-:param a: (a) Valor inicial para el rango (inclusive)
-:param b: (b) Valor final para el rango (inclusive)
+:param a: Valor inicial para el rango (inclusive)
+:param b: Valor final para el rango (inclusive)
 
 Alias for ``randrange(a, b + 1)``."""
     ...
@@ -75,6 +75,6 @@ def uniform(a: float, b: float) -> float:
 
 Example: ``random.uniform(0, 9)``
 
-:param a: (a) Valor inicial para el rango (inclusive)
-:param b: (b) Valor final para el rango (inclusive)"""
+:param a: Valor inicial para el rango (inclusive)
+:param b: Valor final para el rango (inclusive)"""
     ...

--- a/lang/es-es/typeshed/stdlib/speech.pyi
+++ b/lang/es-es/typeshed/stdlib/speech.pyi
@@ -28,7 +28,7 @@ Example: ``speech.pronounce(' /HEHLOW WERLD')``
 :param speed: (velocidad) Un número que representa la velocidad de la voz
 :param mouth: (boca) Un número que representa la boca de la voz
 :param throat: (garganta) Un número que representa la garganta de la voz
-:param pin: (pin) Se puede usar un argumento opcional para especificar el pin de salida, reemplazando el valor predeterminado de ``pin0``.
+:param pin: Se puede usar un argumento opcional para especificar el pin de salida, reemplazando el valor predeterminado de ``pin0``.
 Si no queremos que se reproduzca ningún sonido, podemos usar ``pin=None``. Solo para el micro:bit V2.
 
 Override the optional pitch, speed, mouth and throat settings to change the
@@ -47,7 +47,7 @@ Example: ``speech.say('hello world')``
 :param speed: (velocidad) Un número que representa la velocidad de la voz
 :param mouth: (boca) Un número que representa la boca de la voz
 :param throat: (garganta) Un número que representa la garganta de la voz
-:param pin: (pin) Se puede usar un argumento opcional para especificar el pin de salida, reemplazando el valor predeterminado de ``pin0``.
+:param pin: Se puede usar un argumento opcional para especificar el pin de salida, reemplazando el valor predeterminado de ``pin0``.
 Si no queremos que se reproduzca ningún sonido, podemos usar ``pin=None``. Solo para el micro:bit V2.
 
 The result is semi-accurate for English. Override the optional pitch, speed,
@@ -69,7 +69,7 @@ Example: ``speech.sing(' /HEHLOW WERLD')``
 :param speed: (velocidad) Un número que representa la velocidad de la voz
 :param mouth: (boca) Un número que representa la boca de la voz
 :param throat: (garganta) Un número que representa la garganta de la voz
-:param pin: (pin) Se puede usar un argumento opcional para especificar el pin de salida, reemplazando el valor predeterminado de ``pin0``.
+:param pin: Se puede usar un argumento opcional para especificar el pin de salida, reemplazando el valor predeterminado de ``pin0``.
 Si no queremos que se reproduzca ningún sonido, podemos usar ``pin=None``. Solo para el micro:bit V2.
 
 Override the optional pitch, speed, mouth and throat settings to change

--- a/lang/es-es/typeshed/stdlib/struct.pyi
+++ b/lang/es-es/typeshed/stdlib/struct.pyi
@@ -7,7 +7,7 @@ def calcsize(fmt: str) -> int:
 
 Example: ``struct.calcsize('hf')``
 
-:param fmt: (fmt) Una cadena de formato.
+:param fmt: Una cadena de formato.
 :return The number of bytes needed to store such a value."""
     ...
 
@@ -16,9 +16,9 @@ def pack(fmt: str, v1: Any, *vn: Any) -> bytes:
 
 Example: ``struct.pack('hf', 1, 3.1415)``
 
-:param fmt: (fmt) La cadena de formato.
-:param v1: (v1) El primer valor.
-:param *vn: (*vn) Los valores restantes.
+:param fmt: La cadena de formato.
+:param v1: El primer valor.
+:param *vn: Los valores restantes.
 :return A bytes object encoding the values."""
     ...
 
@@ -27,11 +27,11 @@ def pack_into(fmt: str, buffer: WriteableBuffer, offset: int, v1: Any, *vn: Any)
 
 Example: ``struct.pack_info('hf', buffer, 1, 3.1415)``
 
-:param fmt: (fmt) La cadena de formato.
+:param fmt: La cadena de formato.
 :param buffer: (búfer) El búfer de destino en el que se va a escribir.
 :param offset: (desplazamiento) El desplazamiento en el búfer. Puede ser negativo para contar desde el final del búfer.
-:param v1: (v1) El primer valor.
-:param *vn: (*vn) Los valores restantes."""
+:param v1: El primer valor.
+:param *vn: Los valores restantes."""
     ...
 
 def unpack(fmt: str, data: ReadableBuffer) -> Tuple[Any, ...]:
@@ -39,7 +39,7 @@ def unpack(fmt: str, data: ReadableBuffer) -> Tuple[Any, ...]:
 
 Example: ``v1, v2 = struct.unpack('hf', buffer)``
 
-:param fmt: (fmt) La cadena de formato.
+:param fmt: La cadena de formato.
 :param data: (datos) Los datos.
 :return: A tuple of the unpacked values."""
     ...
@@ -49,7 +49,7 @@ def unpack_from(fmt: str, buffer: ReadableBuffer, offset: int=0) -> Tuple:
 
 Example: ``v1, v2 = struct.unpack_from('hf', buffer)``
 
-:param fmt: (fmt) La cadena de formato.
+:param fmt: La cadena de formato.
 :param buffer: (búfer) El búfer de origen del que leer.
 :param offset: (desplazamiento) El desplazamiento en el búfer. Puede ser negativo para contar desde el final del búfer.
 :return: A tuple of the unpacked values."""

--- a/lang/es-es/typeshed/stdlib/sys.pyi
+++ b/lang/es-es/typeshed/stdlib/sys.pyi
@@ -1,4 +1,4 @@
-"""Funciones específicas del sistema (sys)"""
+"""Funciones específicas del sistema"""
 from typing import Any, Dict, List, NoReturn, TextIO, Tuple
 
 def exit(retval: object=...) -> NoReturn:
@@ -9,7 +9,7 @@ Example: ``sys.exit(1)``
 This function raises a ``SystemExit`` exception. If an argument is given, its
 value given as an argument to ``SystemExit``.
 
-:param retval: (retval) El mensaje o código de salida."""
+:param retval: El mensaje o código de salida."""
     ...
 
 def print_exception(exc: Exception) -> None:
@@ -17,12 +17,12 @@ def print_exception(exc: Exception) -> None:
 
 Example: ``sys.print_exception(e)``
 
-:param exc: (exc) La excepción a imprimir
+:param exc: La excepción a imprimir
 
 This is simplified version of a function which appears in the
 ``traceback`` module in CPython."""
 argv: List[str]
-"""Una lista mutable de argumentos con los que se inició el programa actual. (argv)"""
+"""Una lista mutable de argumentos con los que se inició el programa actual."""
 byteorder: str
 """El orden de bytes del sistema (``"little"`` o ``"big"``). (ordenbytes)"""
 
@@ -70,13 +70,13 @@ value directly, but instead count number of bits in it::
         # "> 32", "> 64" style of comparisons.
 """
 modules: Dict[str, Any]
-"""Diccionario de módulos cargados.  (módulos)
+"""Diccionario de módulos cargados. (módulos) 
 
 On some ports, it may not include builtin modules."""
 path: List[str]
 """Una lista mutable de directorios para buscar módulos importados. (ruta)"""
 platform: str
-"""La plataforma en la que se está ejecutando MicroPython.  (plataforma)
+"""La plataforma en la que se está ejecutando MicroPython. (plataforma) 
 
 For OS/RTOS ports, this is usually an identifier of the OS, e.g. ``"linux"``.
 For baremetal ports it is an identifier of a board, e.g. ``"pyboard"`` for 

--- a/lang/es-es/typeshed/stdlib/time.pyi
+++ b/lang/es-es/typeshed/stdlib/time.pyi
@@ -15,7 +15,7 @@ def sleep_ms(ms: int) -> None:
 
 Example: ``time.sleep_ms(1_000_000)``
 
-:param ms: (ms) El número de milisegundos de retardo (>= 0)."""
+:param ms: El número de milisegundos de retardo (>= 0)."""
     ...
 
 def sleep_us(us: int) -> None:
@@ -23,7 +23,7 @@ def sleep_us(us: int) -> None:
 
 Example: ``time.sleep_us(1000)``
 
-:param us: (us) El número de microsegundos de retardo (>= 0)."""
+:param us: El número de microsegundos de retardo (>= 0)."""
     ...
 
 def ticks_ms() -> int:
@@ -53,7 +53,7 @@ value delta ticks before or after it, following modular-arithmetic
 definition of tick values.
 
 :param ticks: (tics) Un valor de tics
-:param delta: (delta) Un desplazamiento entero
+:param delta: Un desplazamiento entero
 
 Example::
 

--- a/lang/fr/typeshed/stdlib/gc.pyi
+++ b/lang/fr/typeshed/stdlib/gc.pyi
@@ -1,22 +1,22 @@
-"""Contrôler le ramasse-miettes (gc)"""
+"""Contrôler le ramasse-miettes"""
 from typing import overload
 
 def enable() -> None:
-    """Active la collecte automatique du ramasse-miettes. (enable)"""
+    """Active la collecte automatique du ramasse-miettes."""
     ...
 
 def disable() -> None:
-    """Désactive la collecte automatique du ramasse-miettes. (disable)
+    """Désactive la collecte automatique du ramasse-miettes.
 
 Heap memory can still be allocated,
 and garbage collection can still be initiated manually using ``gc.collect``."""
 
 def collect() -> None:
-    """Exécute une collecte avec le ramasse-miettes (collect)"""
+    """Exécute une collecte avec le ramasse-miettes"""
     ...
 
 def mem_alloc() -> int:
-    """Obtenir le nombre d'octets alloués pour le tas en RAM (mem alloc)
+    """Obtenir le nombre d'octets alloués pour le tas en RAM
 
 :return: The number of bytes allocated.
 
@@ -24,7 +24,7 @@ This function is MicroPython extension."""
     ...
 
 def mem_free() -> int:
-    """Obtenir le nombre d'octets disponibles pour le tas en RAM, ou -1 si ce nombre est inconnu. (mem free)
+    """Obtenir le nombre d'octets disponibles pour le tas en RAM, ou -1 si ce nombre est inconnu.
 
 :return: The number of bytes free.
 
@@ -33,7 +33,7 @@ This function is MicroPython extension."""
 
 @overload
 def threshold() -> int:
-    """Demander le seuil d'allocation supplémentaire GC. (threshold)
+    """Demander le seuil d'allocation supplémentaire GC.
 
 :return: The GC allocation threshold.
 
@@ -44,7 +44,7 @@ implementations, its signature and semantics are different."""
 
 @overload
 def threshold(amount: int) -> None:
-    """Fixer le seuil d'allocation supplémentaire GC. (threshold)
+    """Fixer le seuil d'allocation supplémentaire GC.
 
 Normally, a collection is triggered only when a new allocation
 cannot be satisfied, i.e. on an  out-of-memory (OOM) condition.
@@ -64,5 +64,5 @@ This function is a MicroPython extension. CPython has a similar
 function - ``set_threshold()``, but due to different GC
 implementations, its signature and semantics are different.
 
-:param amount: (amount) Le nombre d'octets après lequel un passage du ramasse-miettes doit être déclenché."""
+:param amount: Le nombre d'octets après lequel un passage du ramasse-miettes doit être déclenché."""
     ...

--- a/lang/fr/typeshed/stdlib/log.pyi
+++ b/lang/fr/typeshed/stdlib/log.pyi
@@ -1,18 +1,18 @@
-"""Journalisez des données sur votre micro:bit V2. (log)"""
+"""Journalisez des données sur votre micro:bit V2."""
 from typing import Literal, Optional, Union, overload
 MILLISECONDS = 1
-"""Format d'horodatage en millisecondes. (milliseconds)"""
+"""Format d'horodatage en millisecondes."""
 SECONDS = 10
-"""Format d'horodatage en secondes. (seconds)"""
+"""Format d'horodatage en secondes."""
 MINUTES = 600
-"""Format d'horodatage en minutes. (minutes)"""
+"""Format d'horodatage en minutes."""
 HOURS = 36000
-"""Format d'horodatage en heures. (hours)"""
+"""Format d'horodatage en heures."""
 DAYS = 864000
-"""Format d'horodatage en jours. (days)"""
+"""Format d'horodatage en jours."""
 
 def set_labels(*args: str, timestamp: Optional[Literal[1, 10, 36000, 864000]]=SECONDS) -> None:
-    """Définir l'en-tête du fichier journal (set labels)
+    """Définir l'en-tête du fichier journal
 
 Example: ``log.set_labels('x', 'y', 'z', timestamp=log.MINUTES)``
 
@@ -24,14 +24,14 @@ labels set up by this function call to the last headers declared in the
 file. If the headers are different it will add a new header entry at the
 end of the file.
 
-:param *args: (*args) Un argument positionnel pour chaque en-tête du journal
+:param *args: Un argument positionnel pour chaque en-tête du journal
 :param timestamp: (horodatage) L'unité d'horodatage qui sera automatiquement ajoutée comme première colonne de chaque ligne.
 Définir cet argument à ``None`` désactive l'horodatage. Passer les valeurs ``log.MILLISECONDS``, ``log.SECONDS``, , ``log.MINUTES``, ``log.HOURS`` ou ``log.DAYS`` définies par ce module. Une valeur invalide lèvera une exception."""
     ...
 
 @overload
 def add(log_data: Optional[dict[str, Union[str, int, float]]]) -> None:
-    """Ajoute une ligne de données au journal en passant un dictionnaire d'en-têtes et de valeurs. (add)
+    """Ajoute une ligne de données au journal en passant un dictionnaire d'en-têtes et de valeurs.
 
 Example: ``log.add({ 'temp': temperature() })``
 
@@ -44,12 +44,12 @@ entry to be added to the log with the extra label.
 Labels previously specified and not present in this function call will be
 skipped with an empty value in the log row.
 
-:param log_data: (log data) Les données à journaliser, sous la forme d'un dictionnaire ayant une clé pour chaque en-tête."""
+:param log_data: Les données à journaliser, sous la forme d'un dictionnaire ayant une clé pour chaque en-tête."""
     ...
 
 @overload
 def add(**kwargs: Union[str, int, float]) -> None:
-    """Ajoute une ligne de données au journal en utilisant des arguments nommés. (add)
+    """Ajoute une ligne de données au journal en utilisant des arguments nommés.
 
 Example: ``log.add(temp=temperature())``
 
@@ -64,22 +64,22 @@ skipped with an empty value in the log row."""
     ...
 
 def delete(full=False):
-    """Supprime le contenu du journal, y compris les en-têtes. (delete)
+    """Supprime le contenu du journal, y compris les en-têtes.
 
 Example: ``log.delete()``
 
 To add the log headers the ``set_labels`` function has to be called again
 after this.
 
-:param full: (full) Sélectionne un moyen de suppression "complet" qui supprime les données sur le stockage flash. Si défini à ``False``, une méthode "rapide" est utilisée, elle consiste à invalider les données au lieu d'effectuer un effacement complet plus lent."""
+:param full: Sélectionne un moyen de suppression "complet" qui supprime les données sur le stockage flash. Si défini à ``False``, une méthode "rapide" est utilisée, elle consiste à invalider les données au lieu d'effectuer un effacement complet plus lent."""
     ...
 
 def set_mirroring(serial: bool):
-    """Effectue une copie de l'activité de journalisation des données vers la sortie série. (set mirroring)
+    """Effectue une copie de l'activité de journalisation des données vers la sortie série.
 
 Example: ``log.set_mirroring(True)``
 
 Mirroring is disabled by default.
 
-:param serial: (serial) Passer ``True`` pour répliquer l'activité de journalisation des données sur la sortie série, ``False`` pour désactiver la réplication."""
+:param serial: Passer ``True`` pour répliquer l'activité de journalisation des données sur la sortie série, ``False`` pour désactiver la réplication."""
     ...

--- a/lang/fr/typeshed/stdlib/machine.pyi
+++ b/lang/fr/typeshed/stdlib/machine.pyi
@@ -1,9 +1,9 @@
-"""Utilitaires bas niveau (machine)"""
+"""Utilitaires bas niveau"""
 from typing import Any
 from .microbit import MicroBitDigitalPin
 
 def unique_id() -> bytes:
-    """Récupère une chaîne d'octets représentant un identifiant unique d'une carte. (unique id)
+    """Récupère une chaîne d'octets représentant un identifiant unique d'une carte.
 
 Example: ``machine.unique_id()``
 
@@ -11,13 +11,13 @@ Example: ``machine.unique_id()``
     ...
 
 def reset() -> None:
-    """Réinitialise l'appareil d'une manière similaire à la pression sur le bouton RESET externe. (reset)
+    """Réinitialise l'appareil d'une manière similaire à la pression sur le bouton RESET externe.
 
 Example: ``machine.reset()``"""
     ...
 
 def freq() -> int:
-    """Récupère la fréquence du CPU en hertz. (freq)
+    """Récupère la fréquence du CPU en hertz.
 
 Example: ``machine.freq()``
 
@@ -25,7 +25,7 @@ Example: ``machine.freq()``
     ...
 
 def disable_irq() -> Any:
-    """Désactiver les demandes d'interruption. (disable irq)
+    """Désactiver les demandes d'interruption.
 
 Example: ``interrupt_state = machine.disable_irq()``
 
@@ -36,15 +36,15 @@ interrupts to their original state."""
     ...
 
 def enable_irq(state: Any) -> None:
-    """Réactiver les demandes d'interruption. (enable irq)
+    """Réactiver les demandes d'interruption.
 
 Example: ``machine.enable_irq(interrupt_state)``
 
-:param state: (state) La valeur qui a été renvoyée par l'appel le plus récent à la fonction ``disable_irq``."""
+:param state: La valeur qui a été renvoyée par l'appel le plus récent à la fonction ``disable_irq``."""
     ...
 
 def time_pulse_us(pin: MicroBitDigitalPin, pulse_level: int, timeout_us: int=1000000) -> int:
-    """Chronométrer une impulsion sur une broche. (time pulse us)
+    """Chronométrer une impulsion sur une broche.
 
 Example: ``time_pulse_us(pin0, 1)``
 
@@ -55,30 +55,30 @@ function first waits until the pin input becomes equal to
 starts straight away.
 
 :param pin: (broche) La broche à utiliser
-:param pulse_level: (pulse level) 0 pour chronométrer une impulsion basse ou 1 pour chronométrer une impulsion haute.
-:param timeout_us: (timeout us) Un délai d'attente en microseconde
+:param pulse_level: 0 pour chronométrer une impulsion basse ou 1 pour chronométrer une impulsion haute.
+:param timeout_us: Un délai d'attente en microseconde
 :return: The duration of the pulse in microseconds, or -1 for a timeout waiting for the level to match ``pulse_level``, or -2 on timeout waiting for the pulse to end"""
     ...
 
 class mem:
-    """La classe pour les vues mémoire ``mem8``, ``mem16`` et ``mem32``. (mem)"""
+    """La classe pour les vues mémoire ``mem8``, ``mem16`` et ``mem32``."""
 
     def __getitem__(self, address: int) -> int:
-        """Accéder à une valeur dans la mémoire. (getitem)
+        """Accéder à une valeur dans la mémoire.
 
-:param address: (address) L'adresse en mémoire.
+:param address: L'adresse en mémoire.
 :return: The value at that address as an integer."""
         ...
 
     def __setitem__(self, address: int, value: int) -> None:
-        """Écrire une valeur à une adresse donnée. (setitem)
+        """Écrire une valeur à une adresse donnée.
 
-:param address: (address) L'adresse en mémoire.
-:param value: (value) La valeur entière à écrire."""
+:param address: L'adresse en mémoire.
+:param value: La valeur entière à écrire."""
         ...
 mem8: mem
-"""Vue de la mémoire au format 8-bit (octet). (mem8)"""
+"""Vue de la mémoire au format 8-bit (octet)."""
 mem16: mem
-"""Vue de la mémoire au format 16-bit. (mem16)"""
+"""Vue de la mémoire au format 16-bit."""
 mem32: mem
-"""Vue de la mémoire au format 32-bit. (mem32)"""
+"""Vue de la mémoire au format 32-bit."""

--- a/lang/fr/typeshed/stdlib/math.pyi
+++ b/lang/fr/typeshed/stdlib/math.pyi
@@ -1,68 +1,68 @@
-"""Fonctions mathématiques. (math)"""
+"""Fonctions mathématiques."""
 from typing import Tuple
 
 def acos(x: float) -> float:
-    """Calculer le cosinus inversé. (acos)
+    """Calculer le cosinus inversé.
 
 Example: ``math.acos(1)``
 
-:param x: (x) Un nombre
+:param x: Un nombre
 :return: The inverse cosine of ``x``"""
     ...
 
 def asin(x: float) -> float:
-    """Calculer le sinus inversé. (asin)
+    """Calculer le sinus inversé.
 
 Example: ``math.asin(0)``
 
-:param x: (x) Un nombre
+:param x: Un nombre
 :return: The inverse sine of ``x``"""
     ...
 
 def atan(x: float) -> float:
-    """Calculer la tangente inverse. (atan)
+    """Calculer la tangente inverse.
 
 Example: ``math.atan(0)``
 
-:param x: (x) Un nombre
+:param x: Un nombre
 :return: The inverse tangent of ``x``"""
     ...
 
 def atan2(y: float, x: float) -> float:
-    """Calculer la valeur principale de la tangente inverse de ``y/x``. (atan2)
+    """Calculer la valeur principale de la tangente inverse de ``y/x``.
 
 Example: ``math.atan2(0, -1)``
 
-:param y: (x) Un nombre
-:param x: (x) Un nombre
+:param y: Un nombre
+:param x: Un nombre
 :return: The principal value of the inverse tangent of ``y/x``"""
     ...
 
 def ceil(x: float) -> float:
-    """Arrondir un nombre vers l'infini positif. (ceil)
+    """Arrondir un nombre vers l'infini positif.
 
 Example: ``math.ceil(0.1)``
 
-:param x: (x) Un nombre
+:param x: Un nombre
 :return: ``x`` rounded towards positive infinity."""
     ...
 
 def copysign(x: float, y: float) -> float:
-    """Calculer ``x`` avec le signe de ``y``. (copysign)
+    """Calculer ``x`` avec le signe de ``y``.
 
 Example: ``math.copysign(1, -1)``
 
-:param x: (x) Un nombre
-:param y: (y) La source du signe pour la valeur de retour
+:param x: Un nombre
+:param y: La source du signe pour la valeur de retour
 :return: ``x`` with the sign of ``y``"""
     ...
 
 def cos(x: float) -> float:
-    """Calculer le cosinus de ``x``. (cos)
+    """Calculer le cosinus de ``x``.
 
 Example: ``math.cos(0)``
 
-:param x: (x) Un nombre
+:param x: Un nombre
 :return: The cosine of ``x``"""
     ...
 
@@ -71,48 +71,48 @@ def degrees(x: float) -> float:
 
 Example: ``math.degrees(2 * math.pi)``
 
-:param x: (x) Une valeur en radians
+:param x: Une valeur en radians
 :return: The value converted to degrees"""
     ...
 
 def exp(x: float) -> float:
-    """Calculer l'exponentiel de ``x``. (exp)
+    """Calculer l'exponentiel de ``x``.
 
 Example: ``math.exp(1)``
 
-:param x: (x) Un nombre
+:param x: Un nombre
 :return: The exponential of ``x``."""
     ...
 
 def fabs(x: float) -> float:
-    """Renvoie la valeur absolue de ``x``. (fabs)
+    """Renvoie la valeur absolue de ``x``.
 
 Example: ``math.fabs(-0.1)``
 
-:param x: (x) Un nombre
+:param x: Un nombre
 :return: The absolute value of ``x``"""
     ...
 
 def floor(x: float) -> int:
-    """Arrondir un nombre vers l'infini négatif. (floor)
+    """Arrondir un nombre vers l'infini négatif.
 
 Example: ``math.floor(0.9)``
 
-:param x: (x) Un nombre
+:param x: Un nombre
 :return: ``x`` rounded towards negative infinity."""
     ...
 
 def fmod(x: float, y: float) -> float:
-    """Calculer le reste de ``x/y``. (fmod)
+    """Calculer le reste de ``x/y``.
 
 Example: ``math.fmod(10, 3)``
 
-:param x: (x) Le numérateur
-:param y: (y) Le dénominateur"""
+:param x: Le numérateur
+:param y: Le dénominateur"""
     ...
 
 def frexp(x: float) -> Tuple[float, int]:
-    """Décompose un nombre à virgule flottante en sa mantisse et son exposant. (frexp)
+    """Décompose un nombre à virgule flottante en sa mantisse et son exposant.
 
 Example: ``mantissa, exponent = math.frexp(2)``
 
@@ -120,49 +120,49 @@ The returned value is the tuple ``(m, e)`` such that ``x == m * 2**e``
 exactly.  If ``x == 0`` then the function returns ``(0.0, 0)``, otherwise
 the relation ``0.5 <= abs(m) < 1`` holds.
 
-:param x: (x) Un nombre à virgule flottante
+:param x: Un nombre à virgule flottante
 :return: A tuple of length two containing its mantissa then exponent"""
     ...
 
 def isfinite(x: float) -> bool:
-    """Vérifier si une valeur est finie. (isfinite)
+    """Vérifier si une valeur est finie.
 
 Example: ``math.isfinite(float('inf'))``
 
-:param x: (x) Un nombre.
+:param x: Un nombre.
 :return: ``True`` if ``x`` is finite, ``False`` otherwise."""
     ...
 
 def isinf(x: float) -> bool:
-    """Vérifie si une valeur est infinie. (isinf)
+    """Vérifie si une valeur est infinie.
 
 Example: ``math.isinf(float('-inf'))``
 
-:param x: (x) Un nombre.
+:param x: Un nombre.
 :return: ``True`` if ``x`` is infinite, ``False`` otherwise."""
     ...
 
 def isnan(x: float) -> bool:
-    """Vérifie si une valeur n'est pas un nombre (NaN). (isnan)
+    """Vérifie si une valeur n'est pas un nombre (NaN).
 
 Example: ``math.isnan(float('nan'))``
 
-:param x: (x) Un nombre
+:param x: Un nombre
 :return: ``True`` if ``x`` is not-a-number (NaN), ``False`` otherwise."""
     ...
 
 def ldexp(x: float, exp: int) -> float:
-    """Calculer ``x * (2**exp)``. (ldexp)
+    """Calculer ``x * (2**exp)``.
 
 Example: ``math.ldexp(0.5, 2)``
 
-:param x: (x) Un nombre
-:param exp: (exp) Exposant entier
+:param x: Un nombre
+:param exp: Exposant entier
 :return: ``x * (2**exp)``"""
     ...
 
 def log(x: float, base: float=e) -> float:
-    """Calculer le logarithme de ``x`` à la base donnée (logarithme naturel par défaut). (log)
+    """Calculer le logarithme de ``x`` à la base donnée (logarithme naturel par défaut).
 
 Example: ``math.log(math.e)``
 
@@ -170,77 +170,77 @@ With one argument, return the natural logarithm of x (to base e).
 
 With two arguments, return the logarithm of x to the given base, calculated as ``log(x)/log(base)``.
 
-:param x: (x) Un nombre
-:param base: (base) La base à utiliser
+:param x: Un nombre
+:param base: La base à utiliser
 :return: The natural logarithm of ``x``"""
     ...
 
 def modf(x: float) -> Tuple[float, float]:
-    """Calculer les parties fractionnelles et intégrales de ``x``. (modf)
+    """Calculer les parties fractionnelles et intégrales de ``x``.
 
 Example: ``fractional, integral = math.modf(1.5)``
 
-:param x: (x) Un nombre
+:param x: Un nombre
 :return: A tuple of two floats representing the fractional then integral parts of ``x``.
 
 Both the fractional and integral values have the same sign as ``x``."""
     ...
 
 def pow(x: float, y: float) -> float:
-    """Renvoie ``x`` à la puissance ``y``. (pow)
+    """Renvoie ``x`` à la puissance ``y``.
 
 Example: ``math.pow(4, 0.5)``
 
-:param x: (x) Un nombre
-:param y: (y) L'exposant
+:param x: Un nombre
+:param y: L'exposant
 :return: ``x`` to the power of ``y``"""
     ...
 
 def radians(x: float) -> float:
-    """Convertir les degrés en radians. (radians)
+    """Convertir les degrés en radians.
 
 Example: ``math.radians(360)``
 
-:param x: (x) Une valeur en degrés
+:param x: Une valeur en degrés
 :return: The value converted to radians"""
     ...
 
 def sin(x: float) -> float:
-    """Calculer le sinus de ``x``. (sin)
+    """Calculer le sinus de ``x``.
 
 Example: ``math.sin(math.pi/2)``
 
-:param x: (x) Un nombre
+:param x: Un nombre
 :return: The sine of ``x``"""
     ...
 
 def sqrt(x: float) -> float:
-    """Calculer la racine carrée de ``x``. (sqrt)
+    """Calculer la racine carrée de ``x``.
 
 Example: ``math.sqrt(4)``
 
-:param x: (x) Un nombre
+:param x: Un nombre
 :return: The square root of ``x``"""
     ...
 
 def tan(x: float) -> float:
-    """Calculer la tangente de ``x``. (tan)
+    """Calculer la tangente de ``x``.
 
 Example: ``math.tan(0)``
 
-:param x: (x) Un nombre
+:param x: Un nombre
 :return: The tangent of ``x``."""
     ...
 
 def trunc(x: float) -> int:
-    """Arrondir un nombre vers 0. (trunc)
+    """Arrondir un nombre vers 0.
 
 Example: ``math.trunc(-0.9)``
 
-:param x: (x) Un nombre
+:param x: Un nombre
 :return: ``x`` rounded towards zero."""
     ...
 e: float
-"""Base du logarithme naturel (e)"""
+"""Base du logarithme naturel"""
 pi: float
-"""Le ratio entre la circonférence d'un cercle et son diamètre (pi)"""
+"""Le ratio entre la circonférence d'un cercle et son diamètre"""

--- a/lang/fr/typeshed/stdlib/microbit/__init__.pyi
+++ b/lang/fr/typeshed/stdlib/microbit/__init__.pyi
@@ -1,4 +1,4 @@
-"""Broches, images, sons, température et volume (microbit)"""
+"""Broches, images, sons, température et volume"""
 from _typeshed import ReadableBuffer
 from typing import Any, Callable, List, Optional, overload
 from . import accelerometer as accelerometer
@@ -12,7 +12,7 @@ from . import uart as uart
 from . import audio as audio
 
 def run_every(callback: Optional[Callable[[], None]]=None, days: int=0, h: int=0, min: int=0, s: int=0, ms: int=0) -> Callable[[Callable[[], None]], Callable[[], None]]:
-    """Planifie une fonction à appeler à un intervalle donné **V2 uniquement**. (run every)
+    """Planifie une fonction à appeler à un intervalle donné **V2 uniquement**.
 
 Example: ``run_every(my_logging, min=5)``
 
@@ -28,31 +28,31 @@ or used as a decorator::
 
 Arguments with different time units are additive.
 
-:param callback: (callback) Le callback à appeler. A omettre dans le cas de l'utilisation via décorateur
-:param days: (days) L'intervalle en jours.
-:param h: (h) L'intervalle en heures.
-:param min: (min) L'intervalle en minutes.
-:param s: (s) L'intervalle en secondes.
-:param ms: (ms) L'intervalle en millisecondes."""
+:param callback: Le callback à appeler. A omettre dans le cas de l'utilisation via décorateur
+:param days: L'intervalle en jours.
+:param h: L'intervalle en heures.
+:param min: L'intervalle en minutes.
+:param s: L'intervalle en secondes.
+:param ms: L'intervalle en millisecondes."""
 
 def panic(n: int) -> None:
-    """Passer en mode panique. (panic)
+    """Passer en mode panique.
 
 Example: ``panic(127)``
 
-:param n: (n) Un nombre entier arbitraire <= 255 pour indiquer un état.
+:param n: Un nombre entier arbitraire <= 255 pour indiquer un état.
 
 Requires restart."""
 
 def reset() -> None:
-    """Redémarrer la carte. (reset)"""
+    """Redémarrer la carte."""
 
 def sleep(n: float) -> None:
-    """Attendre ``n`` millisecondes. (sleep)
+    """Attendre ``n`` millisecondes.
 
 Example: ``sleep(1000)``
 
-:param n: (n) Le nombre de millisecondes à attendre
+:param n: Le nombre de millisecondes à attendre
 
 One second is 1000 milliseconds, so::
 
@@ -61,19 +61,19 @@ One second is 1000 milliseconds, so::
 will pause the execution for one second."""
 
 def running_time() -> int:
-    """Obtenir le temps de fonctionnement de la carte. (running time)
+    """Obtenir le temps de fonctionnement de la carte.
 
 :return: The number of milliseconds since the board was switched on or restarted."""
 
 def temperature() -> int:
-    """Obtenir la température du micro:bit en degrés Celcius. (temperature)"""
+    """Obtenir la température du micro:bit en degrés Celcius."""
 
 def set_volume(v: int) -> None:
-    """Définit le volume. (set volume)
+    """Définit le volume.
 
 Example: ``set_volume(127)``
 
-:param v: (v) Une valeur entre 0 (bas) et 255 (haut).
+:param v: Une valeur entre 0 (bas) et 255 (haut).
 
 Out of range values will be clamped to 0 or 255.
 
@@ -81,16 +81,16 @@ Out of range values will be clamped to 0 or 255.
     ...
 
 class Button:
-    """La classe pour les boutons ``button_a`` et ``button_b``. (button)"""
+    """La classe pour les boutons ``button_a`` et ``button_b``."""
 
     def is_pressed(self) -> bool:
-        """Vérifier si le bouton est appuyé. (is pressed)
+        """Vérifier si le bouton est appuyé.
 
 :return: ``True`` if the specified button ``button`` is pressed, and ``False`` otherwise."""
         ...
 
     def was_pressed(self) -> bool:
-        """Vérifie si le bouton a été pressé depuis que l'appareil a été démarré ou depuis la dernière fois où cette méthode a été appelée. (was pressed)
+        """Vérifie si le bouton a été pressé depuis que l'appareil a été démarré ou depuis la dernière fois où cette méthode a été appelée.
 
 Calling this method will clear the press state so
 that the button must be pressed again before this method will return
@@ -100,17 +100,17 @@ that the button must be pressed again before this method will return
         ...
 
     def get_presses(self) -> int:
-        """Obtenir le nombre total d'occurrences où le bouton a été appuyé, et réinitialise ce total avant de retourner. (get presses)
+        """Obtenir le nombre total d'occurrences où le bouton a été appuyé, et réinitialise ce total avant de retourner.
 
 :return: The number of presses since the device started or the last time this method was called"""
         ...
 button_a: Button
-"""L'objet bouton ``Button`` gauche. (button a)"""
+"""L'objet bouton ``Button`` gauche."""
 button_b: Button
-"""L'objet bouton ``Button`` droit. (button b)"""
+"""L'objet bouton ``Button`` droit."""
 
 class MicroBitDigitalPin:
-    """Une broche numérique. (microbitdigitalpin)
+    """Une broche numérique.
 
 Some pins support analog and touch features using the ``MicroBitAnalogDigitalPin`` and ``MicroBitTouchPin`` subclasses."""
     NO_PULL: int
@@ -118,7 +118,7 @@ Some pins support analog and touch features using the ``MicroBitAnalogDigitalPin
     PULL_DOWN: int
 
     def read_digital(self) -> int:
-        """Récupère la valeur numérique de la broche (read digital)
+        """Récupère la valeur numérique de la broche
 
 Example: ``value = pin0.read_digital()``
 
@@ -126,23 +126,23 @@ Example: ``value = pin0.read_digital()``
         ...
 
     def write_digital(self, value: int) -> None:
-        """Définit la valeur numérique de la broche (write digital)
+        """Définit la valeur numérique de la broche
 
 Example: ``pin0.write_digital(1)``
 
-:param value: (value) 1 pour définir la broche à un niveau haut ou 0 pour définir la broche à un niveau bas"""
+:param value: 1 pour définir la broche à un niveau haut ou 0 pour définir la broche à un niveau bas"""
         ...
 
     def set_pull(self, value: int) -> None:
-        """Définissez l'état de tirage sur l'une des trois valeurs possibles\xa0: ``PULL_UP``, ``PULL_DOWN`` ou ``NO_PULL``. (set pull)
+        """Définissez l'état de tirage sur l'une des trois valeurs possibles\xa0: ``PULL_UP``, ``PULL_DOWN`` ou ``NO_PULL``.
 
 Example: ``pin0.set_pull(pin0.PULL_UP)``
 
-:param value: (value) L'état de tirage sur la broche correspondante, par exemple ``pin0.PULL_UP``."""
+:param value: L'état de tirage sur la broche correspondante, par exemple ``pin0.PULL_UP``."""
         ...
 
     def get_pull(self) -> int:
-        """Obtenir l'état de tirage sur une broche. (get pull)
+        """Obtenir l'état de tirage sur une broche.
 
 Example: ``pin0.get_pull()``
 
@@ -153,7 +153,7 @@ when a pin mode requires it."""
         ...
 
     def get_mode(self) -> str:
-        """Renvoie le mode de la broche (get mode)
+        """Renvoie le mode de la broche
 
 Example: ``pin0.get_mode()``
 
@@ -165,43 +165,43 @@ changes.
         ...
 
     def write_analog(self, value: int) -> None:
-        """Sortie d'un signal PWM sur la broche, avec un rapport cyclique proportionnel à ``value``. (write analog)
+        """Sortie d'un signal PWM sur la broche, avec un rapport cyclique proportionnel à ``value``.
 
 Example: ``pin0.write_analog(254)``
 
-:param value: (value) Un entier ou un nombre à virgule flottante entre 0 (rapport cyclique à 0%) et 1023 (rapport cyclique à 100%)."""
+:param value: Un entier ou un nombre à virgule flottante entre 0 (rapport cyclique à 0%) et 1023 (rapport cyclique à 100%)."""
 
     def set_analog_period(self, period: int) -> None:
-        """Définit la période de sortie du signal PWM à ``period`` en millisecondes. (set analog period)
+        """Définit la période de sortie du signal PWM à ``period`` en millisecondes.
 
 Example: ``pin0.set_analog_period(10)``
 
-:param period: (period) La période en millisecondes avec une valeur minimale valide de 1 ms."""
+:param period: La période en millisecondes avec une valeur minimale valide de 1 ms."""
 
     def set_analog_period_microseconds(self, period: int) -> None:
-        """Définit la période de sortie du signal PWM à ``period`` en millisecondes. (set analog period microseconds)
+        """Définit la période de sortie du signal PWM à ``period`` en millisecondes.
 
 Example: ``pin0.set_analog_period_microseconds(512)``
 
-:param period: (period) La période en microsecondes avec une valeur minimale valide de 256µs."""
+:param period: La période en microsecondes avec une valeur minimale valide de 256µs."""
 
 class MicroBitAnalogDigitalPin(MicroBitDigitalPin):
-    """Une broche avec des fonctions analogiques et numériques. (microbitanalogdigitalpin)"""
+    """Une broche avec des fonctions analogiques et numériques."""
 
     def read_analog(self) -> int:
-        """Lit la tension appliquée à la broche. (read analog)
+        """Lit la tension appliquée à la broche.
 
 Example: ``pin0.read_analog()``
 
 :return: An integer between 0 (meaning 0V) and 1023 (meaning 3.3V)."""
 
 class MicroBitTouchPin(MicroBitAnalogDigitalPin):
-    """Une broche avec des fonctions analogiques, numériques et tactiles. (microbittouchpin)"""
+    """Une broche avec des fonctions analogiques, numériques et tactiles."""
     CAPACITIVE: int
     RESISTIVE: int
 
     def is_touched(self) -> bool:
-        """Vérifie si la broche est touchée. (is touched)
+        """Vérifie si la broche est touchée.
 
 Example: ``pin0.is_touched()``
 
@@ -224,201 +224,201 @@ does not require you to make a ground connection as part of a circuit.
         ...
 
     def set_touch_mode(self, value: int) -> None:
-        """Définit le mode tactile pour la broche. (set touch mode)
+        """Définit le mode tactile pour la broche.
 
 Example: ``pin0.set_touch_mode(pin0.CAPACITIVE)``
 
 The default touch mode for the pins on the edge connector is
 ``resistive``. The default for the logo pin **V2** is ``capacitive``.
 
-:param value: (value) ``CAPACITIVE`` ou ``RESISTIVE`` pour la broche correspondante."""
+:param value: ``CAPACITIVE`` ou ``RESISTIVE`` pour la broche correspondante."""
         ...
 pin0: MicroBitTouchPin
-"""Broche avec des fonctionnalités numériques, analogiques, et tactiles. (pin0)"""
+"""Broche avec des fonctionnalités numériques, analogiques, et tactiles."""
 pin1: MicroBitTouchPin
-"""Broche avec des fonctionnalités numériques, analogiques, et tactiles. (pin1)"""
+"""Broche avec des fonctionnalités numériques, analogiques, et tactiles."""
 pin2: MicroBitTouchPin
-"""Broche avec des fonctionnalités numériques, analogiques, et tactiles. (pin2)"""
+"""Broche avec des fonctionnalités numériques, analogiques, et tactiles."""
 pin3: MicroBitAnalogDigitalPin
-"""Broche avec des fonctionnalités numériques et analogiques. (pin3)"""
+"""Broche avec des fonctionnalités numériques et analogiques."""
 pin4: MicroBitAnalogDigitalPin
-"""Broche avec des fonctionnalités numériques et analogiques. (pin4)"""
+"""Broche avec des fonctionnalités numériques et analogiques."""
 pin5: MicroBitDigitalPin
-"""Broche avec des fonctionnalités numériques (pin5)"""
+"""Broche avec des fonctionnalités numériques"""
 pin6: MicroBitDigitalPin
-"""Broche avec des fonctionnalités numériques (pin6)"""
+"""Broche avec des fonctionnalités numériques"""
 pin7: MicroBitDigitalPin
-"""Broche avec des fonctionnalités numériques (pin7)"""
+"""Broche avec des fonctionnalités numériques"""
 pin8: MicroBitDigitalPin
-"""Broche avec des fonctionnalités numériques (pin8)"""
+"""Broche avec des fonctionnalités numériques"""
 pin9: MicroBitDigitalPin
-"""Broche avec des fonctionnalités numériques (pin9)"""
+"""Broche avec des fonctionnalités numériques"""
 pin10: MicroBitAnalogDigitalPin
-"""Broche avec des fonctionnalités numériques et analogiques. (pin10)"""
+"""Broche avec des fonctionnalités numériques et analogiques."""
 pin11: MicroBitDigitalPin
-"""Broche avec des fonctionnalités numériques (pin11)"""
+"""Broche avec des fonctionnalités numériques"""
 pin12: MicroBitDigitalPin
-"""Broche avec des fonctionnalités numériques (pin12)"""
+"""Broche avec des fonctionnalités numériques"""
 pin13: MicroBitDigitalPin
-"""Broche avec des fonctionnalités numériques (pin13)"""
+"""Broche avec des fonctionnalités numériques"""
 pin14: MicroBitDigitalPin
-"""Broche avec des fonctionnalités numériques (pin14)"""
+"""Broche avec des fonctionnalités numériques"""
 pin15: MicroBitDigitalPin
-"""Broche avec des fonctionnalités numériques (pin15)"""
+"""Broche avec des fonctionnalités numériques"""
 pin16: MicroBitDigitalPin
-"""Broche avec des fonctionnalités numériques (pin16)"""
+"""Broche avec des fonctionnalités numériques"""
 pin19: MicroBitDigitalPin
-"""Broche avec des fonctionnalités numériques (pin19)"""
+"""Broche avec des fonctionnalités numériques"""
 pin20: MicroBitDigitalPin
-"""Broche avec des fonctionnalités numériques (pin20)"""
+"""Broche avec des fonctionnalités numériques"""
 pin_logo: MicroBitTouchPin
-"""Une broche logo sensible au toucher sur l'avant du micro:bit, qui est définie par défaut en mode tactile capacitif. (pin logo)"""
+"""Une broche logo sensible au toucher sur l'avant du micro:bit, qui est définie par défaut en mode tactile capacitif."""
 pin_speaker: MicroBitAnalogDigitalPin
-"""Une broche pour adresser le haut-parleur micro:bit. (pin speaker)
+"""Une broche pour adresser le haut-parleur micro:bit.
 
 This API is intended only for use in Pulse-Width Modulation pin operations e.g. pin_speaker.write_analog(128).
 """
 
 class Image:
-    """Une image à afficher sur l'écran LED du micro:bit. (image)
+    """Une image à afficher sur l'écran LED du micro:bit.
 
 Given an image object it's possible to display it via the ``display`` API::
 
     display.show(Image.HAPPY)"""
     HEART: Image
-    """Image d'un cœur. (heart)"""
+    """Image d'un cœur."""
     HEART_SMALL: Image
-    """Petite image d'un cœur (heart small)"""
+    """Petite image d'un cœur"""
     HAPPY: Image
-    """Image de visage heureux. (happy)"""
+    """Image de visage heureux."""
     SMILE: Image
-    """Image de visage souriant. (smile)"""
+    """Image de visage souriant."""
     SAD: Image
-    """Image de visage triste. (sad)"""
+    """Image de visage triste."""
     CONFUSED: Image
-    """Image d'un visage perplexe. (confused)"""
+    """Image d'un visage perplexe."""
     ANGRY: Image
-    """Image de visage en colère. (angry)"""
+    """Image de visage en colère."""
     ASLEEP: Image
-    """Image de visage endormi (asleep)"""
+    """Image de visage endormi"""
     SURPRISED: Image
-    """Image de visage surpris. (surprised)"""
+    """Image de visage surpris."""
     SILLY: Image
-    """Image de visage absurde. (silly)"""
+    """Image de visage absurde."""
     FABULOUS: Image
-    """Image de visage avec lunettes de soleil. (fabulous)"""
+    """Image de visage avec lunettes de soleil."""
     MEH: Image
-    """Image de visage pas impressionné (meh)"""
+    """Image de visage pas impressionné"""
     YES: Image
-    """Image d'une coche. (yes)"""
+    """Image d'une coche."""
     NO: Image
-    """Image d'une croix. (no)"""
+    """Image d'une croix."""
     CLOCK12: Image
-    """Image avec une ligne indiquant vers 12 heures. (clock12)"""
+    """Image avec une ligne indiquant vers 12 heures."""
     CLOCK11: Image
-    """Image avec une ligne indiquant vers 11 heures. (clock11)"""
+    """Image avec une ligne indiquant vers 11 heures."""
     CLOCK10: Image
-    """Image avec une ligne indiquant vers 10 heures. (clock10)"""
+    """Image avec une ligne indiquant vers 10 heures."""
     CLOCK9: Image
-    """Image avec une ligne indiquant vers 9 heures. (clock9)"""
+    """Image avec une ligne indiquant vers 9 heures."""
     CLOCK8: Image
-    """Image avec une ligne indiquant vers 8 heures. (clock8)"""
+    """Image avec une ligne indiquant vers 8 heures."""
     CLOCK7: Image
-    """Image avec une ligne indiquant vers 7 heures. (clock7)"""
+    """Image avec une ligne indiquant vers 7 heures."""
     CLOCK6: Image
-    """Image avec une ligne indiquant vers 6 heures. (clock6)"""
+    """Image avec une ligne indiquant vers 6 heures."""
     CLOCK5: Image
-    """Image avec une ligne indiquant vers 5 heures. (clock5)"""
+    """Image avec une ligne indiquant vers 5 heures."""
     CLOCK4: Image
-    """Image avec une ligne indiquant vers 4 heures. (clock4)"""
+    """Image avec une ligne indiquant vers 4 heures."""
     CLOCK3: Image
-    """Image avec une ligne indiquant vers 3 heures. (clock3)"""
+    """Image avec une ligne indiquant vers 3 heures."""
     CLOCK2: Image
-    """Image avec une ligne indiquant vers 2 heures. (clock2)"""
+    """Image avec une ligne indiquant vers 2 heures."""
     CLOCK1: Image
-    """Image avec une ligne indiquant vers 1 heure. (clock1)"""
+    """Image avec une ligne indiquant vers 1 heure."""
     ARROW_N: Image
-    """Image de flèche pointant vers le nord. (arrow n)"""
+    """Image de flèche pointant vers le nord."""
     ARROW_NE: Image
-    """Image de flèche pointant vers le nord est. (arrow ne)"""
+    """Image de flèche pointant vers le nord est."""
     ARROW_E: Image
-    """Image de flèche pointant vers l'est. (arrow e)"""
+    """Image de flèche pointant vers l'est."""
     ARROW_SE: Image
-    """Image de flèche pointant vers le sud-est. (arrow se)"""
+    """Image de flèche pointant vers le sud-est."""
     ARROW_S: Image
-    """Image de flèche pointant vers le sud. (arrow s)"""
+    """Image de flèche pointant vers le sud."""
     ARROW_SW: Image
-    """Image de flèche pointant vers le sud-ouest. (arrow sw)"""
+    """Image de flèche pointant vers le sud-ouest."""
     ARROW_W: Image
-    """Image de flèche pointant vers l'ouest. (arrow w)"""
+    """Image de flèche pointant vers l'ouest."""
     ARROW_NW: Image
-    """Image de flèche pointant vers le nord ouest. (arrow nw)"""
+    """Image de flèche pointant vers le nord ouest."""
     TRIANGLE: Image
-    """Image d'un triangle pointant vers le haut. (triangle)"""
+    """Image d'un triangle pointant vers le haut."""
     TRIANGLE_LEFT: Image
-    """Image d'un triangle dans le coin gauche. (triangle left)"""
+    """Image d'un triangle dans le coin gauche."""
     CHESSBOARD: Image
-    """Éclairage alternatif des LEDs dans un motif d'échiquier. (chessboard)"""
+    """Éclairage alternatif des LEDs dans un motif d'échiquier."""
     DIAMOND: Image
-    """Image de diamant. (diamond)"""
+    """Image de diamant."""
     DIAMOND_SMALL: Image
-    """Petite image de diamant. (diamond small)"""
+    """Petite image de diamant."""
     SQUARE: Image
-    """Image de carré. (square)"""
+    """Image de carré."""
     SQUARE_SMALL: Image
-    """Petite image de carré. (square small)"""
+    """Petite image de carré."""
     RABBIT: Image
-    """Image de lapin. (rabbit)"""
+    """Image de lapin."""
     COW: Image
-    """Image de vache. (cow)"""
+    """Image de vache."""
     MUSIC_CROTCHET: Image
-    """Image d'une note. (music crotchet)"""
+    """Image d'une note."""
     MUSIC_QUAVER: Image
-    """Image d'une croche. (music quaver)"""
+    """Image d'une croche."""
     MUSIC_QUAVERS: Image
-    """Image d'une paire de croche. (music quavers)"""
+    """Image d'une paire de croche."""
     PITCHFORK: Image
-    """Image d'une fourche. (pitchfork)"""
+    """Image d'une fourche."""
     XMAS: Image
-    """Image d'un arbre de Noël. (xmas)"""
+    """Image d'un arbre de Noël."""
     PACMAN: Image
-    """Image du personnage d'arcade Pac-Man. (pacman)"""
+    """Image du personnage d'arcade Pac-Man."""
     TARGET: Image
-    """Image d'une cible. (target)"""
+    """Image d'une cible."""
     TSHIRT: Image
-    """Image de t-shirt. (tshirt)"""
+    """Image de t-shirt."""
     ROLLERSKATE: Image
-    """Image de patin à roulette. (rollerskate)"""
+    """Image de patin à roulette."""
     DUCK: Image
-    """Image de canard. (duck)"""
+    """Image de canard."""
     HOUSE: Image
-    """Image d'une maison. (house)"""
+    """Image d'une maison."""
     TORTOISE: Image
-    """Image d'une tortue. (tortoise)"""
+    """Image d'une tortue."""
     BUTTERFLY: Image
-    """Image d'un papillon. (butterfly)"""
+    """Image d'un papillon."""
     STICKFIGURE: Image
-    """Image d'un personnage. (stickfigure)"""
+    """Image d'un personnage."""
     GHOST: Image
-    """Image de fantôme. (ghost)"""
+    """Image de fantôme."""
     SWORD: Image
-    """Image d'une épée. (sword)"""
+    """Image d'une épée."""
     GIRAFFE: Image
-    """Image d'une girafe. (giraffe)"""
+    """Image d'une girafe."""
     SKULL: Image
-    """Image d'un crâne. (skull)"""
+    """Image d'un crâne."""
     UMBRELLA: Image
-    """Image d'un parapluie. (umbrella)"""
+    """Image d'un parapluie."""
     SNAKE: Image
-    """Image de serpent. (snake)"""
+    """Image de serpent."""
     ALL_CLOCKS: List[Image]
-    """Une liste contenant toutes les images CLOCK_ en séquence. (all clocks)"""
+    """Une liste contenant toutes les images CLOCK_ en séquence."""
     ALL_ARROWS: List[Image]
-    """Une liste contenant toutes les images ARROW_ en séquence. (all arrows)"""
+    """Une liste contenant toutes les images ARROW_ en séquence."""
 
     @overload
     def __init__(self, string: str) -> None:
-        """Créer une image à partir d'une chaîne de caractères décrivant quelles LED sont allumées. (init)
+        """Créer une image à partir d'une chaîne de caractères décrivant quelles LED sont allumées.
 
 ``string`` has to consist of digits 0-9 arranged into lines,
 describing the image, for example::
@@ -432,16 +432,16 @@ describing the image, for example::
 will create a 5×5 image of an X. The end of a line is indicated by a
 colon. It's also possible to use newlines (\\n) insead of the colons.
 
-:param string: (string) La chaîne de caractères décrivant l'image."""
+:param string: La chaîne de caractères décrivant l'image."""
         ...
 
     @overload
     def __init__(self, width: int=5, height: int=5, buffer: ReadableBuffer=None) -> None:
-        """Créer une image vide avec ``width`` colonnes et ``height`` lignes. (init)
+        """Créer une image vide avec ``width`` colonnes et ``height`` lignes.
 
-:param width: (width) Largeur optionnelle de l'image
-:param height: (height) Hauteur optionnelle de l'image
-:param buffer: (buffer) Tableau optionnel ou octets de ``width``×``height`` entiers dans la plage 0-9 pour initialiser l'image
+:param width: Largeur optionnelle de l'image
+:param height: Hauteur optionnelle de l'image
+:param buffer: Tableau optionnel ou octets de ``width``×``height`` entiers dans la plage 0-9 pour initialiser l'image
 
 Examples::
 
@@ -452,90 +452,90 @@ These create 2 x 2 pixel images at full brightness."""
         ...
 
     def width(self) -> int:
-        """Récupère le nombre de colonnes. (width)
+        """Récupère le nombre de colonnes.
 
 :return: The number of columns in the image"""
         ...
 
     def height(self) -> int:
-        """Récupère le nombre de lignes. (height)
+        """Récupère le nombre de lignes.
 
 :return: The number of rows in the image"""
         ...
 
     def set_pixel(self, x: int, y: int, value: int) -> None:
-        """Définit la luminosité d'un pixel. (set pixel)
+        """Définit la luminosité d'un pixel.
 
 Example: ``my_image.set_pixel(0, 0, 9)``
 
-:param x: (x) Le numéro de colonne
-:param y: (y) Le numéro de ligne
-:param value: (value) La luminosité sous la forme d'un entier compris entre 0 (sombre) et 9 (lumineux)
+:param x: Le numéro de colonne
+:param y: Le numéro de ligne
+:param value: La luminosité sous la forme d'un entier compris entre 0 (sombre) et 9 (lumineux)
 
 This method will raise an exception when called on any of the built-in
 read-only images, like ``Image.HEART``."""
         ...
 
     def get_pixel(self, x: int, y: int) -> int:
-        """Récupère la luminosité d'un pixel. (get pixel)
+        """Récupère la luminosité d'un pixel.
 
 Example: ``my_image.get_pixel(0, 0)``
 
-:param x: (x) Le numéro de colonne
-:param y: (y) Le numéro de ligne
+:param x: Le numéro de colonne
+:param y: Le numéro de ligne
 :return: The brightness as an integer between 0 and 9."""
         ...
 
     def shift_left(self, n: int) -> Image:
-        """Créer une nouvelle image en déplaçant l'image à gauche. (shift left)
+        """Créer une nouvelle image en déplaçant l'image à gauche.
 
 Example: ``Image.HEART_SMALL.shift_left(1)``
 
-:param n: (n) Le nombre de colonnes par lequel déplacer
+:param n: Le nombre de colonnes par lequel déplacer
 :return: The shifted image"""
         ...
 
     def shift_right(self, n: int) -> Image:
-        """Créer une nouvelle image en déplaçant l'image à droite. (shift right)
+        """Créer une nouvelle image en déplaçant l'image à droite.
 
 Example: ``Image.HEART_SMALL.shift_right(1)``
 
-:param n: (n) Le nombre de colonnes par lequel déplacer
+:param n: Le nombre de colonnes par lequel déplacer
 :return: The shifted image"""
         ...
 
     def shift_up(self, n: int) -> Image:
-        """Créer une nouvelle image en déplaçant l'image vers le haut. (shift up)
+        """Créer une nouvelle image en déplaçant l'image vers le haut.
 
 Example: ``Image.HEART_SMALL.shift_up(1)``
 
-:param n: (n) Le nombre de lignes par lequel déplacer
+:param n: Le nombre de lignes par lequel déplacer
 :return: The shifted image"""
         ...
 
     def shift_down(self, n: int) -> Image:
-        """Créer une nouvelle image en déplaçant l'image vers le bas. (shift down)
+        """Créer une nouvelle image en déplaçant l'image vers le bas.
 
 Example: ``Image.HEART_SMALL.shift_down(1)``
 
-:param n: (n) Le nombre de lignes par lequel déplacer
+:param n: Le nombre de lignes par lequel déplacer
 :return: The shifted image"""
         ...
 
     def crop(self, x: int, y: int, w: int, h: int) -> Image:
-        """Créer une nouvelle image en recadrant l'image. (crop)
+        """Créer une nouvelle image en recadrant l'image.
 
 Example: ``Image.HEART.crop(1, 1, 3, 3)``
 
-:param x: (x) Le nombre de colonnes duquel décaler le recadrage
-:param y: (y) Le nombre de lignes duquel décaler le recadrage
-:param w: (w) La largeur du recadrage
-:param h: (h) La hauteur du recadrage
+:param x: Le nombre de colonnes duquel décaler le recadrage
+:param y: Le nombre de lignes duquel décaler le recadrage
+:param w: La largeur du recadrage
+:param h: La hauteur du recadrage
 :return: The new image"""
         ...
 
     def copy(self) -> Image:
-        """Créer une copie exacte de l'image. (copy)
+        """Créer une copie exacte de l'image.
 
 Example: ``Image.HEART.copy()``
 
@@ -543,7 +543,7 @@ Example: ``Image.HEART.copy()``
         ...
 
     def invert(self) -> Image:
-        """Créer une nouvelle image en inversant la luminosité des pixels de l'image source. (invert)
+        """Créer une nouvelle image en inversant la luminosité des pixels de l'image source.
 
 Example: ``Image.SMALL_HEART.invert()``
 
@@ -551,28 +551,28 @@ Example: ``Image.SMALL_HEART.invert()``
         ...
 
     def fill(self, value: int) -> None:
-        """Définit la luminosité de tous les pixels de l'image. (fill)
+        """Définit la luminosité de tous les pixels de l'image.
 
 Example: ``my_image.fill(5)``
 
-:param value: (value) La nouvelle luminosité sous la forme d'un nombre compris entre 0 (sombre) et 9 (lumineux).
+:param value: La nouvelle luminosité sous la forme d'un nombre compris entre 0 (sombre) et 9 (lumineux).
 
 This method will raise an exception when called on any of the built-in
 read-only images, like ``Image.HEART``."""
         ...
 
     def blit(self, src: Image, x: int, y: int, w: int, h: int, xdest: int=0, ydest: int=0) -> None:
-        """Copier la zone d'une autre image vers cette image. (blit)
+        """Copier la zone d'une autre image vers cette image.
 
 Example: ``my_image.blit(Image.HEART, 1, 1, 3, 3, 1, 1)``
 
-:param src: (src) L'image source
-:param x: (x) Le décalage de la colonne de départ dans l'image source
-:param y: (y) Décalage de la ligne de départ dans l'image source
-:param w: (w) Le nombre de colonnes à copier
-:param h: (h) Le nombre de lignes à copier
-:param xdest: (xdest) Le décalage de la colonne à modifier dans cette image
-:param ydest: (ydest) Le décalage de la ligne à modifier dans cette image
+:param src: L'image source
+:param x: Le décalage de la colonne de départ dans l'image source
+:param y: Décalage de la ligne de départ dans l'image source
+:param w: Le nombre de colonnes à copier
+:param h: Le nombre de lignes à copier
+:param xdest: Le décalage de la colonne à modifier dans cette image
+:param ydest: Le décalage de la ligne à modifier dans cette image
 
 Pixels outside the source image are treated as having a brightness of 0.
 
@@ -588,74 +588,74 @@ For example, img.crop(x, y, w, h) can be implemented as::
         ...
 
     def __repr__(self) -> str:
-        """Récupère une représentation de l'image sous forme de texte compact. (repr)"""
+        """Récupère une représentation de l'image sous forme de texte compact."""
         ...
 
     def __str__(self) -> str:
-        """Récupère une chaîne de caractères lisible de l'image. (str)"""
+        """Récupère une chaîne de caractères lisible de l'image."""
         ...
 
     def __add__(self, other: Image) -> Image:
         """Crée une nouvelle image en additionnant les valeurs de luminosité des deux images
-pour chaque pixel. (add)
+pour chaque pixel.
 
 Example: ``Image.HEART + Image.HAPPY``
 
-:param other: (other) L'image à ajouter."""
+:param other: L'image à ajouter."""
         ...
 
     def __sub__(self, other: Image) -> Image:
         """Crée une nouvelle image en soustrayant de cette image les valeurs de luminosité de
-l'autre image. (sub)
+l'autre image.
 
 Example: ``Image.HEART - Image.HEART_SMALL``
 
-:param other: (other) L'image à soustraire."""
+:param other: L'image à soustraire."""
         ...
 
     def __mul__(self, n: float) -> Image:
         """Crée une nouvelle image en multipliant la luminosité de chaque pixel par
-``n``. (mul)
+``n``.
 
 Example: ``Image.HEART * 0.5``
 
-:param n: (n) La valeur par laquelle multiplier."""
+:param n: La valeur par laquelle multiplier."""
         ...
 
     def __truediv__(self, n: float) -> Image:
         """Crée une nouvelle image en divisant la luminosité de chaque pixel par
-``n``. (truediv)
+``n``.
 
 Example: ``Image.HEART / 2``
 
-:param n: (n) La valeur par laquelle diviser."""
+:param n: La valeur par laquelle diviser."""
         ...
 
 class SoundEvent:
     LOUD: SoundEvent
-    """Représente la transition d'événements sonores, de ``quiet`` à ``loud`` comme un clap dans les mains ou un cri. (loud)"""
+    """Représente la transition d'événements sonores, de ``quiet`` à ``loud`` comme un clap dans les mains ou un cri."""
     QUIET: SoundEvent
-    """Représente la transition d'événements sonores de ``loud`` à ``quiet`` comme parler ou écouter de la musique de fond. (quiet)"""
+    """Représente la transition d'événements sonores de ``loud`` à ``quiet`` comme parler ou écouter de la musique de fond."""
 
 class Sound:
-    """Les sons intégrés peuvent être appelés en utilisant ``audio.play(Sound.NAME)``. (sound)"""
+    """Les sons intégrés peuvent être appelés en utilisant ``audio.play(Sound.NAME)``."""
     GIGGLE: Sound
-    """Bruit de gloussement. (giggle)"""
+    """Bruit de gloussement."""
     HAPPY: Sound
-    """Son joyeux. (happy)"""
+    """Son joyeux."""
     HELLO: Sound
-    """Son de salutation. (hello)"""
+    """Son de salutation."""
     MYSTERIOUS: Sound
-    """Son mystérieux. (mysterious)"""
+    """Son mystérieux."""
     SAD: Sound
-    """Son triste. (sad)"""
+    """Son triste."""
     SLIDE: Sound
-    """Bruit de glissade. (slide)"""
+    """Bruit de glissade."""
     SOARING: Sound
-    """Bruit d'envolée. (soaring)"""
+    """Bruit d'envolée."""
     SPRING: Sound
-    """Son d'un ressort. (spring)"""
+    """Son d'un ressort."""
     TWINKLE: Sound
-    """Son de scintillement. (twinkle)"""
+    """Son de scintillement."""
     YAWN: Sound
-    """Son de bâillement. (yawn)"""
+    """Son de bâillement."""

--- a/lang/fr/typeshed/stdlib/microbit/accelerometer.pyi
+++ b/lang/fr/typeshed/stdlib/microbit/accelerometer.pyi
@@ -1,8 +1,8 @@
-"""Mesurer l'accélération du micro:bit et reconnaitre des mouvements. (accelerometer)"""
+"""Mesurer l'accélération du micro:bit et reconnaitre des mouvements."""
 from typing import Tuple
 
 def get_x() -> int:
-    """Récupérer la mesure de l'accélération dans l'axe ``x`` en milli-g. (get x)
+    """Récupérer la mesure de l'accélération dans l'axe ``x`` en milli-g.
 
 Example: ``accelerometer.get_x()``
 
@@ -10,7 +10,7 @@ Example: ``accelerometer.get_x()``
     ...
 
 def get_y() -> int:
-    """Récupérer la mesure de l'accélération dans l'axe ``y`` en milli-g. (get y)
+    """Récupérer la mesure de l'accélération dans l'axe ``y`` en milli-g.
 
 Example: ``accelerometer.get_y()``
 
@@ -18,7 +18,7 @@ Example: ``accelerometer.get_y()``
     ...
 
 def get_z() -> int:
-    """Récupérer la mesure de l'accélération dans l'axe ``z`` en milli-g. (get z)
+    """Récupérer la mesure de l'accélération dans l'axe ``z`` en milli-g.
 
 Example: ``accelerometer.get_z()``
 
@@ -26,7 +26,7 @@ Example: ``accelerometer.get_z()``
     ...
 
 def get_values() -> Tuple[int, int, int]:
-    """Récupérer en une fois les mesures d'accélération dans tous les axes sous forme d'un tuple. (get values)
+    """Récupérer en une fois les mesures d'accélération dans tous les axes sous forme d'un tuple.
 
 Example: ``x, y, z = accelerometer.get_values()``
 
@@ -34,7 +34,7 @@ Example: ``x, y, z = accelerometer.get_values()``
     ...
 
 def current_gesture() -> str:
-    """Récupérer le nom du geste actuel. (current gesture)
+    """Récupérer le nom du geste actuel.
 
 Example: ``accelerometer.current_gesture()``
 
@@ -47,7 +47,7 @@ represented as strings.
     ...
 
 def is_gesture(name: str) -> bool:
-    """Vérifier si le geste nommé est actif en ce moment. (is gesture)
+    """Vérifier si le geste nommé est actif en ce moment.
 
 Example: ``accelerometer.is_gesture('shake')``
 
@@ -56,12 +56,12 @@ MicroPython understands the following gesture names: ``"up"``, ``"down"``,
 ``"3g"``, ``"6g"``, ``"8g"``, ``"shake"``. Gestures are always
 represented as strings.
 
-:param name: (name) Le nom du geste.
+:param name: Le nom du geste.
 :return: ``True`` if the gesture is active, ``False`` otherwise."""
     ...
 
 def was_gesture(name: str) -> bool:
-    """Vérifier si le geste nommé a été actif depuis le dernier appel. (was gesture)
+    """Vérifier si le geste nommé a été actif depuis le dernier appel.
 
 Example: ``accelerometer.was_gesture('shake')``
 
@@ -70,11 +70,11 @@ MicroPython understands the following gesture names: ``"up"``, ``"down"``,
 ``"3g"``, ``"6g"``, ``"8g"``, ``"shake"``. Gestures are always
 represented as strings.
 
-:param name: (name) Le nom du geste.
+:param name: Le nom du geste.
 :return: ``True`` if the gesture was active since the last call, ``False`` otherwise."""
 
 def get_gestures() -> Tuple[str, ...]:
-    """Renvoyer un tuple de l'historique des gestes. (get gestures)
+    """Renvoyer un tuple de l'historique des gestes.
 
 Example: ``accelerometer.get_gestures()``
 

--- a/lang/fr/typeshed/stdlib/microbit/audio.pyi
+++ b/lang/fr/typeshed/stdlib/microbit/audio.pyi
@@ -1,19 +1,19 @@
-"""Jouer des sons en utilisant le micro:bit (importer ``audio`` pour compatibilité V1). (audio)"""
+"""Jouer des sons en utilisant le micro:bit (importer ``audio`` pour compatibilité V1)."""
 from ..microbit import MicroBitDigitalPin, Sound, pin0
 from typing import Iterable, Union
 
 def play(source: Union[Iterable[AudioFrame], Sound], wait: bool=True, pin: MicroBitDigitalPin=pin0, return_pin: Union[MicroBitDigitalPin, None]=None) -> None:
-    """Jouer un son intégré ou des frames audio personnalisées. (play)
+    """Jouer un son intégré ou des frames audio personnalisées.
 
 Example: ``audio.play(Sound.GIGGLE)``
 
-:param source: (source) Un ``son`` intégré tel que ``Sound.GIGGLE`` ou un échantillon de données en tant qu'itérable d'objets ``AudioFrame``.
-:param wait: (wait) Si ``wait`` est ``True``, cette fonction bloquera jusqu'à ce que le son soit terminé.
+:param source: Un ``son`` intégré tel que ``Sound.GIGGLE`` ou un échantillon de données en tant qu'itérable d'objets ``AudioFrame``.
+:param wait: Si ``wait`` est ``True``, cette fonction bloquera jusqu'à ce que le son soit terminé.
 :param pin: (broche) Un argument optionnel pour spécifier la broche de sortie, peut être utilisé pour remplacer la valeur par défaut ``pin0``. Si nous ne voulons pas que le son soit joué, il est possible d'utiliser ``pin=None``.
-:param return_pin: (return pin) Spécifie une broche de connecteur de bord différentiel à connecter à un haut-parleur externe au lieu de la masse. Ceci est ignoré dans la révision **V2**."""
+:param return_pin: Spécifie une broche de connecteur de bord différentiel à connecter à un haut-parleur externe au lieu de la masse. Ceci est ignoré dans la révision **V2**."""
 
 def is_playing() -> bool:
-    """Vérifier si un son est en train d'être joué. (is playing)
+    """Vérifier si un son est en train d'être joué.
 
 Example: ``audio.is_playing()``
 
@@ -21,14 +21,14 @@ Example: ``audio.is_playing()``
     ...
 
 def stop() -> None:
-    """Arrêter toute lecture audio. (stop)
+    """Arrêter toute lecture audio.
 
 Example: ``audio.stop()``"""
     ...
 
 class AudioFrame:
     """Un objet ``AudioFrame`` est une liste de 32 échantillons, chacun d'eux étant un octet non signé
-(nombre entier entre 0 et 255). (audioframe)
+(nombre entier entre 0 et 255).
 
 It takes just over 4 ms to play a single frame.
 

--- a/lang/fr/typeshed/stdlib/microbit/compass.pyi
+++ b/lang/fr/typeshed/stdlib/microbit/compass.pyi
@@ -1,7 +1,7 @@
-"""Utiliser la boussole intégrée. (compass)"""
+"""Utiliser la boussole intégrée."""
 
 def calibrate() -> None:
-    """Démarrer le processus d'étalonnage. (calibrate)
+    """Démarrer le processus d'étalonnage.
 
 Example: ``compass.calibrate()``
 
@@ -10,7 +10,7 @@ to rotate the device in order to draw a circle on the LED display."""
     ...
 
 def is_calibrated() -> bool:
-    """Vérifier si la boussole est étalonnée. (is calibrated)
+    """Vérifier si la boussole est étalonnée.
 
 Example: ``compass.is_calibrated()``
 
@@ -18,13 +18,13 @@ Example: ``compass.is_calibrated()``
     ...
 
 def clear_calibration() -> None:
-    """Annule l'étalonnage, la boussole est ainsi à nouveau non-étalonnée. (clear calibration)
+    """Annule l'étalonnage, la boussole est ainsi à nouveau non-étalonnée.
 
 Example: ``compass.clear_calibration()``"""
     ...
 
 def get_x() -> int:
-    """Obtenir la force du champ magnétique sur l'axe ``x``. (get x)
+    """Obtenir la force du champ magnétique sur l'axe ``x``.
 
 Example: ``compass.get_x()``
 
@@ -34,7 +34,7 @@ Call ``calibrate`` first or the results will be inaccurate.
     ...
 
 def get_y() -> int:
-    """Obtenir la force du champ magnétique sur l'axe ``y``. (get y)
+    """Obtenir la force du champ magnétique sur l'axe ``y``.
 
 Example: ``compass.get_y()``
 
@@ -44,7 +44,7 @@ Call ``calibrate`` first or the results will be inaccurate.
     ...
 
 def get_z() -> int:
-    """Obtenir la force du champ magnétique sur l'axe ``z``. (get z)
+    """Obtenir la force du champ magnétique sur l'axe ``z``.
 
 Example: ``compass.get_z()``
 
@@ -54,7 +54,7 @@ Call ``calibrate`` first or the results will be inaccurate.
     ...
 
 def heading() -> int:
-    """Obtenir le cap de la boussole. (heading)
+    """Obtenir le cap de la boussole.
 
 Example: ``compass.heading()``
 
@@ -62,7 +62,7 @@ Example: ``compass.heading()``
     ...
 
 def get_field_strength() -> int:
-    """Récupère la magnitude du champ magnétique autour de l'appareil. (get field strength)
+    """Récupère la magnitude du champ magnétique autour de l'appareil.
 
 Example: ``compass.get_field_strength()``
 

--- a/lang/fr/typeshed/stdlib/microbit/display.pyi
+++ b/lang/fr/typeshed/stdlib/microbit/display.pyi
@@ -1,79 +1,79 @@
-"""Afficher du texte, des images et des animations sur l'écran LED 5×5. (display)"""
+"""Afficher du texte, des images et des animations sur l'écran LED 5×5."""
 from ..microbit import Image
 from typing import Union, overload, Iterable
 
 def get_pixel(x: int, y: int) -> int:
-    """Récupère la luminosité de la LED à la colonne ``x`` et à la ligne ``y``. (get pixel)
+    """Récupère la luminosité de la LED à la colonne ``x`` et à la ligne ``y``.
 
 Example: ``display.get_pixel(0, 0)``
 
-:param x: (x) La colonne d'affichage (0..4)
-:param y: (y) La ligne d'affichage (0..4)
+:param x: La colonne d'affichage (0..4)
+:param y: La ligne d'affichage (0..4)
 :return: A number between 0 (off) and 9 (bright)"""
     ...
 
 def set_pixel(x: int, y: int, value: int) -> None:
-    """Définit la luminosité de la LED à la colonne ``x`` et à la ligne ``y``. (set pixel)
+    """Définit la luminosité de la LED à la colonne ``x`` et à la ligne ``y``.
 
 Example: ``display.set_pixel(0, 0, 9)``
 
-:param x: (x) La colonne d'affichage (0..4)
-:param y: (y) La ligne d'affichage (0..4)
-:param value: (value) La luminosité entre 0 (éteint) et 9 (lumineux)"""
+:param x: La colonne d'affichage (0..4)
+:param y: La ligne d'affichage (0..4)
+:param value: La luminosité entre 0 (éteint) et 9 (lumineux)"""
     ...
 
 def clear() -> None:
-    """Régler la luminosité de toutes les LED à 0 (éteintes). (clear)
+    """Régler la luminosité de toutes les LED à 0 (éteintes).
 
 Example: ``display.clear()``"""
     ...
 
 def show(image: Union[str, float, int, Image, Iterable[Image]], delay: int=400, wait: bool=True, loop: bool=False, clear: bool=False) -> None:
-    """Afficher des images, des lettres ou des chiffres sur l'affichage LED. (show)
+    """Afficher des images, des lettres ou des chiffres sur l'affichage LED.
 
 Example: ``display.show(Image.HEART)``
 
 When ``image`` is an image or a list of images then each image is displayed in turn.
 If ``image`` is a string or number, each letter or digit is displayed in turn.
 
-:param image: (image) Une chaîne de caractères, un nombre, une image ou une liste d'images à afficher.
-:param delay: (delay) Chaque lettre, chiffre ou image est séparé par un délai de ``delay`` millisecondes.
-:param wait: (wait) Si ``wait`` est ``True`` cette fonction bloquera jusqu'à la fin de l'animation, sinon l'animation s'effectuera en arrière-plan.
-:param loop: (loop) Si ``loop`` est ``True``, l'animation se répétera indéfiniment.
-:param clear: (clear) Si ``clear`` est ``True``, l'affichage sera effacé une fois la séquence terminée.
+:param image: Une chaîne de caractères, un nombre, une image ou une liste d'images à afficher.
+:param delay: Chaque lettre, chiffre ou image est séparé par un délai de ``delay`` millisecondes.
+:param wait: Si ``wait`` est ``True`` cette fonction bloquera jusqu'à la fin de l'animation, sinon l'animation s'effectuera en arrière-plan.
+:param loop: Si ``loop`` est ``True``, l'animation se répétera indéfiniment.
+:param clear: Si ``clear`` est ``True``, l'affichage sera effacé une fois la séquence terminée.
 
 The ``wait``, ``loop`` and ``clear`` arguments must be specified using their keyword."""
     ...
 
 def scroll(text: Union[str, float, int], delay: int=150, wait: bool=True, loop: bool=False, monospace: bool=False) -> None:
-    """Faire défiler un nombre ou un texte sur l'affichage LED. (scroll)
+    """Faire défiler un nombre ou un texte sur l'affichage LED.
 
 Example: ``display.scroll('micro:bit')``
 
-:param text: (text) La chaîne de caractères à faire défiler. Si ``text`` est un entier ou un nombre décimal, il sera converti en une chaîne avec ``str()``.
-:param delay: (delay) Le paramètre ``delay`` contrôle la vitesse de défilement du texte.
-:param wait: (wait) Si ``wait`` est ``True`` cette fonction bloquera jusqu'à la fin de l'animation, sinon l'animation s'effectuera en arrière-plan.
-:param loop: (loop) Si ``loop`` est ``True``, l'animation se répétera indéfiniment.
-:param monospace: (monospace) Si ``monospace`` est ``True``, tous les caractères utiliseront 5 pixels en largeur, sinon, exactement 1 colonne de pixel vide sera insérée entre chaque caractère lors du défilement.
+:param text: La chaîne de caractères à faire défiler. Si ``text`` est un entier ou un nombre décimal, il sera converti en une chaîne avec ``str()``.
+:param delay: Le paramètre ``delay`` contrôle la vitesse de défilement du texte.
+:param wait: Si ``wait`` est ``True`` cette fonction bloquera jusqu'à la fin de l'animation, sinon l'animation s'effectuera en arrière-plan.
+:param loop: Si ``loop`` est ``True``, l'animation se répétera indéfiniment.
+:param monospace: Si ``monospace`` est ``True``, tous les caractères utiliseront 5 pixels en largeur, sinon, exactement 1 colonne de pixel vide sera insérée entre chaque caractère lors du défilement.
 
 The ``wait``, ``loop`` and ``monospace`` arguments must be specified
 using their keyword."""
     ...
 
 def on() -> None:
-    """Allumer l'écran LED. (on)
+    """Allumer l'écran LED.
 
 Example: ``display.on()``"""
     ...
 
 def off() -> None:
-    """Eteindre l'écran LED (désactiver l'affichage vous permet de réutiliser les broches GPIO à d'autres fins). (off)
+    """Eteindre l'écran LED (désactiver l'affichage vous permet de réutiliser les broches GPIO à d'autres fins).
 
 Example: ``display.off()``"""
     ...
 
 def is_on() -> bool:
-    """Vérifier si l'affichage LED est activé. (is on)
+    """Vérifier si l'affichage LED est activé.
 
 Example: ``display.is_on()``
 
@@ -81,7 +81,7 @@ Example: ``display.is_on()``
     ...
 
 def read_light_level() -> int:
-    """Lit le niveau de lumière. (read light level)
+    """Lit le niveau de lumière.
 
 Example: ``display.read_light_level()``
 

--- a/lang/fr/typeshed/stdlib/microbit/i2c.pyi
+++ b/lang/fr/typeshed/stdlib/microbit/i2c.pyi
@@ -1,16 +1,16 @@
-"""Communiquer avec les périphériques en utilisant le protocole de bus I²C. (i2c)"""
+"""Communiquer avec les périphériques en utilisant le protocole de bus I²C."""
 from _typeshed import ReadableBuffer
 from ..microbit import MicroBitDigitalPin, pin19, pin20
 from typing import List
 
 def init(freq: int=100000, sda: MicroBitDigitalPin=pin20, scl: MicroBitDigitalPin=pin19) -> None:
-    """Réinitialiser un périphérique. (init)
+    """Réinitialiser un périphérique.
 
 Example: ``i2c.init()``
 
-:param freq: (freq) fréquence d'horloge
-:param sda: (sda) Broche ``sda`` (19 par défaut)
-:param scl: (scl) Broche ``scl`` (19 par défaut)
+:param freq: fréquence d'horloge
+:param sda: Broche ``sda`` (19 par défaut)
+:param scl: Broche ``scl`` (19 par défaut)
 
 On a micro:bit V1 board, changing the I²C pins from defaults will make
 the accelerometer and compass stop working, as they are connected
@@ -20,7 +20,7 @@ for the motion sensors and the edge connector."""
     ...
 
 def scan() -> List[int]:
-    """Scanner le bus pour détecter des périphériques. (scan)
+    """Scanner le bus pour détecter des périphériques.
 
 Example: ``i2c.scan()``
 
@@ -28,22 +28,22 @@ Example: ``i2c.scan()``
     ...
 
 def read(addr: int, n: int, repeat: bool=False) -> bytes:
-    """Lire des octets depuis un périphérique. (read)
+    """Lire des octets depuis un périphérique.
 
 Example: ``i2c.read(0x50, 64)``
 
-:param addr: (addr) L'adresse 7-bit du périphérique
-:param n: (n) Le nombre d'octets à lire
-:param repeat: (repeat) Si ``True``, aucun bit d'arrêt ne sera envoyé
+:param addr: L'adresse 7-bit du périphérique
+:param n: Le nombre d'octets à lire
+:param repeat: Si ``True``, aucun bit d'arrêt ne sera envoyé
 :return: The bytes read"""
     ...
 
 def write(addr: int, buf: ReadableBuffer, repeat: bool=False) -> None:
-    """Écrire des octets sur un périphérique. (write)
+    """Écrire des octets sur un périphérique.
 
 Example: ``i2c.write(0x50, bytes([1, 2, 3]))``
 
-:param addr: (addr) L'adresse 7-bit du périphérique
-:param buf: (buf) Un buffer contenant les octets à écrire
-:param repeat: (repeat) Si ``True``, aucun bit d'arrêt ne sera envoyé"""
+:param addr: L'adresse 7-bit du périphérique
+:param buf: Un buffer contenant les octets à écrire
+:param repeat: Si ``True``, aucun bit d'arrêt ne sera envoyé"""
     ...

--- a/lang/fr/typeshed/stdlib/microbit/microphone.pyi
+++ b/lang/fr/typeshed/stdlib/microbit/microphone.pyi
@@ -1,9 +1,9 @@
-"""Réagir à du son en utilisant le microphone intégré (V2 uniquement). (microphone)"""
+"""Réagir à du son en utilisant le microphone intégré (V2 uniquement)."""
 from typing import Optional, Tuple
 from ..microbit import SoundEvent
 
 def current_event() -> Optional[SoundEvent]:
-    """Récupérer le dernier événement sonore enregistré (current event)
+    """Récupérer le dernier événement sonore enregistré
 
 Example: ``microphone.current_event()``
 
@@ -11,29 +11,29 @@ Example: ``microphone.current_event()``
     ...
 
 def was_event(event: SoundEvent) -> bool:
-    """Vérifier si un son a été entendu au moins une fois depuis le dernier appel. (was event)
+    """Vérifier si un son a été entendu au moins une fois depuis le dernier appel.
 
 Example: ``microphone.was_event(SoundEvent.LOUD)``
 
 This call clears the sound history before returning.
 
-:param event: (event) L'événement à vérifier, tel que ``SoundEvent.LOUD`` ou ``SoundEvent.QUIET``
+:param event: L'événement à vérifier, tel que ``SoundEvent.LOUD`` ou ``SoundEvent.QUIET``
 :return: ``True`` if sound was heard at least once since the last call, otherwise ``False``."""
     ...
 
 def is_event(event: SoundEvent) -> bool:
-    """Vérifier l'événement sonore le plus récent détecté. (is event)
+    """Vérifier l'événement sonore le plus récent détecté.
 
 Example: ``microphone.is_event(SoundEvent.LOUD)``
 
 This call does not clear the sound event history.
 
-:param event: (event) L'événement à vérifier, tel que ``SoundEvent.LOUD`` ou ``SoundEvent.QUIET``
+:param event: L'événement à vérifier, tel que ``SoundEvent.LOUD`` ou ``SoundEvent.QUIET``
 :return: ``True`` if sound was the most recent heard, ``False`` otherwise."""
     ...
 
 def get_events() -> Tuple[SoundEvent, ...]:
-    """Récupérer l'historique des événements sonores en tant que tuple. (get events)
+    """Récupérer l'historique des événements sonores en tant que tuple.
 
 Example: ``microphone.get_events()``
 
@@ -43,18 +43,18 @@ This call clears the sound history before returning.
     ...
 
 def set_threshold(event: SoundEvent, value: int) -> None:
-    """Définir le seuil pour un événement sonore. (set threshold)
+    """Définir le seuil pour un événement sonore.
 
 Example: ``microphone.set_threshold(SoundEvent.LOUD, 250)``
 
 A high threshold means the event will only trigger if the sound is very loud (>= 250 in the example).
 
-:param event: (event) Un événement sonore, tel que ``SoundEvent.LOUD`` ou ``SoundEvent.QUIET``.
-:param value: (value) Le niveau du seuil dans la plage 0-255."""
+:param event: Un événement sonore, tel que ``SoundEvent.LOUD`` ou ``SoundEvent.QUIET``.
+:param value: Le niveau du seuil dans la plage 0-255."""
     ...
 
 def sound_level() -> int:
-    """Obtenir le niveau de pression acoustique. (sound level)
+    """Obtenir le niveau de pression acoustique.
 
 Example: ``microphone.sound_level()``
 

--- a/lang/fr/typeshed/stdlib/microbit/speaker.pyi
+++ b/lang/fr/typeshed/stdlib/microbit/speaker.pyi
@@ -1,7 +1,7 @@
-"""Contrôler le haut-parleur intégré (V2 uniquement). (speaker)"""
+"""Contrôler le haut-parleur intégré (V2 uniquement)."""
 
 def off() -> None:
-    """Éteindre le haut-parleur. (off)
+    """Éteindre le haut-parleur.
 
 Example: ``speaker.off()``
 
@@ -9,7 +9,7 @@ This does not disable sound output to an edge connector pin."""
     ...
 
 def on() -> None:
-    """Activer le haut-parleur. (on)
+    """Activer le haut-parleur.
 
 Example: ``speaker.on()``"""
     ...

--- a/lang/fr/typeshed/stdlib/microbit/spi.pyi
+++ b/lang/fr/typeshed/stdlib/microbit/spi.pyi
@@ -1,46 +1,46 @@
-"""Communiquer avec les périphériques à l'aide du bus SPI (Serial Peripheral Interface). (spi)"""
+"""Communiquer avec les périphériques à l'aide du bus SPI (Serial Peripheral Interface)."""
 from _typeshed import ReadableBuffer, WriteableBuffer
 from ..microbit import pin13, pin14, pin15, MicroBitDigitalPin
 
 def init(baudrate: int=1000000, bits: int=8, mode: int=0, sclk: MicroBitDigitalPin=pin13, mosi: MicroBitDigitalPin=pin15, miso: MicroBitDigitalPin=pin14) -> None:
-    """Initialiser la communication SPI. (init)
+    """Initialiser la communication SPI.
 
 Example: ``spi.init()``
 
 For correct communication, the parameters have to be the same on both communicating devices.
 
-:param baudrate: (baudrate) La vitesse de communication.
-:param bits: (bits) La largeur en bits de chaque transfert. Actuellement, seul ``bits=8`` est pris en charge. Cependant, cela peut évoluer à l'avenir.
-:param mode: (mode) Détermine la combinaison de la polarité et de la phase de l'horloge. - `voir le tableau en ligne <https://microbit-micropython.readthedocs.io/en/v2-docs/spi.html#microbit.spi.init>`_.
-:param sclk: (sclk) Broche sclk (13 par défaut)
-:param mosi: (mosi) Broche mosi (15 par défaut)
-:param miso: (miso) Broche miso (14 par défaut)"""
+:param baudrate: La vitesse de communication.
+:param bits: La largeur en bits de chaque transfert. Actuellement, seul ``bits=8`` est pris en charge. Cependant, cela peut évoluer à l'avenir.
+:param mode: Détermine la combinaison de la polarité et de la phase de l'horloge. - `voir le tableau en ligne <https://microbit-micropython.readthedocs.io/en/v2-docs/spi.html#microbit.spi.init>`_.
+:param sclk: Broche sclk (13 par défaut)
+:param mosi: Broche mosi (15 par défaut)
+:param miso: Broche miso (14 par défaut)"""
     ...
 
 def read(nbytes: int) -> bytes:
-    """Lire des octets. (read)
+    """Lire des octets.
 
 Example: ``spi.read(64)``
 
-:param nbytes: (nbytes) Nombre maximal d'octets à lire.
+:param nbytes: Nombre maximal d'octets à lire.
 :return: The bytes read."""
     ...
 
 def write(buffer: ReadableBuffer) -> None:
-    """Écrire des octets sur le bus. (write)
+    """Écrire des octets sur le bus.
 
 Example: ``spi.write(bytes([1, 2, 3]))``
 
-:param buffer: (buffer) Un buffer à partir duquel lire les données."""
+:param buffer: Un buffer à partir duquel lire les données."""
     ...
 
 def write_readinto(out: WriteableBuffer, in_: ReadableBuffer) -> None:
-    """Ecrire le buffer ``out`` sur le bus et lire toute réponse dans le buffer ``in_``. (write readinto)
+    """Ecrire le buffer ``out`` sur le bus et lire toute réponse dans le buffer ``in_``.
 
 Example: ``spi.write_readinto(out_buffer, in_buffer)``
 
 The length of the buffers should be the same. The buffers can be the same object.
 
-:param out: (out) Le buffer vers lequel écrire une réponse.
-:param in_: (in) Le buffer depuis lequel lire les données."""
+:param out: Le buffer vers lequel écrire une réponse.
+:param in_: Le buffer depuis lequel lire les données."""
     ...

--- a/lang/fr/typeshed/stdlib/microbit/uart.pyi
+++ b/lang/fr/typeshed/stdlib/microbit/uart.pyi
@@ -1,23 +1,23 @@
-"""Communiquer avec un périphérique à l'aide d'une interface série. (uart)"""
+"""Communiquer avec un périphérique à l'aide d'une interface série."""
 from _typeshed import WriteableBuffer
 from ..microbit import MicroBitDigitalPin
 from typing import Optional, Union
 ODD: int
-"""Parité impaire (odd)"""
+"""Parité impaire"""
 EVEN: int
-"""Parité paire (even)"""
+"""Parité paire"""
 
 def init(baudrate: int=9600, bits: int=8, parity: Optional[int]=None, stop: int=1, tx: Optional[MicroBitDigitalPin]=None, rx: Optional[MicroBitDigitalPin]=None) -> None:
-    """Initialiser la communication série. (init)
+    """Initialiser la communication série.
 
 Example: ``uart.init(115200, tx=pin0, rx=pin1)``
 
-:param baudrate: (baudrate) La vitesse de communication.
-:param bits: (bits) La taille des octets transmis. micro:bit ne prend en charge que 8.
-:param parity: (parity) Comment la parité est vérifiée, ``None``, ``uart.ODD`` ou ``uart.EVEN``.
-:param stop: (stop) Le nombre de bits d'arrêt, doit être 1 pour micro:bit.
-:param tx: (tx) Broche de transmission.
-:param rx: (rx) Broche de réception.
+:param baudrate: La vitesse de communication.
+:param bits: La taille des octets transmis. micro:bit ne prend en charge que 8.
+:param parity: Comment la parité est vérifiée, ``None``, ``uart.ODD`` ou ``uart.EVEN``.
+:param stop: Le nombre de bits d'arrêt, doit être 1 pour micro:bit.
+:param tx: Broche de transmission.
+:param rx: Broche de réception.
 
 Initializing the UART on external pins will cause the Python console on
 USB to become unaccessible, as it uses the same hardware. To bring the
@@ -29,7 +29,7 @@ For more details see `the online documentation <https://microbit-micropython.rea
     ...
 
 def any() -> bool:
-    """Check if any data is waiting. (any)
+    """Check if any data is waiting.
 
 Example: ``uart.any()``
 
@@ -37,26 +37,26 @@ Example: ``uart.any()``
     ...
 
 def read(nbytes: Optional[int]=None) -> Optional[bytes]:
-    """Lire des octets. (read)
+    """Lire des octets.
 
 Example: ``uart.read()``
 
-:param nbytes: (nbytes) Si ``nbytes`` est spécifié, alors lire au maximum cette quantité d'octets, sinon lire autant d'octets que possible
+:param nbytes: Si ``nbytes`` est spécifié, alors lire au maximum cette quantité d'octets, sinon lire autant d'octets que possible
 :return: A bytes object or ``None`` on timeout"""
     ...
 
 def readinto(buf: WriteableBuffer, nbytes: Optional[int]=None) -> Optional[int]:
-    """Lire les octets dans le ``buf``. (readinto)
+    """Lire les octets dans le ``buf``.
 
 Example: ``uart.readinto(input_buffer)``
 
-:param buf: (buf) Le buffer dans lequel écrire.
-:param nbytes: (nbytes) Si ``nbytes`` est spécifié, alors lire au maximum cette quantité d'octets, sinon lire ``len(buf)`` octets.
+:param buf: Le buffer dans lequel écrire.
+:param nbytes: Si ``nbytes`` est spécifié, alors lire au maximum cette quantité d'octets, sinon lire ``len(buf)`` octets.
 :return: number of bytes read and stored into ``buf`` or ``None`` on timeout."""
     ...
 
 def readline() -> Optional[bytes]:
-    """Lire une ligne terminée par un caractère de nouvelle ligne. (readline)
+    """Lire une ligne terminée par un caractère de nouvelle ligne.
 
 Example: ``uart.readline()``
 
@@ -64,11 +64,11 @@ Example: ``uart.readline()``
     ...
 
 def write(buf: Union[bytes, str]) -> Optional[int]:
-    """Écrire un buffer sur un bus (write)
+    """Écrire un buffer sur un bus
 
 Example: ``uart.write('hello world')``
 
-:param buf: (buf) Un objet d'octets ou une chaîne de caractères.
+:param buf: Un objet d'octets ou une chaîne de caractères.
 :return: The number of bytes written, or ``None`` on timeout.
 
 Examples::

--- a/lang/fr/typeshed/stdlib/micropython.pyi
+++ b/lang/fr/typeshed/stdlib/micropython.pyi
@@ -1,10 +1,10 @@
-"""Les coulisses de MicroPython. (micropython)"""
+"""Les coulisses de MicroPython."""
 from typing import Any, TypeVar, overload
 _T = TypeVar('_T')
 
 def const(expr: _T) -> _T:
     """Utilisé pour déclarer que l'expression est une constante afin que le compilateur puisse
-l'optimiser. (const)
+l'optimiser.
 
 The use of this function should be as follows::
 
@@ -17,12 +17,12 @@ outside the module they are declared in. On the other hand, if a constant
 begins with an underscore then it is hidden, it is not available as a
 global variable, and does not take up any memory during execution.
 
-:param expr: (expr) Une expression constante."""
+:param expr: Une expression constante."""
     ...
 
 @overload
 def opt_level() -> int:
-    """Récupère le niveau d'optimisation actuel pour la compilation des scripts. (opt level)
+    """Récupère le niveau d'optimisation actuel pour la compilation des scripts.
 
 Example: ``micropython.opt_level()``
 
@@ -44,7 +44,7 @@ The optimisation level controls the following compilation features:
 
 @overload
 def opt_level(level: int) -> None:
-    """Définir le niveau d'optimisation pour la compilation ultérieure des scripts. (opt level)
+    """Définir le niveau d'optimisation pour la compilation ultérieure des scripts.
 
 Example: ``micropython.opt_level(1)``
 
@@ -63,23 +63,23 @@ The optimisation level controls the following compilation features:
 
 The default optimisation level is usually level 0.
 
-:param level: (level) Un entier indiquant le niveau d'optimisation."""
+:param level: Un entier indiquant le niveau d'optimisation."""
     ...
 
 def mem_info(verbose: Any=None) -> None:
-    """Afficher des informations sur la mémoire actuellement utilisée. (mem info)
+    """Afficher des informations sur la mémoire actuellement utilisée.
 
 Example: ``micropython.mem_info()``
 
-:param verbose: (verbose) Si l'argument ``verbose`` est spécifié, des informations supplémentaires seront affichées."""
+:param verbose: Si l'argument ``verbose`` est spécifié, des informations supplémentaires seront affichées."""
     ...
 
 def qstr_info(verbose: Any=None) -> None:
-    """Affiche des informations sur les chaînes de caractères internalisées. (qstr info)
+    """Affiche des informations sur les chaînes de caractères internalisées.
 
 Example: ``micropython.qstr_info()``
 
-:param verbose: (verbose) Si l'argument ``verbose`` est spécifié, des informations supplémentaires seront affichées.
+:param verbose: Si l'argument ``verbose`` est spécifié, des informations supplémentaires seront affichées.
 
 The information that is printed is implementation dependent, but currently
 includes the number of interned strings and the amount of RAM they use.  In
@@ -87,7 +87,7 @@ verbose mode it prints out the names of all RAM-interned strings."""
     ...
 
 def stack_use() -> int:
-    """Renvoie un nombre entier représentant la taille de la pile en cours d'utilisation. (stack use)
+    """Renvoie un nombre entier représentant la taille de la pile en cours d'utilisation.
 
 Example: ``micropython.stack_use()``
 
@@ -98,7 +98,7 @@ should be used to compute differences in stack usage at different points.
     ...
 
 def heap_lock() -> None:
-    """Verrouille le tas (heap). (heap lock)
+    """Verrouille le tas (heap).
 
 Example: ``micropython.heap_lock()``
 
@@ -107,7 +107,7 @@ raised if any heap allocation is attempted."""
     ...
 
 def heap_unlock() -> None:
-    """Déverrouille le tas (heap). (heap unlock)
+    """Déverrouille le tas (heap).
 
 Example: ``micropython.heap_unlock()``
 
@@ -116,11 +116,11 @@ raised if any heap allocation is attempted."""
     ...
 
 def kbd_intr(chr: int) -> None:
-    """Définir le caractère qui lèvera une exception ``KeyboardInterrupt``. (kbd intr)
+    """Définir le caractère qui lèvera une exception ``KeyboardInterrupt``.
 
 Example: ``micropython.kbd_intr(-1)``
 
-:param chr: (chr) Code de caractère pour générer l'interruption ou -1 pour désactiver la capture de Ctrl-C.
+:param chr: Code de caractère pour générer l'interruption ou -1 pour désactiver la capture de Ctrl-C.
 
 By default this is set to 3 during script execution, corresponding to Ctrl-C.
 Passing -1 to this function will disable capture of Ctrl-C, and passing 3

--- a/lang/fr/typeshed/stdlib/music.pyi
+++ b/lang/fr/typeshed/stdlib/music.pyi
@@ -1,64 +1,64 @@
-"""Créer et jouer des mélodies. (music)"""
+"""Créer et jouer des mélodies."""
 from typing import Tuple, Union, List
 from .microbit import MicroBitDigitalPin, pin0
 DADADADUM: Tuple[str, ...]
-"""Mélodie : l'ouverture de la 5e symphonie en do mineur de Beethoven. (dadadadum)"""
+"""Mélodie : l'ouverture de la 5e symphonie en do mineur de Beethoven."""
 ENTERTAINER: Tuple[str, ...]
-"""Mélodie : le fragment d'ouverture du classique de ragtime "The Entertainer" de Scott Joplin. (entertainer)"""
+"""Mélodie : le fragment d'ouverture du classique de ragtime "The Entertainer" de Scott Joplin."""
 PRELUDE: Tuple[str, ...]
-"""Mélodie : le prélude et fugue en ut majeur (BWV 846) de Jean-Sébastien Bach. (prelude)"""
+"""Mélodie : le prélude et fugue en ut majeur (BWV 846) de Jean-Sébastien Bach."""
 ODE: Tuple[str, ...]
-"""Mélodie : le thème de l'"Ode à la joie" de la 9e symphonie en ré mineur de Beethoven. (ode)"""
+"""Mélodie : le thème de l'"Ode à la joie" de la 9e symphonie en ré mineur de Beethoven."""
 NYAN: Tuple[str, ...]
-"""Mélodie : le thème de Nyan Cat (http://www.nyan.cat/). (nyan)
+"""Mélodie : le thème de Nyan Cat (http://www.nyan.cat/).
 
 The composer is unknown. This is fair use for educational porpoises (as they say in New York)."""
 RINGTONE: Tuple[str, ...]
-"""Mélodie : son qui ressemble à une sonnerie de téléphone mobile. (ringtone)
+"""Mélodie : son qui ressemble à une sonnerie de téléphone mobile.
 
 To be used to indicate an incoming message.
 """
 FUNK: Tuple[str, ...]
-"""Mélodie : une ligne de basse funky pour les agents secrets et les cerveaux criminels. (funk)"""
+"""Mélodie : une ligne de basse funky pour les agents secrets et les cerveaux criminels."""
 BLUES: Tuple[str, ...]
-"""Mélodie : une walking bass blues de boogie-woogie à 12 mesures. (blues)"""
+"""Mélodie : une walking bass blues de boogie-woogie à 12 mesures."""
 BIRTHDAY: Tuple[str, ...]
-"""Mélodie : « Joyeux anniversaire…» (birthday)
+"""Mélodie : « Joyeux anniversaire…»
 
 For copyright status see: http://www.bbc.co.uk/news/world-us-canada-34332853
 """
 WEDDING: Tuple[str, ...]
-"""Mélodie : la marche nuptiale de l'opéra "Lohengrin" de Wagner. (wedding)"""
+"""Mélodie : la marche nuptiale de l'opéra "Lohengrin" de Wagner."""
 FUNERAL: Tuple[str, ...]
-"""Mélodie : la "marche funèbre " aussi connue sous le nom de Sonate pour piano n° 2 en B♭ mineur, opus 35 de Frédéric Chopin. (funeral)"""
+"""Mélodie : la "marche funèbre " aussi connue sous le nom de Sonate pour piano n° 2 en B♭ mineur, opus 35 de Frédéric Chopin."""
 PUNCHLINE: Tuple[str, ...]
-"""Mélodie : un extrait amusant qui signifie qu'une blague a été faite. (punchline)"""
+"""Mélodie : un extrait amusant qui signifie qu'une blague a été faite."""
 PYTHON: Tuple[str, ...]
-"""Mélodie : La marche "Liberty Bell" de John Philip Sousa, alias le thème du "Monty Python's Flying Circus" (qui a donné son nom au langage de programmation Python). (python)"""
+"""Mélodie : La marche "Liberty Bell" de John Philip Sousa, alias le thème du "Monty Python's Flying Circus" (qui a donné son nom au langage de programmation Python)."""
 BADDY: Tuple[str, ...]
-"""Mélodie\xa0: entrée d'un méchant à l'époque des films muets. (baddy)"""
+"""Mélodie\xa0: entrée d'un méchant à l'époque des films muets."""
 CHASE: Tuple[str, ...]
-"""Mélodie : scène de poursuite à l'époque du film muet. (chase)"""
+"""Mélodie : scène de poursuite à l'époque du film muet."""
 BA_DING: Tuple[str, ...]
-"""Mélodie : un signal court pour indiquer que quelque chose s'est produit. (ba ding)"""
+"""Mélodie : un signal court pour indiquer que quelque chose s'est produit."""
 WAWAWAWAA: Tuple[str, ...]
-"""Mélodie : un trombone très triste. (wawawawaa)"""
+"""Mélodie : un trombone très triste."""
 JUMP_UP: Tuple[str, ...]
-"""Mélodie\xa0: pour une utilisation dans un jeu, indiquant un mouvement vers le haut. (jump up)"""
+"""Mélodie\xa0: pour une utilisation dans un jeu, indiquant un mouvement vers le haut."""
 JUMP_DOWN: Tuple[str, ...]
-"""Mélodie\xa0: pour une utilisation dans un jeu, indiquant un mouvement vers le bas. (jump down)"""
+"""Mélodie\xa0: pour une utilisation dans un jeu, indiquant un mouvement vers le bas."""
 POWER_UP: Tuple[str, ...]
-"""Mélodie : une fanfare pour indiquer un succès débloqué. (power up)"""
+"""Mélodie : une fanfare pour indiquer un succès débloqué."""
 POWER_DOWN: Tuple[str, ...]
-"""Mélodie : une fanfare triste pour indiquer un succès manqué. (power down)"""
+"""Mélodie : une fanfare triste pour indiquer un succès manqué."""
 
 def set_tempo(ticks: int=4, bpm: int=120) -> None:
-    """Définir le tempo approximatif pour la lecture. (set tempo)
+    """Définir le tempo approximatif pour la lecture.
 
 Example: ``music.set_tempo(bpm=120)``
 
-:param ticks: (ticks) Le nombre de ticks constituant un battement.
-:param bpm: (bpm) Un entier déterminant le nombre de battements par minute.
+:param ticks: Le nombre de ticks constituant un battement.
+:param bpm: Un entier déterminant le nombre de battements par minute.
 
 Suggested default values allow the following useful behaviour:
 
@@ -72,7 +72,7 @@ To work out the length of a tick in milliseconds is very simple arithmetic:
     ...
 
 def get_tempo() -> Tuple[int, int]:
-    """Récupérer le tempo actuel sous la forme d'un tuple d'entiers : ``(ticks, bpm)``. (get tempo)
+    """Récupérer le tempo actuel sous la forme d'un tuple d'entiers : ``(ticks, bpm)``.
 
 Example: ``ticks, beats = music.get_tempo()``
 
@@ -80,14 +80,14 @@ Example: ``ticks, beats = music.get_tempo()``
     ...
 
 def play(music: Union[str, List[str], Tuple[str, ...]], pin: Union[MicroBitDigitalPin, None]=pin0, wait: bool=True, loop: bool=False) -> None:
-    """Jouer de la musique. (play)
+    """Jouer de la musique.
 
 Example: ``music.play(music.NYAN)``
 
-:param music: (music) musique spécifiée dans `une notation spéciale <https://microbit-micropython.readthedocs.io/en/v2-docs/music.html#musical-notation>`_
+:param music: musique spécifiée dans `une notation spéciale <https://microbit-micropython.readthedocs.io/en/v2-docs/music.html#musical-notation>`_
 :param pin: (broche) la broche de sortie à utiliser avec un haut-parleur externe (par défaut ``pin0``), ``None`` pour aucun son.
-:param wait: (wait) Si ``wait`` est défini à ``True``, cette fonction est bloquante.
-:param loop: (loop) Si ``loop`` est défini à ``True``, la mélodie se répète jusqu'à ce que ``stop`` soit appelé, ou que l'appel bloquant soit interrompu.
+:param wait: Si ``wait`` est défini à ``True``, cette fonction est bloquante.
+:param loop: Si ``loop`` est défini à ``True``, la mélodie se répète jusqu'à ce que ``stop`` soit appelé, ou que l'appel bloquant soit interrompu.
 
 Many built-in melodies are defined in this module."""
     ...
@@ -98,9 +98,9 @@ def pitch(frequency: int, duration: int=-1, pin: MicroBitDigitalPin=pin0, wait: 
 Example: ``music.pitch(185, 1000)``
 
 :param frequency: (fréquence) Une fréquence entière
-:param duration: (duration) Une durée en milliseconde. Si la valeur est négative alors le son sera continu jusqu'au prochain appel, ou jusqu'à un appel à ``stop``.
+:param duration: Une durée en milliseconde. Si la valeur est négative alors le son sera continu jusqu'au prochain appel, ou jusqu'à un appel à ``stop``.
 :param pin: (broche) Broche de sortie optionnelle (par défaut ``pin0``).
-:param wait: (wait) Si ``wait`` est défini à ``True``, cette fonction est bloquante.
+:param wait: Si ``wait`` est défini à ``True``, cette fonction est bloquante.
 
 For example, if the frequency is set to 440 and the length to
 1000 then we hear a standard concert A for one second.
@@ -109,14 +109,14 @@ You can only play one pitch on one pin at any one time."""
     ...
 
 def stop(pin: MicroBitDigitalPin=pin0) -> None:
-    """Met fin à toute lecture de musique sur le haut-parleur intégré et à tout son en sortie sur la broche. (stop)
+    """Met fin à toute lecture de musique sur le haut-parleur intégré et à tout son en sortie sur la broche.
 
 Example: ``music.stop()``
 
 :param pin: (broche) Un argument optionnel peut être spécifié pour indiquer une broche, par exemple ``music.stop(pin1)``."""
 
 def reset() -> None:
-    """Réinitialiser les ticks, bpm, durée et octave à leurs valeurs par défaut. (reset)
+    """Réinitialiser les ticks, bpm, durée et octave à leurs valeurs par défaut.
 
 Example: ``music.reset()``
 

--- a/lang/fr/typeshed/stdlib/neopixel.pyi
+++ b/lang/fr/typeshed/stdlib/neopixel.pyi
@@ -1,11 +1,11 @@
-"""Bandes LED RGB et RGBW individuellement adressables. (neopixel)"""
+"""Bandes LED RGB et RGBW individuellement adressables."""
 from .microbit import MicroBitDigitalPin
 from typing import Tuple
 
 class NeoPixel:
 
     def __init__(self, pin: MicroBitDigitalPin, n: int, bpp: int=3) -> None:
-        """Initialiser une nouvelle bande de LEDs neopixel contrôlée via une broche. (init)
+        """Initialiser une nouvelle bande de LEDs neopixel contrôlée via une broche.
 
 Example: ``np = neopixel.NeoPixel(pin0, 8)``
 
@@ -14,18 +14,18 @@ RGBW neopixels are only supported by micro:bit V2.
 See `the online docs <https://microbit-micropython.readthedocs.io/en/v2-docs/neopixel.html>`_ for warnings and other advice.
 
 :param pin: (broche) La broche qui contrôle la bande neopixel.
-:param n: (n) Le nombre de neopixels sur la bande.
-:param bpp: (bpp) Octets par pixel. Pour le support du neopixel RGBW microbit V2, passez 4 plutôt que la valeur par défaut de 3 pour RGB et GRB."""
+:param n: Le nombre de neopixels sur la bande.
+:param bpp: Octets par pixel. Pour le support du neopixel RGBW microbit V2, passez 4 plutôt que la valeur par défaut de 3 pour RGB et GRB."""
         ...
 
     def clear(self) -> None:
-        """Effacer tous les pixels. (clear)
+        """Effacer tous les pixels.
 
 Example: ``np.clear()``"""
         ...
 
     def show(self) -> None:
-        """Afficher les pixels. (show)
+        """Afficher les pixels.
 
 Example: ``np.show()``
 
@@ -33,7 +33,7 @@ Must be called for any updates to become visible."""
         ...
 
     def write(self) -> None:
-        """Afficher les pixels (micro:bit V2 uniquement). (write)
+        """Afficher les pixels (micro:bit V2 uniquement).
 
 Example: ``np.write()``
 
@@ -43,32 +43,32 @@ Equivalent to ``show``."""
         ...
 
     def fill(self, colour: Tuple[int, ...]) -> None:
-        """Colorer tous les pixels d'une valeur RGB/RGBW donnée. (fill)
+        """Colorer tous les pixels d'une valeur RGB/RGBW donnée.
 
 Example: ``np.fill((0, 0, 255))``
 
-:param colour: (colour) Un tuple de la même longueur que le nombre d'octets par pixel (bpp).
+:param colour: Un tuple de la même longueur que le nombre d'octets par pixel (bpp).
 
 Use in conjunction with ``show()`` to update the neopixels."""
         ...
 
     def __setitem__(self, key: int, value: Tuple[int, ...]) -> None:
-        """Définit une couleur de pixel. (setitem)
+        """Définit une couleur de pixel.
 
 Example: ``np[0] = (255, 0, 0)``
 
-:param key: (key) Le numéro du pixel
-:param value: (value) La couleur."""
+:param key: Le numéro du pixel
+:param value: La couleur."""
 
     def __getitem__(self, key: int) -> Tuple[int, ...]:
-        """Récupère la couleur d'un pixel (getitem)
+        """Récupère la couleur d'un pixel
 
 Example: ``r, g, b = np[0]``
 
-:param key: (key) Le numéro du pixel
+:param key: Le numéro du pixel
 :return: The colour tuple."""
 
     def __len__(self) -> int:
-        """Récupère la longueur de cette bande de pixels. (len)
+        """Récupère la longueur de cette bande de pixels.
 
 Example: ``len(np)``"""

--- a/lang/fr/typeshed/stdlib/os.pyi
+++ b/lang/fr/typeshed/stdlib/os.pyi
@@ -1,9 +1,9 @@
-"""Accéder au système de fichiers. (os)"""
+"""Accéder au système de fichiers."""
 from typing import Tuple
 from typing import List
 
 def listdir() -> List[str]:
-    """Lister les fichiers. (listdir)
+    """Lister les fichiers.
 
 Example: ``os.listdir()``
 
@@ -12,40 +12,40 @@ persistent on-device file system."""
     ...
 
 def remove(filename: str) -> None:
-    """Supprimer (effacer) un fichier. (remove)
+    """Supprimer (effacer) un fichier.
 
 Example: ``os.remove('data.txt')``
 
-:param filename: (filename) Le fichier à effacer.
+:param filename: Le fichier à effacer.
 
 If the file does not exist an ``OSError`` exception will occur."""
     ...
 
 def size(filename: str) -> int:
-    """Retourne la taille d'un fichier. (size)
+    """Retourne la taille d'un fichier.
 
 Example: ``os.size('data.txt')``
 
-:param filename: (filename) Le fichier
+:param filename: Le fichier
 :return: The size in bytes.
 
 If the file does not exist an ``OSError`` exception will occur."""
 
 class uname_result(Tuple[str, str, str, str, str]):
-    """Résultat de ``os.uname()`` (uname result)"""
+    """Résultat de ``os.uname()``"""
     sysname: str
-    """Nom du système d'exploitation. (sysname)"""
+    """Nom du système d'exploitation."""
     nodename: str
-    """Nom de la machine sur le réseau (selon implémentation). (nodename)"""
+    """Nom de la machine sur le réseau (selon implémentation)."""
     release: str
-    """La release du système d'exploitation (release)"""
+    """La release du système d'exploitation"""
     version: str
-    """Version du système d'exploitation (version)"""
+    """Version du système d'exploitation"""
     machine: str
-    """Identifiant matériel. (machine)"""
+    """Identifiant matériel."""
 
 def uname() -> uname_result:
-    """Retourne les informations identifiant le système d'exploitation actuel. (uname)
+    """Retourne les informations identifiant le système d'exploitation actuel.
 
 Example: ``os.uname()``
 

--- a/lang/fr/typeshed/stdlib/radio.pyi
+++ b/lang/fr/typeshed/stdlib/radio.pyi
@@ -1,13 +1,13 @@
-"""Communiquer entre micro:bits avec la radio intégrée. (radio)"""
+"""Communiquer entre micro:bits avec la radio intégrée."""
 from _typeshed import WriteableBuffer
 from typing import Optional, Tuple
 RATE_1MBIT: int
-"""Constante utilisée pour indiquer un débit de 1 MBit par seconde. (rate 1mbit)"""
+"""Constante utilisée pour indiquer un débit de 1 MBit par seconde."""
 RATE_2MBIT: int
-"""Constante utilisée pour indiquer un débit de 2 MBit par seconde. (rate 2mbit)"""
+"""Constante utilisée pour indiquer un débit de 2 MBit par seconde."""
 
 def on() -> None:
-    """Allume la radio. (on)
+    """Allume la radio.
 
 Example: ``radio.on()``
 
@@ -16,38 +16,38 @@ up memory that you may otherwise need."""
     ...
 
 def off() -> None:
-    """Désactive la radio, économisant ainsi de l'énergie et de la mémoire. (off)
+    """Désactive la radio, économisant ainsi de l'énergie et de la mémoire.
 
 Example: ``radio.off()``"""
     ...
 
 def config(length: int=32, queue: int=3, channel: int=7, power: int=6, address: int=1969383796, group: int=0, data_rate: int=RATE_1MBIT) -> None:
-    """Configure la radio. (config)
+    """Configure la radio.
 
 Example: ``radio.config(group=42)``
 
 The default configuration is suitable for most use.
 
-:param length: (length) (par défaut=32) définit la longueur maximale en octets d'un message envoyé via la radio.
+:param length: (par défaut=32) définit la longueur maximale en octets d'un message envoyé via la radio.
 Il peut faire jusqu'à 251 octets de long (254 - 3 octets pour S0, LENGTH et préambule S1).
-:param queue: (queue) (par défaut=3) spécifie le nombre de messages qui peuvent être stockés dans la file d'attente des messages entrants.
+:param queue: (par défaut=3) spécifie le nombre de messages qui peuvent être stockés dans la file d'attente des messages entrants.
 S'il n'y a plus de place dans la file d'attente des messages entrants, alors le message entrant est abandonné.
-:param channel: (channel) (par défaut=7) une valeur entière comprise entre 0 et 83 (y compris) qui définit un « canal » arbitraire sur lequel la radio est réglée.
+:param channel: (par défaut=7) une valeur entière comprise entre 0 et 83 (y compris) qui définit un « canal » arbitraire sur lequel la radio est réglée.
 Les messages seront envoyés via ce canal et seuls les messages reçus via ce canal seront placés dans la file d'attente des messages entrants. Chaque incrément est de 1 MHz de largeur, basé à 2400 MHz.
-:param power: (power) (par défaut=6) est une valeur entière comprise entre 0 et 7 (y compris) pour indiquer la force du signal utilisé lors de la diffusion d'un message.
+:param power: (par défaut=6) est une valeur entière comprise entre 0 et 7 (y compris) pour indiquer la force du signal utilisé lors de la diffusion d'un message.
 Plus la valeur est élevée, plus le signal est fort, mais plus les besoins en alimentation sont élevés. La numérotation se traduit par des positions dans la liste suivante de valeurs en dBm (décibel milliwatt) : -30, -20, -16, -12, -8, -4, 0, 4.
-:param address: (address) (par défaut=0x75626974) un nom arbitraire, exprimé sous la forme d'une adresse 32-bit, utilisé pour filtrer au niveau matériel les paquet entrants, seuls les paquets correspondant à l'adresse définie seront conservés.
+:param address: (par défaut=0x75626974) un nom arbitraire, exprimé sous la forme d'une adresse 32-bit, utilisé pour filtrer au niveau matériel les paquet entrants, seuls les paquets correspondant à l'adresse définie seront conservés.
 La valeur par défaut utilisée par d'autres plateformes liées au micro:bit est celle indiquée ici.
-:param group: (group) (par défaut=0) une valeur de 8 bits (0-255) utilisée avec ``address`` lors du filtrage des messages.
+:param group: (par défaut=0) une valeur de 8 bits (0-255) utilisée avec ``address`` lors du filtrage des messages.
 Conceptuellement, "adress" est comme l'adresse d'une maison ou d'un bureau, et "group" est comme la personne à laquelle vous voulez envoyer votre message.
-:param data_rate: (data rate) (par défaut=``radio.RATE_1MBIT``) indique la vitesse à laquelle le débit de données a lieu.
+:param data_rate: (par défaut=``radio.RATE_1MBIT``) indique la vitesse à laquelle le débit de données a lieu.
 Peut être une des constantes suivantes définies dans le module ``radio``\xa0: ``RATE_250KBIT``, ``RATE_1MBIT`` ou ``RATE_2MBIT``.
 
 If ``config`` is not called then the defaults described above are assumed."""
     ...
 
 def reset() -> None:
-    """Réinitialiser les paramètres à leurs valeurs par défaut. (reset)
+    """Réinitialiser les paramètres à leurs valeurs par défaut.
 
 Example: ``radio.reset()``
 
@@ -55,15 +55,15 @@ The defaults as as per the ``config`` function above."""
     ...
 
 def send_bytes(message: bytes) -> None:
-    """Envoie un message contenant des octets. (send bytes)
+    """Envoie un message contenant des octets.
 
 Example: ``radio.send_bytes(b'hello')``
 
-:param message: (message) Les octets à envoyer."""
+:param message: Les octets à envoyer."""
     ...
 
 def receive_bytes() -> Optional[bytes]:
-    """Recevoir le message entrant suivant dans la file d'attente des messages. (receive bytes)
+    """Recevoir le message entrant suivant dans la file d'attente des messages.
 
 Example: ``radio.receive_bytes()``
 
@@ -71,27 +71,27 @@ Example: ``radio.receive_bytes()``
     ...
 
 def receive_bytes_into(buffer: WriteableBuffer) -> Optional[int]:
-    """Copier le message entrant suivant de la file d'attente des messages vers un buffer. (receive bytes into)
+    """Copier le message entrant suivant de la file d'attente des messages vers un buffer.
 
 Example: ``radio.receive_bytes_info(buffer)``
 
-:param buffer: (buffer) Le buffer cible. Le message est tronqué s'il est plus grand que le buffer.
+:param buffer: Le buffer cible. Le message est tronqué s'il est plus grand que le buffer.
 :return: ``None`` if there are no pending messages, otherwise it returns the length of the message (which might be more than the length of the buffer)."""
     ...
 
 def send(message: str) -> None:
-    """Envoie un message avec une chaîne de caractères. (send)
+    """Envoie un message avec une chaîne de caractères.
 
 Example: ``radio.send('hello')``
 
 This is the equivalent of ``radio.send_bytes(bytes(message, 'utf8'))`` but with ``b'\x01\x00\x01'``
 prepended to the front (to make it compatible with other platforms that target the micro:bit).
 
-:param message: (message) Le texte à envoyer."""
+:param message: Le texte à envoyer."""
     ...
 
 def receive() -> Optional[str]:
-    """Fonctionne exactement de la même manière que ``receive_bytes`` mais retourne ce qui a été envoyé. (receive)
+    """Fonctionne exactement de la même manière que ``receive_bytes`` mais retourne ce qui a été envoyé.
 
 Example: ``radio.receive()``
 
@@ -105,7 +105,7 @@ A ``ValueError`` exception is raised if conversion to string fails."""
     ...
 
 def receive_full() -> Optional[Tuple[bytes, int, int]]:
-    """Retourne un tuple contenant trois valeurs qui représentent le prochain message entrant dans la file d'attente. (receive full)
+    """Retourne un tuple contenant trois valeurs qui représentent le prochain message entrant dans la file d'attente.
 
 Example: ``radio.receive_full()``
 

--- a/lang/fr/typeshed/stdlib/random.pyi
+++ b/lang/fr/typeshed/stdlib/random.pyi
@@ -1,69 +1,69 @@
-"""Générer des nombres aléatoires. (random)"""
+"""Générer des nombres aléatoires."""
 from typing import TypeVar, Sequence, Union, overload
 
 def getrandbits(n: int) -> int:
-    """Générer un entier avec ``n`` bits aléatoires. (getrandbits)
+    """Générer un entier avec ``n`` bits aléatoires.
 
 Example: ``random.getrandbits(1)``
 
-:param n: (n) Une valeur comprise entre 1-30 (inclus)."""
+:param n: Une valeur comprise entre 1-30 (inclus)."""
     ...
 
 def seed(n: int) -> None:
-    """Initialiser le générateur de nombres aléatoires. (seed)
+    """Initialiser le générateur de nombres aléatoires.
 
 Example: ``random.seed(0)``
 
-:param n: (n) La graine aléatoire
+:param n: La graine aléatoire
 
 This will give you reproducibly deterministic randomness from a given starting
 state (``n``)."""
     ...
 
 def randint(a: int, b: int) -> int:
-    """Choisir un entier aléatoire entre ``a`` et ``b`` inclus. (randint)
+    """Choisir un entier aléatoire entre ``a`` et ``b`` inclus.
 
 Example: ``random.randint(0, 9)``
 
-:param a: (a) Valeur de départ pour l'intervalle (inclus)
-:param b: (b) Valeur de fin pour l'intervalle (inclus)
+:param a: Valeur de départ pour l'intervalle (inclus)
+:param b: Valeur de fin pour l'intervalle (inclus)
 
 Alias for ``randrange(a, b + 1)``."""
     ...
 
 @overload
 def randrange(stop: int) -> int:
-    """Choisir un entier aléatoirement entre zéro et ``stop`` (mais sans inclure ce dernier). (randrange)
+    """Choisir un entier aléatoirement entre zéro et ``stop`` (mais sans inclure ce dernier).
 
 Example: ``random.randrange(10)``
 
-:param stop: (stop) Valeur de fin pour l'intervalle (exclusif)"""
+:param stop: Valeur de fin pour l'intervalle (exclusif)"""
     ...
 
 @overload
 def randrange(start: int, stop: int, step: int=1) -> int:
-    """Choisir un élément sélectionné aléatoirement dans ``range(start, stop, step)``. (randrange)
+    """Choisir un élément sélectionné aléatoirement dans ``range(start, stop, step)``.
 
 Example: ``random.randrange(0, 10)``
 
-:param start: (start) Le début de la plage (inclus)
-:param stop: (stop) La fin de l'intervalle (exclusif)
-:param step: (step) L'incrément."""
+:param start: Le début de la plage (inclus)
+:param stop: La fin de l'intervalle (exclusif)
+:param step: L'incrément."""
     ...
 _T = TypeVar('_T')
 
 def choice(seq: Sequence[_T]) -> _T:
-    """Choisir un élément aléatoire dans la séquence non vide ``seq``. (choice)
+    """Choisir un élément aléatoire dans la séquence non vide ``seq``.
 
 Example: ``random.choice([Image.HAPPY, Image.SAD])``
 
-:param seq: (seq) Une séquence.
+:param seq: Une séquence.
 
 If ``seq`` is  empty, raises ``IndexError``."""
     ...
 
 def random() -> float:
-    """Générer un nombre aléatoire à virgule flottante [0.0, 1.0). (random)
+    """Générer un nombre aléatoire à virgule flottante [0.0, 1.0).
 
 Example: ``random.random()``
 
@@ -71,10 +71,10 @@ Example: ``random.random()``
     ...
 
 def uniform(a: float, b: float) -> float:
-    """Renvoie un nombre aléatoire à virgule flottante entre ``a`` et ``b`` inclus. (uniform)
+    """Renvoie un nombre aléatoire à virgule flottante entre ``a`` et ``b`` inclus.
 
 Example: ``random.uniform(0, 9)``
 
-:param a: (a) Valeur de départ pour l'intervalle (inclus)
-:param b: (b) Valeur de fin pour l'intervalle (inclus)"""
+:param a: Valeur de départ pour l'intervalle (inclus)
+:param b: Valeur de fin pour l'intervalle (inclus)"""
     ...

--- a/lang/fr/typeshed/stdlib/speech.pyi
+++ b/lang/fr/typeshed/stdlib/speech.pyi
@@ -1,13 +1,13 @@
-"""Faites parler ou chanter le micro:bit, ainsi que d'autres sons liés à la parole. (speech)"""
+"""Faites parler ou chanter le micro:bit, ainsi que d'autres sons liés à la parole."""
 from typing import Optional
 from .microbit import MicroBitDigitalPin, pin0
 
 def translate(words: str) -> str:
-    """Traduire les mots anglais en phonèmes. (translate)
+    """Traduire les mots anglais en phonèmes.
 
 Example: ``speech.translate('hello world')``
 
-:param words: (words) Une chaîne de caractères de mots anglais.
+:param words: Une chaîne de caractères de mots anglais.
 :return: A string containing a best guess at the appropriate phonemes to pronounce.
 The output is generated from this `text to phoneme translation table <https://github.com/s-macke/SAM/wiki/Text-to-phoneme-translation-table>`_.
 
@@ -19,15 +19,15 @@ See `the online documentation <https://microbit-micropython.readthedocs.io/en/v2
     ...
 
 def pronounce(phonemes: str, pitch: int=64, speed: int=72, mouth: int=128, throat: int=128, pin: Optional[MicroBitDigitalPin]=pin0) -> None:
-    """Prononcer les phonèmes. (pronounce)
+    """Prononcer les phonèmes.
 
 Example: ``speech.pronounce(' /HEHLOW WERLD')``
 
-:param phonemes: (phonemes) La chaîne de phonèmes à prononcer
+:param phonemes: La chaîne de phonèmes à prononcer
 :param pitch: (tangage) Un nombre représentant le ton de la voix
-:param speed: (speed) Un nombre représentant la vitesse de la voix
-:param mouth: (mouth) Un nombre représentant la bouche de la voix
-:param throat: (throat) Un nombre représentant la gorge de la voix
+:param speed: Un nombre représentant la vitesse de la voix
+:param mouth: Un nombre représentant la bouche de la voix
+:param throat: Un nombre représentant la gorge de la voix
 :param pin: (broche) Argument optionnel pour spécifier la broche de sortie. Peut être utilisé pour remplacer la valeur par défaut de ``pin0``.
 Pour empêcher l'émission d'un son via les broches, il est possible d'utiliser ``pin=None``. micro:bit V2 seulement.
 
@@ -38,15 +38,15 @@ See `the online documentation <https://microbit-micropython.readthedocs.io/en/v2
     ...
 
 def say(words: str, pitch: int=64, speed: int=72, mouth: int=128, throat: int=128, pin: MicroBitDigitalPin=pin0) -> None:
-    """Dire des mots anglais. (say)
+    """Dire des mots anglais.
 
 Example: ``speech.say('hello world')``
 
-:param words: (words) La chaîne de mots à dire.
+:param words: La chaîne de mots à dire.
 :param pitch: (tangage) Un nombre représentant le ton de la voix
-:param speed: (speed) Un nombre représentant la vitesse de la voix
-:param mouth: (mouth) Un nombre représentant la bouche de la voix
-:param throat: (throat) Un nombre représentant la gorge de la voix
+:param speed: Un nombre représentant la vitesse de la voix
+:param mouth: Un nombre représentant la bouche de la voix
+:param throat: Un nombre représentant la gorge de la voix
 :param pin: (broche) Argument optionnel pour spécifier la broche de sortie. Peut être utilisé pour remplacer la valeur par défaut de ``pin0``.
 Pour empêcher l'émission d'un son via les broches, il est possible d'utiliser ``pin=None``. micro:bit V2 seulement.
 
@@ -60,15 +60,15 @@ See `the online documentation <https://microbit-micropython.readthedocs.io/en/v2
     ...
 
 def sing(phonemes: str, pitch: int=64, speed: int=72, mouth: int=128, throat: int=128, pin: MicroBitDigitalPin=pin0) -> None:
-    """Chanter des phonèmes. (sing)
+    """Chanter des phonèmes.
 
 Example: ``speech.sing(' /HEHLOW WERLD')``
 
-:param phonemes: (phonemes) La chaîne de mots à chanter.
+:param phonemes: La chaîne de mots à chanter.
 :param pitch: (tangage) Un nombre représentant le ton de la voix
-:param speed: (speed) Un nombre représentant la vitesse de la voix
-:param mouth: (mouth) Un nombre représentant la bouche de la voix
-:param throat: (throat) Un nombre représentant la gorge de la voix
+:param speed: Un nombre représentant la vitesse de la voix
+:param mouth: Un nombre représentant la bouche de la voix
+:param throat: Un nombre représentant la gorge de la voix
 :param pin: (broche) Argument optionnel pour spécifier la broche de sortie. Peut être utilisé pour remplacer la valeur par défaut de ``pin0``.
 Pour empêcher l'émission d'un son via les broches, il est possible d'utiliser ``pin=None``. micro:bit V2 seulement.
 

--- a/lang/fr/typeshed/stdlib/struct.pyi
+++ b/lang/fr/typeshed/stdlib/struct.pyi
@@ -1,24 +1,24 @@
-"""Rassembler et désassembler des types de données primitives. (struct)"""
+"""Rassembler et désassembler des types de données primitives."""
 from _typeshed import ReadableBuffer, WriteableBuffer
 from typing import Any, Tuple, Union
 
 def calcsize(fmt: str) -> int:
-    """Récupère le nombre d'octets nécessaires pour stocker le ``fmt`` donné. (calcsize)
+    """Récupère le nombre d'octets nécessaires pour stocker le ``fmt`` donné.
 
 Example: ``struct.calcsize('hf')``
 
-:param fmt: (fmt) Une chaîne de mise en forme.
+:param fmt: Une chaîne de mise en forme.
 :return The number of bytes needed to store such a value."""
     ...
 
 def pack(fmt: str, v1: Any, *vn: Any) -> bytes:
-    """Rassembler les valeurs selon une chaîne de mise en forme. (pack)
+    """Rassembler les valeurs selon une chaîne de mise en forme.
 
 Example: ``struct.pack('hf', 1, 3.1415)``
 
-:param fmt: (fmt) La chaîne de mise en forme.
-:param v1: (v1) La première valeur.
-:param *vn: (*vn) Les valeurs restantes.
+:param fmt: La chaîne de mise en forme.
+:param v1: La première valeur.
+:param *vn: Les valeurs restantes.
 :return A bytes object encoding the values."""
     ...
 
@@ -27,30 +27,30 @@ def pack_into(fmt: str, buffer: WriteableBuffer, offset: int, v1: Any, *vn: Any)
 
 Example: ``struct.pack_info('hf', buffer, 1, 3.1415)``
 
-:param fmt: (fmt) La chaîne de format.
-:param buffer: (buffer) Le tampon cible dans lequel écrire.
-:param offset: (offset) Le décalage dans le tampon. Peut être négatif pour compter à partir de la fin du tampon.
-:param v1: (v1) La première valeur.
-:param *vn: (*vn) Les valeurs restantes."""
+:param fmt: La chaîne de format.
+:param buffer: Le tampon cible dans lequel écrire.
+:param offset: Le décalage dans le tampon. Peut être négatif pour compter à partir de la fin du tampon.
+:param v1: La première valeur.
+:param *vn: Les valeurs restantes."""
     ...
 
 def unpack(fmt: str, data: ReadableBuffer) -> Tuple[Any, ...]:
-    """Décompacter les données selon une chaîne de format. (unpack)
+    """Décompacter les données selon une chaîne de format.
 
 Example: ``v1, v2 = struct.unpack('hf', buffer)``
 
-:param fmt: (fmt) La chaîne de format.
-:param data: (data) Les données.
+:param fmt: La chaîne de format.
+:param data: Les données.
 :return: A tuple of the unpacked values."""
     ...
 
 def unpack_from(fmt: str, buffer: ReadableBuffer, offset: int=0) -> Tuple:
-    """Décompacter les données d'un tampon selon une chaîne de format. (unpack from)
+    """Décompacter les données d'un tampon selon une chaîne de format.
 
 Example: ``v1, v2 = struct.unpack_from('hf', buffer)``
 
-:param fmt: (fmt) La chaîne de format.
-:param buffer: (buffer) Le tampon source à partir duquel lire.
-:param offset: (offset) Le décalage dans le tampon. Peut être négatif pour compter à partir de la fin du tampon.
+:param fmt: La chaîne de format.
+:param buffer: Le tampon source à partir duquel lire.
+:param offset: Le décalage dans le tampon. Peut être négatif pour compter à partir de la fin du tampon.
 :return: A tuple of the unpacked values."""
     ...

--- a/lang/fr/typeshed/stdlib/sys.pyi
+++ b/lang/fr/typeshed/stdlib/sys.pyi
@@ -1,36 +1,36 @@
-"""Fonctions spécifiques au système (sys)"""
+"""Fonctions spécifiques au système"""
 from typing import Any, Dict, List, NoReturn, TextIO, Tuple
 
 def exit(retval: object=...) -> NoReturn:
-    """Terminer le programme en cours avec un code de sortie donné. (exit)
+    """Terminer le programme en cours avec un code de sortie donné.
 
 Example: ``sys.exit(1)``
 
 This function raises a ``SystemExit`` exception. If an argument is given, its
 value given as an argument to ``SystemExit``.
 
-:param retval: (retval) Le code de sortie ou le message."""
+:param retval: Le code de sortie ou le message."""
     ...
 
 def print_exception(exc: Exception) -> None:
-    """Imprime une exception avec une pile d'appels. (print exception)
+    """Imprime une exception avec une pile d'appels.
 
 Example: ``sys.print_exception(e)``
 
-:param exc: (exc) L'exception à imprimer
+:param exc: L'exception à imprimer
 
 This is simplified version of a function which appears in the
 ``traceback`` module in CPython."""
 argv: List[str]
-"""Une liste mutable d'arguments avec lesquels le programme courant a été démarré. (argv)"""
+"""Une liste mutable d'arguments avec lesquels le programme courant a été démarré."""
 byteorder: str
-"""L'ordre des octets du système (``"little"`` ou ``"big"``). (byteorder)"""
+"""L'ordre des octets du système (``"little"`` ou ``"big"``)."""
 
 class _implementation:
     name: str
     version: Tuple[int, int, int]
 implementation: _implementation
-"""Objet avec des informations sur l'implémentation actuelle de Python. (implementation)
+"""Objet avec des informations sur l'implémentation actuelle de Python.
 
 For MicroPython, it has following attributes:
 
@@ -49,7 +49,7 @@ maxsize: int
 Valeur maximale qu'un entier natif peut stocker sur la plate-forme courante,
 ou valeur maximale représentable par le type entier de MicroPython, si elle est plus petite
 que la valeur maximale de la plate-forme (c'est le cas pour les portages MicroPython sans support
-des entiers long). (maxsize)
+des entiers long).
 
 This attribute is useful for detecting "bitness" of a platform (32-bit vs
 64-bit, etc.). It's recommended to not compare this attribute to some
@@ -70,13 +70,13 @@ value directly, but instead count number of bits in it::
         # "> 32", "> 64" style of comparisons.
 """
 modules: Dict[str, Any]
-"""Dictionnaire des modules chargés.  (modules)
+"""Dictionnaire des modules chargés. 
 
 On some ports, it may not include builtin modules."""
 path: List[str]
-"""Une liste mutable de répertoires dans lesquels rechercher des modules importés. (path)"""
+"""Une liste mutable de répertoires dans lesquels rechercher des modules importés."""
 platform: str
-"""La plate-forme sur laquelle MicroPython s'exécute.  (platform)
+"""La plate-forme sur laquelle MicroPython s'exécute. 
 
 For OS/RTOS ports, this is usually an identifier of the OS, e.g. ``"linux"``.
 For baremetal ports it is an identifier of a board, e.g. ``"pyboard"`` for 
@@ -87,9 +87,9 @@ If you need to check whether your program runs on MicroPython (vs other
 Python implementation), use ``sys.implementation`` instead.
 """
 version: str
-"""Version du langage Python à laquelle cette implémentation correspond, sous la forme d'une chaîne de caractères . (version)"""
+"""Version du langage Python à laquelle cette implémentation correspond, sous la forme d'une chaîne de caractères ."""
 version_info: Tuple[int, int, int]
-"""Version du langage Python à laquelle cette implémentation correspond, sous forme d'un tuple d'entiers. (version info)
+"""Version du langage Python à laquelle cette implémentation correspond, sous forme d'un tuple d'entiers.
 
 Only the first three version numbers (major, minor, micro) are supported and
 they can be referenced only by index, not by name.

--- a/lang/fr/typeshed/stdlib/time.pyi
+++ b/lang/fr/typeshed/stdlib/time.pyi
@@ -1,34 +1,34 @@
-"""Mesurer le temps et ajouter des retards aux programmes. (time)"""
+"""Mesurer le temps et ajouter des retards aux programmes."""
 from typing import Union
 
 def sleep(seconds: Union[int, float]) -> None:
-    """Temporiser d'un certain nombre de secondes. (sleep)
+    """Temporiser d'un certain nombre de secondes.
 
 Example: ``time.sleep(1)``
 
-:param seconds: (seconds) Le nombre de secondes pendant lesquelles dormir.
+:param seconds: Le nombre de secondes pendant lesquelles dormir.
 Utiliser un nombre à virgule flottante pour dormir pendant un nombre fractionnaire de secondes."""
     ...
 
 def sleep_ms(ms: int) -> None:
-    """Temporiser pour un nombre donné de millisecondes. (sleep ms)
+    """Temporiser pour un nombre donné de millisecondes.
 
 Example: ``time.sleep_ms(1_000_000)``
 
-:param ms: (ms) Le nombre de millisecondes à attendre (>= 0)."""
+:param ms: Le nombre de millisecondes à attendre (>= 0)."""
     ...
 
 def sleep_us(us: int) -> None:
-    """Temporiser pour un nombre donné de microsecondes. (sleep us)
+    """Temporiser pour un nombre donné de microsecondes.
 
 Example: ``time.sleep_us(1000)``
 
-:param us: (us) Le nombre de microsecondes à attendre (>= 0)."""
+:param us: Le nombre de microsecondes à attendre (>= 0)."""
     ...
 
 def ticks_ms() -> int:
     """Obtenir un compteur croissant en millisecondes avec un point de référence arbitraire.
-Le compteur revient à zéro après une certaine valeur. (ticks ms)
+Le compteur revient à zéro après une certaine valeur.
 
 Example: ``time.ticks_ms()``
 
@@ -37,7 +37,7 @@ Example: ``time.ticks_ms()``
 
 def ticks_us() -> int:
     """Obtenir un compteur croissant en microsecondes avec un point de référence arbitraire.
-Le compteur revient à zéro après une certaine valeur. (ticks us)
+Le compteur revient à zéro après une certaine valeur.
 
 Example: ``time.ticks_us()``
 
@@ -45,7 +45,7 @@ Example: ``time.ticks_us()``
     ...
 
 def ticks_add(ticks: int, delta: int) -> int:
-    """Décaler les ticks par un nombre donné, positif ou négatif. (ticks add)
+    """Décaler les ticks par un nombre donné, positif ou négatif.
 
 Example: ``time.ticks_add(time.ticks_ms(), 200)``
 
@@ -53,8 +53,8 @@ Given a ticks value, this function allows to calculate ticks
 value delta ticks before or after it, following modular-arithmetic
 definition of tick values.
 
-:param ticks: (ticks) Une valeur de ticks
-:param delta: (delta) Un entier représentant le décalage
+:param ticks: Une valeur de ticks
+:param delta: Un entier représentant le décalage
 
 Example::
 
@@ -73,12 +73,12 @@ Example::
 def ticks_diff(ticks1: int, ticks2: int) -> int:
     """Mesurer la différence des ticks entre les valeurs retournées par
 ``time.ticks_ms()`` ou ``ticks_us()``, sous la forme d'une valeur signée
-qui peut passer plusieurs fois par zéro. (ticks diff)
+qui peut passer plusieurs fois par zéro.
 
 Example: ``time.ticks_diff(scheduled_time, now)``
 
-:param ticks1: (ticks1) La valeur à partir de laquelle soustraire
-:param ticks2: (ticks2) La valeur à soustraire
+:param ticks1: La valeur à partir de laquelle soustraire
+:param ticks2: La valeur à soustraire
 
 The argument order is the same as for subtraction operator,
 ``ticks_diff(ticks1, ticks2)`` has the same meaning as ``ticks1 - ticks2``.

--- a/lang/ja/typeshed/stdlib/gc.pyi
+++ b/lang/ja/typeshed/stdlib/gc.pyi
@@ -1,22 +1,22 @@
-"""ガベージコレクターを制御します。 (gc)"""
+"""ガベージコレクターを制御します。"""
 from typing import overload
 
 def enable() -> None:
-    """自動ガベージコレクションを有効にします。 (enable)"""
+    """自動ガベージコレクションを有効にします。"""
     ...
 
 def disable() -> None:
-    """自動ガベージコレクションを無効にします。 (disable)
+    """自動ガベージコレクションを無効にします。
 
 Heap memory can still be allocated,
 and garbage collection can still be initiated manually using ``gc.collect``."""
 
 def collect() -> None:
-    """ガベージコレクションを実行します。 (collect)"""
+    """ガベージコレクションを実行します。"""
     ...
 
 def mem_alloc() -> int:
-    """割り当てられているヒープRAMのバイト数を取得します。 (mem alloc)
+    """割り当てられているヒープRAMのバイト数を取得します。
 
 :return: The number of bytes allocated.
 
@@ -24,7 +24,7 @@ This function is MicroPython extension."""
     ...
 
 def mem_free() -> int:
-    """使用可能なヒープRAMのバイト数を取得します。この量が不明の場合は -1が返されます。 (mem free)
+    """使用可能なヒープRAMのバイト数を取得します。この量が不明の場合は -1が返されます。
 
 :return: The number of bytes free.
 
@@ -33,7 +33,7 @@ This function is MicroPython extension."""
 
 @overload
 def threshold() -> int:
-    """追加のGC 割り当てしきい値を照会します。 (threshold)
+    """追加のGC 割り当てしきい値を照会します。
 
 :return: The GC allocation threshold.
 
@@ -44,7 +44,7 @@ implementations, its signature and semantics are different."""
 
 @overload
 def threshold(amount: int) -> None:
-    """追加の GC 割り当てしきい値を設定します。 (threshold)
+    """追加の GC 割り当てしきい値を設定します。
 
 Normally, a collection is triggered only when a new allocation
 cannot be satisfied, i.e. on an  out-of-memory (OOM) condition.
@@ -64,5 +64,5 @@ This function is a MicroPython extension. CPython has a similar
 function - ``set_threshold()``, but due to different GC
 implementations, its signature and semantics are different.
 
-:param amount: (amount) ガベージコレクションを起こすバイト数。"""
+:param amount: ガベージコレクションを起こすバイト数。"""
     ...

--- a/lang/ja/typeshed/stdlib/log.pyi
+++ b/lang/ja/typeshed/stdlib/log.pyi
@@ -1,18 +1,18 @@
-"""micro:bit V2のログにデータを記録します。 (log)"""
+"""micro:bit V2のログにデータを記録します。"""
 from typing import Literal, Optional, Union, overload
 MILLISECONDS = 1
-"""ミリ秒単位の日時フォーマット。 (milliseconds)"""
+"""ミリ秒単位の日時フォーマット。"""
 SECONDS = 10
-"""秒単位の日時フォーマット。 (seconds)"""
+"""秒単位の日時フォーマット。"""
 MINUTES = 600
-"""分単位の日時フォーマット。 (minutes)"""
+"""分単位の日時フォーマット。"""
 HOURS = 36000
-"""時間単位の日時フォーマット。 (hours)"""
+"""時間単位の日時フォーマット。"""
 DAYS = 864000
-"""日単位の日時フォーマット。 (days)"""
+"""日単位の日時フォーマット。"""
 
 def set_labels(*args: str, timestamp: Optional[Literal[1, 10, 36000, 864000]]=SECONDS) -> None:
-    """ログファイルのヘッダーを設定します。 (set labels)
+    """ログファイルのヘッダーを設定します。
 
 Example: ``log.set_labels('x', 'y', 'z', timestamp=log.MINUTES)``
 
@@ -24,14 +24,14 @@ labels set up by this function call to the last headers declared in the
 file. If the headers are different it will add a new header entry at the
 end of the file.
 
-:param *args: (*args) 各ログヘッダーの位置引数。
-:param timestamp: (timestamp) すべての行の第１列に自動で追加される日時の単位。この引数に ``None`` を指定すると日時が追加されなくなります。
+:param *args: 各ログヘッダーの位置引数。
+:param timestamp: すべての行の第１列に自動で追加される日時の単位。この引数に ``None`` を指定すると日時が追加されなくなります。
 このモジュールに定義されている ``log.MILLISECONDS``、``log.SECONDS``、``log.MINUTES``、``log.HOURS``、``log.DAYS`` を渡します。不正な値を指定すると例外が起きます。"""
     ...
 
 @overload
 def add(log_data: Optional[dict[str, Union[str, int, float]]]) -> None:
-    """ヘッダーと値の辞書を渡すことにより、ログにデータ行を追加します。 (add)
+    """ヘッダーと値の辞書を渡すことにより、ログにデータ行を追加します。
 
 Example: ``log.add({ 'temp': temperature() })``
 
@@ -44,12 +44,12 @@ entry to be added to the log with the extra label.
 Labels previously specified and not present in this function call will be
 skipped with an empty value in the log row.
 
-:param log_data: (log data) 各ヘッダーにキーがある辞書としてログに記録するデータ。"""
+:param log_data: 各ヘッダーにキーがある辞書としてログに記録するデータ。"""
     ...
 
 @overload
 def add(**kwargs: Union[str, int, float]) -> None:
-    """キーワード引数でログにデータ行を追加します。 (add)
+    """キーワード引数でログにデータ行を追加します。
 
 Example: ``log.add(temp=temperature())``
 
@@ -64,23 +64,23 @@ skipped with an empty value in the log row."""
     ...
 
 def delete(full=False):
-    """ログの内容を、ヘッダーもあわせて削除します。 (delete)
+    """ログの内容を、ヘッダーもあわせて削除します。
 
 Example: ``log.delete()``
 
 To add the log headers the ``set_labels`` function has to be called again
 after this.
 
-:param full: (full) フラッシュストレージからデータを削除する「完全」消去フォーマットを選びます。
+:param full: フラッシュストレージからデータを削除する「完全」消去フォーマットを選びます。
 ``False`` を指定すると、遅い完全消去の代わりにデータを無効にするだけの「高速」手段を使います。"""
     ...
 
 def set_mirroring(serial: bool):
-    """データログのアクティビティをシリアル出力に反映させます。 (set mirroring)
+    """データログのアクティビティをシリアル出力に反映させます。
 
 Example: ``log.set_mirroring(True)``
 
 Mirroring is disabled by default.
 
-:param serial: (serial) ``True`` を渡すとデータログのアクティビティをシリアル出力に反映させるようになり、``False`` を渡すとシリアル出力への反映が無効になります。"""
+:param serial: ``True`` を渡すとデータログのアクティビティをシリアル出力に反映させるようになり、``False`` を渡すとシリアル出力への反映が無効になります。"""
     ...

--- a/lang/ja/typeshed/stdlib/machine.pyi
+++ b/lang/ja/typeshed/stdlib/machine.pyi
@@ -1,9 +1,9 @@
-"""低レベルユーティリティ (machine)"""
+"""低レベルユーティリティ"""
 from typing import Any
 from .microbit import MicroBitDigitalPin
 
 def unique_id() -> bytes:
-    """ボードの一意の識別子を持つバイト列を取得します。 (unique id)
+    """ボードの一意の識別子を持つバイト列を取得します。
 
 Example: ``machine.unique_id()``
 
@@ -11,13 +11,13 @@ Example: ``machine.unique_id()``
     ...
 
 def reset() -> None:
-    """外部のRESETボタンを押したと同様にデバイスをリセットします。 (reset)
+    """外部のRESETボタンを押したと同様にデバイスをリセットします。
 
 Example: ``machine.reset()``"""
     ...
 
 def freq() -> int:
-    """CPU周波数をヘルツ単位で取得します。 (freq)
+    """CPU周波数をヘルツ単位で取得します。
 
 Example: ``machine.freq()``
 
@@ -25,7 +25,7 @@ Example: ``machine.freq()``
     ...
 
 def disable_irq() -> Any:
-    """割り込み要求を無効にします。 (disable irq)
+    """割り込み要求を無効にします。
 
 Example: ``interrupt_state = machine.disable_irq()``
 
@@ -36,15 +36,15 @@ interrupts to their original state."""
     ...
 
 def enable_irq(state: Any) -> None:
-    """割り込み要求を再度有効にします。  (enable irq)
+    """割り込み要求を再度有効にします。
 
 Example: ``machine.enable_irq(interrupt_state)``
 
-:param state: (state)  ``disable_irq`` 関数の最も最近の呼び出しから返された値。"""
+:param state: ``disable_irq`` 関数の最も最近の呼び出しから返された値。"""
     ...
 
 def time_pulse_us(pin: MicroBitDigitalPin, pulse_level: int, timeout_us: int=1000000) -> int:
-    """端子のパルス時間を計測します。 (time pulse us)
+    """端子のパルス時間を計測します。
 
 Example: ``time_pulse_us(pin0, 1)``
 
@@ -55,30 +55,30 @@ function first waits until the pin input becomes equal to
 starts straight away.
 
 :param pin: (ピン) 計測対象の端子
-:param pulse_level: (pulse level) 低パルスの時間計測で 0、高パルスの時間計測で 1 を指定
-:param timeout_us: (timeout us) マイクロ秒単位のタイムアウト時間
+:param pulse_level: 低パルスの時間計測で 0、高パルスの時間計測で 1 を指定
+:param timeout_us: マイクロ秒単位のタイムアウト時間
 :return: The duration of the pulse in microseconds, or -1 for a timeout waiting for the level to match ``pulse_level``, or -2 on timeout waiting for the pulse to end"""
     ...
 
 class mem:
-    """``mem8``、``mem16``、``mem32`` メモリビューのクラス。 (mem)"""
+    """``mem8``、``mem16``、``mem32`` メモリビューのクラス。"""
 
     def __getitem__(self, address: int) -> int:
-        """メモリにある値を参照します。 (getitem)
+        """メモリにある値を参照します。
 
-:param address: (address) メモリのアドレス。
+:param address: メモリのアドレス。
 :return: The value at that address as an integer."""
         ...
 
     def __setitem__(self, address: int, value: int) -> None:
-        """指定アドレスに値を設定します。 (setitem)
+        """指定アドレスに値を設定します。
 
-:param address: (address) メモリのアドレス。
-:param value: (value) 設定する整数値。"""
+:param address: メモリのアドレス。
+:param value: 設定する整数値。"""
         ...
 mem8: mem
-"""メモリの8ビット（バイト）ビュー。 (mem8)"""
+"""メモリの8ビット（バイト）ビュー。"""
 mem16: mem
-"""メモリの16ビットビュー。 (mem16)"""
+"""メモリの16ビットビュー。"""
 mem32: mem
-"""メモリの32ビットビュー。 (mem32)"""
+"""メモリの32ビットビュー。"""

--- a/lang/ja/typeshed/stdlib/math.pyi
+++ b/lang/ja/typeshed/stdlib/math.pyi
@@ -1,68 +1,68 @@
-"""数学関数。 (math)"""
+"""数学関数。"""
 from typing import Tuple
 
 def acos(x: float) -> float:
-    """逆余弦を算出します。 (acos)
+    """逆余弦を算出します。
 
 Example: ``math.acos(1)``
 
-:param x: (x) 数値
+:param x: 数値
 :return: The inverse cosine of ``x``"""
     ...
 
 def asin(x: float) -> float:
-    """逆正弦を算出します。 (asin)
+    """逆正弦を算出します。
 
 Example: ``math.asin(0)``
 
-:param x: (x) 数値
+:param x: 数値
 :return: The inverse sine of ``x``"""
     ...
 
 def atan(x: float) -> float:
-    """逆正接を算出します。 (atan)
+    """逆正接を算出します。
 
 Example: ``math.atan(0)``
 
-:param x: (x) 数値
+:param x: 数値
 :return: The inverse tangent of ``x``"""
     ...
 
 def atan2(y: float, x: float) -> float:
-    """``y/x`` の逆正接の主値を算出します。 (atan2)
+    """``y/x`` の逆正接の主値を算出します。
 
 Example: ``math.atan2(0, -1)``
 
-:param y: (x) 数値
-:param x: (x) 数値
+:param y: 数値
+:param x: 数値
 :return: The principal value of the inverse tangent of ``y/x``"""
     ...
 
 def ceil(x: float) -> float:
-    """正の無限大方向に数値を丸めます。 (ceil)
+    """正の無限大方向に数値を丸めます。
 
 Example: ``math.ceil(0.1)``
 
-:param x: (x) 数値
+:param x: 数値
 :return: ``x`` rounded towards positive infinity."""
     ...
 
 def copysign(x: float, y: float) -> float:
-    """``y`` の符号で ``x`` を算出します。 (copysign)
+    """``y`` の符号で ``x`` を算出します。
 
 Example: ``math.copysign(1, -1)``
 
-:param x: (x) 数値
-:param y: (y) 戻り値の符号の元になる値
+:param x: 数値
+:param y: 戻り値の符号の元になる値
 :return: ``x`` with the sign of ``y``"""
     ...
 
 def cos(x: float) -> float:
-    """``x`` の余弦を算出します。 (cos)
+    """``x`` の余弦を算出します。
 
 Example: ``math.cos(0)``
 
-:param x: (x) 数値
+:param x: 数値
 :return: The cosine of ``x``"""
     ...
 
@@ -71,48 +71,48 @@ def degrees(x: float) -> float:
 
 Example: ``math.degrees(2 * math.pi)``
 
-:param x: (x) ラジアン単位の値
+:param x: ラジアン単位の値
 :return: The value converted to degrees"""
     ...
 
 def exp(x: float) -> float:
-    """``x`` の指数を算出します。 (exp)
+    """``x`` の指数を算出します。
 
 Example: ``math.exp(1)``
 
-:param x: (x) 数値
+:param x: 数値
 :return: The exponential of ``x``."""
     ...
 
 def fabs(x: float) -> float:
-    """``x`` の絶対値を返します。 (fabs)
+    """``x`` の絶対値を返します。
 
 Example: ``math.fabs(-0.1)``
 
-:param x: (x) 数値
+:param x: 数値
 :return: The absolute value of ``x``"""
     ...
 
 def floor(x: float) -> int:
-    """負の無限大方向に数値を丸めます。 (floor)
+    """負の無限大方向に数値を丸めます。
 
 Example: ``math.floor(0.9)``
 
-:param x: (x) 数値
+:param x: 数値
 :return: ``x`` rounded towards negative infinity."""
     ...
 
 def fmod(x: float, y: float) -> float:
-    """``x/y`` の剰余を算出します。 (fmod)
+    """``x/y`` の剰余を算出します。
 
 Example: ``math.fmod(10, 3)``
 
-:param x: (x) 分子の値
-:param y: (y) 分母の値"""
+:param x: 分子の値
+:param y: 分母の値"""
     ...
 
 def frexp(x: float) -> Tuple[float, int]:
-    """浮動小数点数を仮数部と指数部に分解します。 (frexp)
+    """浮動小数点数を仮数部と指数部に分解します。
 
 Example: ``mantissa, exponent = math.frexp(2)``
 
@@ -120,49 +120,49 @@ The returned value is the tuple ``(m, e)`` such that ``x == m * 2**e``
 exactly.  If ``x == 0`` then the function returns ``(0.0, 0)``, otherwise
 the relation ``0.5 <= abs(m) < 1`` holds.
 
-:param x: (x) 浮動小数点数
+:param x: 浮動小数点数
 :return: A tuple of length two containing its mantissa then exponent"""
     ...
 
 def isfinite(x: float) -> bool:
-    """有限数かどうかを確認します。 (isfinite)
+    """有限数かどうかを確認します。
 
 Example: ``math.isfinite(float('inf'))``
 
-:param x: (x) 数値。
+:param x: 数値。
 :return: ``True`` if ``x`` is finite, ``False`` otherwise."""
     ...
 
 def isinf(x: float) -> bool:
-    """無限数かどうかを確認します。 (isinf)
+    """無限数かどうかを確認します。
 
 Example: ``math.isinf(float('-inf'))``
 
-:param x: (x) 数値。
+:param x: 数値。
 :return: ``True`` if ``x`` is infinite, ``False`` otherwise."""
     ...
 
 def isnan(x: float) -> bool:
-    """非数（NaN: Not-a-Number）かどうかを確認します。 (isnan)
+    """非数（NaN: Not-a-Number）かどうかを確認します。
 
 Example: ``math.isnan(float('nan'))``
 
-:param x: (x) 数値
+:param x: 数値
 :return: ``True`` if ``x`` is not-a-number (NaN), ``False`` otherwise."""
     ...
 
 def ldexp(x: float, exp: int) -> float:
-    """``x * (2**exp)`` を算出します。 (ldexp)
+    """``x * (2**exp)`` を算出します。
 
 Example: ``math.ldexp(0.5, 2)``
 
-:param x: (x) 数値
-:param exp: (exp) 整数の指数
+:param x: 数値
+:param exp: 整数の指数
 :return: ``x * (2**exp)``"""
     ...
 
 def log(x: float, base: float=e) -> float:
-    """``x`` の対数を指定された底（デフォルトは自然対数）で算出します。 (log)
+    """``x`` の対数を指定された底（デフォルトは自然対数）で算出します。
 
 Example: ``math.log(math.e)``
 
@@ -170,77 +170,77 @@ With one argument, return the natural logarithm of x (to base e).
 
 With two arguments, return the logarithm of x to the given base, calculated as ``log(x)/log(base)``.
 
-:param x: (x) 数値
-:param base: (base) 使用する底
+:param x: 数値
+:param base: 使用する底
 :return: The natural logarithm of ``x``"""
     ...
 
 def modf(x: float) -> Tuple[float, float]:
-    """``x`` の整数部分と小数部分を返します。 (modf)
+    """``x`` の整数部分と小数部分を返します。
 
 Example: ``fractional, integral = math.modf(1.5)``
 
-:param x: (x) 数値
+:param x: 数値
 :return: A tuple of two floats representing the fractional then integral parts of ``x``.
 
 Both the fractional and integral values have the same sign as ``x``."""
     ...
 
 def pow(x: float, y: float) -> float:
-    """``x`` の ``y`` 乗を返します。 (pow)
+    """``x`` の ``y`` 乗を返します。
 
 Example: ``math.pow(4, 0.5)``
 
-:param x: (x) 数値
-:param y: (y) 指数
+:param x: 数値
+:param y: 指数
 :return: ``x`` to the power of ``y``"""
     ...
 
 def radians(x: float) -> float:
-    """度をラジアンに変換します。 (radians)
+    """度をラジアンに変換します。
 
 Example: ``math.radians(360)``
 
-:param x: (x) 度単位の角度
+:param x: 度単位の角度
 :return: The value converted to radians"""
     ...
 
 def sin(x: float) -> float:
-    """``x`` の正弦を算出します。 (sin)
+    """``x`` の正弦を算出します。
 
 Example: ``math.sin(math.pi/2)``
 
-:param x: (x) 数値
+:param x: 数値
 :return: The sine of ``x``"""
     ...
 
 def sqrt(x: float) -> float:
-    """``x`` の平方根を算出します。 (sqrt)
+    """``x`` の平方根を算出します。
 
 Example: ``math.sqrt(4)``
 
-:param x: (x) 数値
+:param x: 数値
 :return: The square root of ``x``"""
     ...
 
 def tan(x: float) -> float:
-    """``x`` の正接を算出します。 (tan)
+    """``x`` の正接を算出します。
 
 Example: ``math.tan(0)``
 
-:param x: (x) 数値
+:param x: 数値
 :return: The tangent of ``x``."""
     ...
 
 def trunc(x: float) -> int:
-    """0 方向に数値を丸めます。 (trunc)
+    """0 方向に数値を丸めます。
 
 Example: ``math.trunc(-0.9)``
 
-:param x: (x) 数値
+:param x: 数値
 :return: ``x`` rounded towards zero."""
     ...
 e: float
-"""自然対数の底 (e)"""
+"""自然対数の底"""
 pi: float
-"""円の円周と直径の比 (pi)"""
+"""円の円周と直径の比"""

--- a/lang/ja/typeshed/stdlib/microbit/__init__.pyi
+++ b/lang/ja/typeshed/stdlib/microbit/__init__.pyi
@@ -1,4 +1,4 @@
-"""端子、イメージ、サウンド、温度と音量。 (microbit)"""
+"""端子、イメージ、サウンド、温度と音量。"""
 from _typeshed import ReadableBuffer
 from typing import Any, Callable, List, Optional, overload
 from . import accelerometer as accelerometer
@@ -12,7 +12,7 @@ from . import uart as uart
 from . import audio as audio
 
 def run_every(callback: Optional[Callable[[], None]]=None, days: int=0, h: int=0, min: int=0, s: int=0, ms: int=0) -> Callable[[Callable[[], None]], Callable[[], None]]:
-    """指定した間隔で呼び出される関数をスケジュールします **V2 のみ**。 (run every)
+    """指定した間隔で呼び出される関数をスケジュールします **V2 のみ**。
 
 Example: ``run_every(my_logging, min=5)``
 
@@ -28,31 +28,31 @@ or used as a decorator::
 
 Arguments with different time units are additive.
 
-:param callback: (callback) 呼び出すコールバック。デコレータとして使う場合には省略します。
-:param days: (days) 日単位の間隔。
-:param h: (h) 時間単位の間隔。
-:param min: (min) 分単位の間隔。
-:param s: (s) 秒単位の間隔。
-:param ms: (ms) ミリ秒単位の間隔。"""
+:param callback: 呼び出すコールバック。デコレータとして使う場合には省略します。
+:param days: 日単位の間隔。
+:param h: 時間単位の間隔。
+:param min: 分単位の間隔。
+:param s: 秒単位の間隔。
+:param ms: ミリ秒単位の間隔。"""
 
 def panic(n: int) -> None:
-    """パニックモードに入ります。 (panic)
+    """パニックモードに入ります。
 
 Example: ``panic(127)``
 
-:param n: (n) 状態を示す 255 以下の任意の整数。
+:param n: 状態を示す 255 以下の任意の整数。
 
 Requires restart."""
 
 def reset() -> None:
-    """ボードを再起動します。 (reset)"""
+    """ボードを再起動します。"""
 
 def sleep(n: float) -> None:
-    """``n`` ミリ秒待機します。 (sleep)
+    """``n`` ミリ秒待機します。
 
 Example: ``sleep(1000)``
 
-:param n: (n) ミリ秒単位の待機時間
+:param n: ミリ秒単位の待機時間
 
 One second is 1000 milliseconds, so::
 
@@ -61,7 +61,7 @@ One second is 1000 milliseconds, so::
 will pause the execution for one second."""
 
 def running_time() -> int:
-    """ボードの実行時間を取得します。 (running time)
+    """ボードの実行時間を取得します。
 
 :return: The number of milliseconds since the board was switched on or restarted."""
 
@@ -69,11 +69,11 @@ def temperature() -> int:
     """micro:bitの温度を摂氏で取得します。 (温度)"""
 
 def set_volume(v: int) -> None:
-    """音量を設定します。 (set volume)
+    """音量を設定します。
 
 Example: ``set_volume(127)``
 
-:param v: (v) 0（下限）から 255（上限）までの間の値。
+:param v: 0（下限）から 255（上限）までの間の値。
 
 Out of range values will be clamped to 0 or 255.
 
@@ -81,16 +81,16 @@ Out of range values will be clamped to 0 or 255.
     ...
 
 class Button:
-    """ボタン ``button_a`` と ``button_b`` のクラス。 (button)"""
+    """ボタン ``button_a`` と ``button_b`` のクラス。"""
 
     def is_pressed(self) -> bool:
-        """ボタンが押されているかどうかを確認します。 (is pressed)
+        """ボタンが押されているかどうかを確認します。
 
 :return: ``True`` if the specified button ``button`` is pressed, and ``False`` otherwise."""
         ...
 
     def was_pressed(self) -> bool:
-        """デバイスが起動されてから、もしくは前回このメソッドが呼び出されてからボタンが押されたかどうかを確認します。 (was pressed)
+        """デバイスが起動されてから、もしくは前回このメソッドが呼び出されてからボタンが押されたかどうかを確認します。
 
 Calling this method will clear the press state so
 that the button must be pressed again before this method will return
@@ -100,17 +100,17 @@ that the button must be pressed again before this method will return
         ...
 
     def get_presses(self) -> int:
-        """ボタンを押した回数の合計を取得し、返す前に回数をゼロにリセットします。 (get presses)
+        """ボタンを押した回数の合計を取得し、返す前に回数をゼロにリセットします。
 
 :return: The number of presses since the device started or the last time this method was called"""
         ...
 button_a: Button
-"""左のボタン ``Button`` オブジェクト。 (button a)"""
+"""左のボタン ``Button`` オブジェクト。"""
 button_b: Button
-"""右のボタン ``Button`` オブジェクト。 (button b)"""
+"""右のボタン ``Button`` オブジェクト。"""
 
 class MicroBitDigitalPin:
-    """デジタル端子。 (microbitdigitalpin)
+    """デジタル端子。
 
 Some pins support analog and touch features using the ``MicroBitAnalogDigitalPin`` and ``MicroBitTouchPin`` subclasses."""
     NO_PULL: int
@@ -118,7 +118,7 @@ Some pins support analog and touch features using the ``MicroBitAnalogDigitalPin
     PULL_DOWN: int
 
     def read_digital(self) -> int:
-        """端子のデジタル値を取得します。 (read digital)
+        """端子のデジタル値を取得します。
 
 Example: ``value = pin0.read_digital()``
 
@@ -126,23 +126,23 @@ Example: ``value = pin0.read_digital()``
         ...
 
     def write_digital(self, value: int) -> None:
-        """端子のデジタル値を設定します。 (write digital)
+        """端子のデジタル値を設定します。
 
 Example: ``pin0.write_digital(1)``
 
-:param value: (value) 端子をハイにするには 1 、ローにするには 0 を指定"""
+:param value: 端子をハイにするには 1 、ローにするには 0 を指定"""
         ...
 
     def set_pull(self, value: int) -> None:
-        """プル状態を ``PULL_UP``、``PULL_DOWN``、``NO_PULL`` の３つの値のいずれかに設定します。 (set pull)
+        """プル状態を ``PULL_UP``、``PULL_DOWN``、``NO_PULL`` の３つの値のいずれかに設定します。
 
 Example: ``pin0.set_pull(pin0.PULL_UP)``
 
-:param value: (value) ``pin0.PULL_UP`` などの関連する端子のプル状態。"""
+:param value: ``pin0.PULL_UP`` などの関連する端子のプル状態。"""
         ...
 
     def get_pull(self) -> int:
-        """端子のプル状態を取得します。 (get pull)
+        """端子のプル状態を取得します。
 
 Example: ``pin0.get_pull()``
 
@@ -153,7 +153,7 @@ when a pin mode requires it."""
         ...
 
     def get_mode(self) -> str:
-        """端子のモードを返します。 (get mode)
+        """端子のモードを返します。
 
 Example: ``pin0.get_mode()``
 
@@ -165,43 +165,43 @@ changes.
         ...
 
     def write_analog(self, value: int) -> None:
-        """PWM 信号を端子に出力します。時間幅周期は ``value`` に比例します。 (write analog)
+        """PWM 信号を端子に出力します。時間幅周期は ``value`` に比例します。
 
 Example: ``pin0.write_analog(254)``
 
-:param value: (value) 0（時間幅周期 0%）から 1023（時間幅周期 100%）までの整数または浮動小数点数。"""
+:param value: 0（時間幅周期 0%）から 1023（時間幅周期 100%）までの整数または浮動小数点数。"""
 
     def set_analog_period(self, period: int) -> None:
-        """出力されるPWM信号の周期を ``period`` にミリ秒単位で設定します。 (set analog period)
+        """出力されるPWM信号の周期を ``period`` にミリ秒単位で設定します。
 
 Example: ``pin0.set_analog_period(10)``
 
-:param period: (period) 周期をミリ秒単位で指定。有効な最小値は1ms。"""
+:param period: 周期をミリ秒単位で指定。有効な最小値は1ms。"""
 
     def set_analog_period_microseconds(self, period: int) -> None:
-        """出力されるPWM信号の周期を ``period`` にマイクロ秒単位で設定します。 (set analog period microseconds)
+        """出力されるPWM信号の周期を ``period`` にマイクロ秒単位で設定します。
 
 Example: ``pin0.set_analog_period_microseconds(512)``
 
-:param period: (period) 周期をマイクロ秒単位で指定。有効な最小値は256µs。"""
+:param period: 周期をマイクロ秒単位で指定。有効な最小値は256µs。"""
 
 class MicroBitAnalogDigitalPin(MicroBitDigitalPin):
-    """アナログとデジタル機能を備えた端子。 (microbitanalogdigitalpin)"""
+    """アナログとデジタル機能を備えた端子。"""
 
     def read_analog(self) -> int:
-        """端子にかかっている電圧を読み取ります。 (read analog)
+        """端子にかかっている電圧を読み取ります。
 
 Example: ``pin0.read_analog()``
 
 :return: An integer between 0 (meaning 0V) and 1023 (meaning 3.3V)."""
 
 class MicroBitTouchPin(MicroBitAnalogDigitalPin):
-    """アナログ、デジタル、タッチ機能を備えた端子。 (microbittouchpin)"""
+    """アナログ、デジタル、タッチ機能を備えた端子。"""
     CAPACITIVE: int
     RESISTIVE: int
 
     def is_touched(self) -> bool:
-        """端子にタッチしているかどうかを確認します。 (is touched)
+        """端子にタッチしているかどうかを確認します。
 
 Example: ``pin0.is_touched()``
 
@@ -224,201 +224,201 @@ does not require you to make a ground connection as part of a circuit.
         ...
 
     def set_touch_mode(self, value: int) -> None:
-        """端子のタッチモードを設定します。 (set touch mode)
+        """端子のタッチモードを設定します。
 
 Example: ``pin0.set_touch_mode(pin0.CAPACITIVE)``
 
 The default touch mode for the pins on the edge connector is
 ``resistive``. The default for the logo pin **V2** is ``capacitive``.
 
-:param value: (value) 関連する端子の ``CAPACITIVE`` または ``RESISTIVE``。"""
+:param value: 関連する端子の ``CAPACITIVE`` または ``RESISTIVE``。"""
         ...
 pin0: MicroBitTouchPin
-"""デジタル、アナログ、タッチ機能を備えた端子。 (pin0)"""
+"""デジタル、アナログ、タッチ機能を備えた端子。"""
 pin1: MicroBitTouchPin
-"""デジタル、アナログ、タッチ機能を備えた端子。 (pin1)"""
+"""デジタル、アナログ、タッチ機能を備えた端子。"""
 pin2: MicroBitTouchPin
-"""デジタル、アナログ、タッチ機能を備えた端子。 (pin2)"""
+"""デジタル、アナログ、タッチ機能を備えた端子。"""
 pin3: MicroBitAnalogDigitalPin
-"""デジタルとアナログ機能を備えた端子。 (pin3)"""
+"""デジタルとアナログ機能を備えた端子。"""
 pin4: MicroBitAnalogDigitalPin
-"""デジタルとアナログ機能を備えた端子。 (pin4)"""
+"""デジタルとアナログ機能を備えた端子。"""
 pin5: MicroBitDigitalPin
-"""デジタル機能を備えた端子。 (pin5)"""
+"""デジタル機能を備えた端子。"""
 pin6: MicroBitDigitalPin
-"""デジタル機能を備えた端子。 (pin6)"""
+"""デジタル機能を備えた端子。"""
 pin7: MicroBitDigitalPin
-"""デジタル機能を備えた端子。 (pin7)"""
+"""デジタル機能を備えた端子。"""
 pin8: MicroBitDigitalPin
-"""デジタル機能を備えた端子。 (pin8)"""
+"""デジタル機能を備えた端子。"""
 pin9: MicroBitDigitalPin
-"""デジタル機能を備えた端子。 (pin9)"""
+"""デジタル機能を備えた端子。"""
 pin10: MicroBitAnalogDigitalPin
-"""デジタルとアナログ機能を備えた端子。 (pin10)"""
+"""デジタルとアナログ機能を備えた端子。"""
 pin11: MicroBitDigitalPin
-"""デジタル機能を備えた端子。 (pin11)"""
+"""デジタル機能を備えた端子。"""
 pin12: MicroBitDigitalPin
-"""デジタル機能を備えた端子。 (pin12)"""
+"""デジタル機能を備えた端子。"""
 pin13: MicroBitDigitalPin
-"""デジタル機能を備えた端子。 (pin13)"""
+"""デジタル機能を備えた端子。"""
 pin14: MicroBitDigitalPin
-"""デジタル機能を備えた端子。 (pin14)"""
+"""デジタル機能を備えた端子。"""
 pin15: MicroBitDigitalPin
-"""デジタル機能を備えた端子。 (pin15)"""
+"""デジタル機能を備えた端子。"""
 pin16: MicroBitDigitalPin
-"""デジタル機能を備えた端子。 (pin16)"""
+"""デジタル機能を備えた端子。"""
 pin19: MicroBitDigitalPin
-"""デジタル機能を備えた端子。 (pin19)"""
+"""デジタル機能を備えた端子。"""
 pin20: MicroBitDigitalPin
-"""デジタル機能を備えた端子。 (pin20)"""
+"""デジタル機能を備えた端子。"""
 pin_logo: MicroBitTouchPin
-"""micro:bitの前面にあるタッチセンサー機能のあるロゴの端子です。デフォルトでは静電容量方式タッチモードになっています。 (pin logo)"""
+"""micro:bitの前面にあるタッチセンサー機能のあるロゴの端子です。デフォルトでは静電容量方式タッチモードになっています。"""
 pin_speaker: MicroBitAnalogDigitalPin
-"""micro:bitスピーカーをアドレスするための端子。 (pin speaker)
+"""micro:bitスピーカーをアドレスするための端子。
 
 This API is intended only for use in Pulse-Width Modulation pin operations e.g. pin_speaker.write_analog(128).
 """
 
 class Image:
-    """micro:bitのLEDディスプレイに表示するイメージ。 (image)
+    """micro:bitのLEDディスプレイに表示するイメージ。
 
 Given an image object it's possible to display it via the ``display`` API::
 
     display.show(Image.HAPPY)"""
     HEART: Image
-    """「ハート」イメージ。 (heart)"""
+    """「ハート」イメージ。"""
     HEART_SMALL: Image
-    """「小さいハート」イメージ。 (heart small)"""
+    """「小さいハート」イメージ。"""
     HAPPY: Image
-    """「うれしい顔」イメージ。 (happy)"""
+    """「うれしい顔」イメージ。"""
     SMILE: Image
-    """「笑顔」イメージ。 (smile)"""
+    """「笑顔」イメージ。"""
     SAD: Image
-    """「かなしい顔」イメージ。 (sad)"""
+    """「かなしい顔」イメージ。"""
     CONFUSED: Image
-    """「こまり顔」イメージ。 (confused)"""
+    """「こまり顔」イメージ。"""
     ANGRY: Image
-    """「おこり顔」イメージ。 (angry)"""
+    """「おこり顔」イメージ。"""
     ASLEEP: Image
-    """「ねてる顔」イメージ。 (asleep)"""
+    """「ねてる顔」イメージ。"""
     SURPRISED: Image
-    """「びっくり顔」イメージ。 (surprised)"""
+    """「びっくり顔」イメージ。"""
     SILLY: Image
-    """「へん顔」イメージ。 (silly)"""
+    """「へん顔」イメージ。"""
     FABULOUS: Image
-    """「サングラスの笑顔」イメージ。 (fabulous)"""
+    """「サングラスの笑顔」イメージ。"""
     MEH: Image
-    """「ふーん」イメージ (meh)"""
+    """「ふーん」イメージ"""
     YES: Image
-    """「チェック」イメージ。 (yes)"""
+    """「チェック」イメージ。"""
     NO: Image
-    """「バツ」イメージ。 (no)"""
+    """「バツ」イメージ。"""
     CLOCK12: Image
-    """「12時を指す線」イメージ。 (clock12)"""
+    """「12時を指す線」イメージ。"""
     CLOCK11: Image
-    """「11時を指す線」イメージ。 (clock11)"""
+    """「11時を指す線」イメージ。"""
     CLOCK10: Image
-    """「10時を指す線」イメージ。 (clock10)"""
+    """「10時を指す線」イメージ。"""
     CLOCK9: Image
-    """「9時を指す線」イメージ。 (clock9)"""
+    """「9時を指す線」イメージ。"""
     CLOCK8: Image
-    """「8時を指す線」イメージ。 (clock8)"""
+    """「8時を指す線」イメージ。"""
     CLOCK7: Image
-    """「7時を指す線」イメージ。 (clock7)"""
+    """「7時を指す線」イメージ。"""
     CLOCK6: Image
-    """「6時を指す線」イメージ。 (clock6)"""
+    """「6時を指す線」イメージ。"""
     CLOCK5: Image
-    """「5時を指す線」イメージ。 (clock5)"""
+    """「5時を指す線」イメージ。"""
     CLOCK4: Image
-    """「4時を指す線」イメージ。 (clock4)"""
+    """「4時を指す線」イメージ。"""
     CLOCK3: Image
-    """「3時を指す線」イメージ。 (clock3)"""
+    """「3時を指す線」イメージ。"""
     CLOCK2: Image
-    """「2時を指す線」イメージ。 (clock2)"""
+    """「2時を指す線」イメージ。"""
     CLOCK1: Image
-    """「1時を指す線」イメージ。 (clock1)"""
+    """「1時を指す線」イメージ。"""
     ARROW_N: Image
-    """「北を指す矢印」イメージ。 (arrow n)"""
+    """「北を指す矢印」イメージ。"""
     ARROW_NE: Image
-    """「北東を指す矢印」イメージ。 (arrow ne)"""
+    """「北東を指す矢印」イメージ。"""
     ARROW_E: Image
-    """「西を指す矢印」イメージ。 (arrow e)"""
+    """「西を指す矢印」イメージ。"""
     ARROW_SE: Image
-    """「南東を指す矢印」イメージ。 (arrow se)"""
+    """「南東を指す矢印」イメージ。"""
     ARROW_S: Image
-    """「南を指す矢印」イメージ。 (arrow s)"""
+    """「南を指す矢印」イメージ。"""
     ARROW_SW: Image
-    """「南西を指す矢印」イメージ。 (arrow sw)"""
+    """「南西を指す矢印」イメージ。"""
     ARROW_W: Image
-    """「西を指す矢印」イメージ。 (arrow w)"""
+    """「西を指す矢印」イメージ。"""
     ARROW_NW: Image
-    """「北西を指す矢印」イメージ。 (arrow nw)"""
+    """「北西を指す矢印」イメージ。"""
     TRIANGLE: Image
-    """「上向きの三角形」イメージ (triangle)"""
+    """「上向きの三角形」イメージ"""
     TRIANGLE_LEFT: Image
-    """「左向き三角」イメージ。 (triangle left)"""
+    """「左向き三角」イメージ。"""
     CHESSBOARD: Image
-    """チェス盤パターンで交互に点灯するLED。 (chessboard)"""
+    """チェス盤パターンで交互に点灯するLED。"""
     DIAMOND: Image
-    """「ダイヤモンド」イメージ。 (diamond)"""
+    """「ダイヤモンド」イメージ。"""
     DIAMOND_SMALL: Image
-    """「小さいダイヤモンド」イメージ。 (diamond small)"""
+    """「小さいダイヤモンド」イメージ。"""
     SQUARE: Image
-    """「四角」イメージ。 (square)"""
+    """「四角」イメージ。"""
     SQUARE_SMALL: Image
-    """「小さい四角」イメージ。 (square small)"""
+    """「小さい四角」イメージ。"""
     RABBIT: Image
-    """「うさぎ」イメージ。 (rabbit)"""
+    """「うさぎ」イメージ。"""
     COW: Image
-    """「うし」イメージ。 (cow)"""
+    """「うし」イメージ。"""
     MUSIC_CROTCHET: Image
-    """「４分音符」イメージ。 (music crotchet)"""
+    """「４分音符」イメージ。"""
     MUSIC_QUAVER: Image
-    """「８分音符」イメージ。 (music quaver)"""
+    """「８分音符」イメージ。"""
     MUSIC_QUAVERS: Image
-    """「連結した８分音符」イメージ。 (music quavers)"""
+    """「連結した８分音符」イメージ。"""
     PITCHFORK: Image
-    """「くまで」イメージ。 (pitchfork)"""
+    """「くまで」イメージ。"""
     XMAS: Image
-    """「クリスマスツリー」イメージ。 (xmas)"""
+    """「クリスマスツリー」イメージ。"""
     PACMAN: Image
-    """「パックマン」イメージ。 (pacman)"""
+    """「パックマン」イメージ。"""
     TARGET: Image
-    """「まと」イメージ。 (target)"""
+    """「まと」イメージ。"""
     TSHIRT: Image
-    """「Tシャツ」イメージ。 (tshirt)"""
+    """「Tシャツ」イメージ。"""
     ROLLERSKATE: Image
-    """「ローラースケート」イメージ。 (rollerskate)"""
+    """「ローラースケート」イメージ。"""
     DUCK: Image
-    """「あひる」イメージ。 (duck)"""
+    """「あひる」イメージ。"""
     HOUSE: Image
-    """「家」イメージ。 (house)"""
+    """「家」イメージ。"""
     TORTOISE: Image
-    """「かめ」イメージ。 (tortoise)"""
+    """「かめ」イメージ。"""
     BUTTERFLY: Image
-    """「ちょうちょ」イメージ。 (butterfly)"""
+    """「ちょうちょ」イメージ。"""
     STICKFIGURE: Image
-    """「棒人間」イメージ。 (stickfigure)"""
+    """「棒人間」イメージ。"""
     GHOST: Image
-    """「おばけ」イメージ。 (ghost)"""
+    """「おばけ」イメージ。"""
     SWORD: Image
-    """「剣」イメージ。 (sword)"""
+    """「剣」イメージ。"""
     GIRAFFE: Image
-    """「きりん」イメージ。 (giraffe)"""
+    """「きりん」イメージ。"""
     SKULL: Image
-    """「がいこつ」イメージ。 (skull)"""
+    """「がいこつ」イメージ。"""
     UMBRELLA: Image
-    """「かさ」イメージ。 (umbrella)"""
+    """「かさ」イメージ。"""
     SNAKE: Image
-    """「へび」イメージ。 (snake)"""
+    """「へび」イメージ。"""
     ALL_CLOCKS: List[Image]
-    """すべての CLOCK_ イメージを順番に並べたリスト。 (all clocks)"""
+    """すべての CLOCK_ イメージを順番に並べたリスト。"""
     ALL_ARROWS: List[Image]
-    """すべての ARROW_ イメージを順番に並べたリスト。 (all arrows)"""
+    """すべての ARROW_ イメージを順番に並べたリスト。"""
 
     @overload
     def __init__(self, string: str) -> None:
-        """LEDの点灯パターンを示す文字列からイメージを作成します。 (init)
+        """LEDの点灯パターンを示す文字列からイメージを作成します。
 
 ``string`` has to consist of digits 0-9 arranged into lines,
 describing the image, for example::
@@ -432,16 +432,16 @@ describing the image, for example::
 will create a 5×5 image of an X. The end of a line is indicated by a
 colon. It's also possible to use newlines (\\n) insead of the colons.
 
-:param string: (string) イメージについて記述する文字列。"""
+:param string: イメージについて記述する文字列。"""
         ...
 
     @overload
     def __init__(self, width: int=5, height: int=5, buffer: ReadableBuffer=None) -> None:
-        """``width`` 列と ``height`` 行からなる空のイメージを作成します。 (init)
+        """``width`` 列と ``height`` 行からなる空のイメージを作成します。
 
-:param width: (width) イメージの幅を指定するオプション
-:param height: (height) イメージの高さを指定するオプション
-:param buffer: (buffer) イメージを初期化するために、整数値（0～9）を ``width``×``height`` 個並べた配列またはバイト列を指定します
+:param width: イメージの幅を指定するオプション
+:param height: イメージの高さを指定するオプション
+:param buffer: イメージを初期化するために、整数値（0～9）を ``width``×``height`` 個並べた配列またはバイト列を指定します
 
 Examples::
 
@@ -452,90 +452,90 @@ These create 2 x 2 pixel images at full brightness."""
         ...
 
     def width(self) -> int:
-        """列数を取得します。 (width)
+        """列数を取得します。
 
 :return: The number of columns in the image"""
         ...
 
     def height(self) -> int:
-        """行数を取得します。 (height)
+        """行数を取得します。
 
 :return: The number of rows in the image"""
         ...
 
     def set_pixel(self, x: int, y: int, value: int) -> None:
-        """1ピクセルの明るさを設定します。 (set pixel)
+        """1ピクセルの明るさを設定します。
 
 Example: ``my_image.set_pixel(0, 0, 9)``
 
-:param x: (x) 列数
-:param y: (y) 行数
-:param value: (value) 明るさを 0（暗い）から 9（明るい）までの整数値で指定します
+:param x: 列数
+:param y: 行数
+:param value: 明るさを 0（暗い）から 9（明るい）までの整数値で指定します
 
 This method will raise an exception when called on any of the built-in
 read-only images, like ``Image.HEART``."""
         ...
 
     def get_pixel(self, x: int, y: int) -> int:
-        """1ピクセルの明るさを取得します。 (get pixel)
+        """1ピクセルの明るさを取得します。
 
 Example: ``my_image.get_pixel(0, 0)``
 
-:param x: (x) 列数
-:param y: (y) 行数
+:param x: 列数
+:param y: 行数
 :return: The brightness as an integer between 0 and 9."""
         ...
 
     def shift_left(self, n: int) -> Image:
-        """画像を左にシフトした新しいイメージを作成します。 (shift left)
+        """画像を左にシフトした新しいイメージを作成します。
 
 Example: ``Image.HEART_SMALL.shift_left(1)``
 
-:param n: (n) シフトする列数
+:param n: シフトする列数
 :return: The shifted image"""
         ...
 
     def shift_right(self, n: int) -> Image:
-        """画像を右にシフトした新しいイメージを作成します。 (shift right)
+        """画像を右にシフトした新しいイメージを作成します。
 
 Example: ``Image.HEART_SMALL.shift_right(1)``
 
-:param n: (n) シフトする列数
+:param n: シフトする列数
 :return: The shifted image"""
         ...
 
     def shift_up(self, n: int) -> Image:
-        """画像を上にシフトした新しいイメージを作成します。 (shift up)
+        """画像を上にシフトした新しいイメージを作成します。
 
 Example: ``Image.HEART_SMALL.shift_up(1)``
 
-:param n: (n) シフトする行数
+:param n: シフトする行数
 :return: The shifted image"""
         ...
 
     def shift_down(self, n: int) -> Image:
-        """画像を下にシフトした新しいイメージを作成します。 (shift down)
+        """画像を下にシフトした新しいイメージを作成します。
 
 Example: ``Image.HEART_SMALL.shift_down(1)``
 
-:param n: (n) シフトする行数
+:param n: シフトする行数
 :return: The shifted image"""
         ...
 
     def crop(self, x: int, y: int, w: int, h: int) -> Image:
-        """画像をトリミングした新しいイメージを作成します。 (crop)
+        """画像をトリミングした新しいイメージを作成します。
 
 Example: ``Image.HEART.crop(1, 1, 3, 3)``
 
-:param x: (x) トリミングするオフセット列
-:param y: (y) トリミングするオフセット行
-:param w: (w) トリミングする幅
-:param h: (h) トリミングする高さ
+:param x: トリミングするオフセット列
+:param y: トリミングするオフセット行
+:param w: トリミングする幅
+:param h: トリミングする高さ
 :return: The new image"""
         ...
 
     def copy(self) -> Image:
-        """イメージ全体のコピーを作成します。 (copy)
+        """イメージ全体のコピーを作成します。
 
 Example: ``Image.HEART.copy()``
 
@@ -543,7 +543,7 @@ Example: ``Image.HEART.copy()``
         ...
 
     def invert(self) -> Image:
-        """元イメージのピクセルの明るさを反転した新しいイメージ作成します。 (invert)
+        """元イメージのピクセルの明るさを反転した新しいイメージ作成します。
 
 Example: ``Image.SMALL_HEART.invert()``
 
@@ -551,28 +551,28 @@ Example: ``Image.SMALL_HEART.invert()``
         ...
 
     def fill(self, value: int) -> None:
-        """イメージのすべてのピクセルの明るさを設定します。 (fill)
+        """イメージのすべてのピクセルの明るさを設定します。
 
 Example: ``my_image.fill(5)``
 
-:param value: (value) 0（暗い）から 9（明るい）までの数値で新しい明るさを指定します。
+:param value: 0（暗い）から 9（明るい）までの数値で新しい明るさを指定します。
 
 This method will raise an exception when called on any of the built-in
 read-only images, like ``Image.HEART``."""
         ...
 
     def blit(self, src: Image, x: int, y: int, w: int, h: int, xdest: int=0, ydest: int=0) -> None:
-        """このイメージに別のイメージから領域をコピーします。 (blit)
+        """このイメージに別のイメージから領域をコピーします。
 
 Example: ``my_image.blit(Image.HEART, 1, 1, 3, 3, 1, 1)``
 
-:param src: (src) 元イメージ
-:param x: (x) 元イメージの開始列オフセット
-:param y: (y) 元イメージの開始行オフセット
-:param w: (w) コピーする列数
-:param h: (h) コピーする行数
-:param xdest: (xdest) このイメージで変更する列オフセット
-:param ydest: (ydest) このイメージで変更する行オフセット
+:param src: 元イメージ
+:param x: 元イメージの開始列オフセット
+:param y: 元イメージの開始行オフセット
+:param w: コピーする列数
+:param h: コピーする行数
+:param xdest: このイメージで変更する列オフセット
+:param ydest: このイメージで変更する行オフセット
 
 Pixels outside the source image are treated as having a brightness of 0.
 
@@ -588,70 +588,70 @@ For example, img.crop(x, y, w, h) can be implemented as::
         ...
 
     def __repr__(self) -> str:
-        """イメージのコンパクトな文字列表現を取得します。 (repr)"""
+        """イメージのコンパクトな文字列表現を取得します。"""
         ...
 
     def __str__(self) -> str:
-        """イメージの判読可能な文字列表現を取得します。 (str)"""
+        """イメージの判読可能な文字列表現を取得します。"""
         ...
 
     def __add__(self, other: Image) -> Image:
-        """２つのイメージの各ピクセルの明るさを足した新しいイメージを作成します。 (add)
+        """２つのイメージの各ピクセルの明るさを足した新しいイメージを作成します。
 
 Example: ``Image.HEART + Image.HAPPY``
 
-:param other: (other) 加算するイメージ。"""
+:param other: 加算するイメージ。"""
         ...
 
     def __sub__(self, other: Image) -> Image:
-        """このイメージから他のイメージの明るさの値を引いた新しいイメージを作成します。 (sub)
+        """このイメージから他のイメージの明るさの値を引いた新しいイメージを作成します。
 
 Example: ``Image.HEART - Image.HEART_SMALL``
 
-:param other: (other) 減算するイメージ。"""
+:param other: 減算するイメージ。"""
         ...
 
     def __mul__(self, n: float) -> Image:
-        """各ピクセルの明るさを ``n`` 倍した新しいイメージを作成します。 (mul)
+        """各ピクセルの明るさを ``n`` 倍した新しいイメージを作成します。
 
 Example: ``Image.HEART * 0.5``
 
-:param n: (n) 乗算する値。"""
+:param n: 乗算する値。"""
         ...
 
     def __truediv__(self, n: float) -> Image:
-        """各ピクセルの明るさを ``n`` で割った新しいイメージを作成します。 (truediv)
+        """各ピクセルの明るさを ``n`` で割った新しいイメージを作成します。
 
 Example: ``Image.HEART / 2``
 
-:param n: (n) 除算する値。"""
+:param n: 除算する値。"""
         ...
 
 class SoundEvent:
     LOUD: SoundEvent
-    """拍手や叫び声などで ``quiet`` から ``loud`` へのサウンドイベントの変化を表します。 (loud)"""
+    """拍手や叫び声などで ``quiet`` から ``loud`` へのサウンドイベントの変化を表します。"""
     QUIET: SoundEvent
-    """発話やBGMなどで ``loud`` から ``quiet`` へのサウンドイベントの変化を表します。 (quiet)"""
+    """発話やBGMなどで ``loud`` から ``quiet`` へのサウンドイベントの変化を表します。"""
 
 class Sound:
-    """内蔵のサウンドは ``audio.play(Sound.NAME)`` で呼び出すことができます。 (sound)"""
+    """内蔵のサウンドは ``audio.play(Sound.NAME)`` で呼び出すことができます。"""
     GIGGLE: Sound
-    """「くすくす笑う」サウンド。 (giggle)"""
+    """「くすくす笑う」サウンド。"""
     HAPPY: Sound
-    """「ハッピー」サウンド。 (happy)"""
+    """「ハッピー」サウンド。"""
     HELLO: Sound
-    """「ハロー」サウンド (hello)"""
+    """「ハロー」サウンド"""
     MYSTERIOUS: Sound
-    """「ミステリアス」サウンド。 (mysterious)"""
+    """「ミステリアス」サウンド。"""
     SAD: Sound
-    """「悲しい」サウンド。 (sad)"""
+    """「悲しい」サウンド。"""
     SLIDE: Sound
-    """「するする動く」サウンド。 (slide)"""
+    """「するする動く」サウンド。"""
     SOARING: Sound
-    """「舞い上がる」サウンド。 (soaring)"""
+    """「舞い上がる」サウンド。"""
     SPRING: Sound
-    """「バネ」サウンド。 (spring)"""
+    """「バネ」サウンド。"""
     TWINKLE: Sound
-    """「キラキラ」サウンド。 (twinkle)"""
+    """「キラキラ」サウンド。"""
     YAWN: Sound
-    """「あくび」サウンド。 (yawn)"""
+    """「あくび」サウンド。"""

--- a/lang/ja/typeshed/stdlib/microbit/accelerometer.pyi
+++ b/lang/ja/typeshed/stdlib/microbit/accelerometer.pyi
@@ -1,8 +1,8 @@
-"""micro:bitの加速度測定とジェスチャー認識をします。 (accelerometer)"""
+"""micro:bitの加速度測定とジェスチャー認識をします。"""
 from typing import Tuple
 
 def get_x() -> int:
-    """``x`` 軸の加速度測定値をミリg単位で取得します。 (get x)
+    """``x`` 軸の加速度測定値をミリg単位で取得します。
 
 Example: ``accelerometer.get_x()``
 
@@ -10,7 +10,7 @@ Example: ``accelerometer.get_x()``
     ...
 
 def get_y() -> int:
-    """``y`` 軸の加速度測定値をミリg単位で取得します。 (get y)
+    """``y`` 軸の加速度測定値をミリg単位で取得します。
 
 Example: ``accelerometer.get_y()``
 
@@ -18,7 +18,7 @@ Example: ``accelerometer.get_y()``
     ...
 
 def get_z() -> int:
-    """``z`` 軸の加速度測定値をミリg単位で取得します。 (get z)
+    """``z`` 軸の加速度測定値をミリg単位で取得します。
 
 Example: ``accelerometer.get_z()``
 
@@ -26,7 +26,7 @@ Example: ``accelerometer.get_z()``
     ...
 
 def get_values() -> Tuple[int, int, int]:
-    """すべての軸の加速度測定値をタプルとして一度に取得します。 (get values)
+    """すべての軸の加速度測定値をタプルとして一度に取得します。
 
 Example: ``x, y, z = accelerometer.get_values()``
 
@@ -34,7 +34,7 @@ Example: ``x, y, z = accelerometer.get_values()``
     ...
 
 def current_gesture() -> str:
-    """現在のジェスチャーの名前を取得します。 (current gesture)
+    """現在のジェスチャーの名前を取得します。
 
 Example: ``accelerometer.current_gesture()``
 
@@ -47,7 +47,7 @@ represented as strings.
     ...
 
 def is_gesture(name: str) -> bool:
-    """指定した名前のジェスチャーが現在アクティブであるかどうかを確認します。 (is gesture)
+    """指定した名前のジェスチャーが現在アクティブであるかどうかを確認します。
 
 Example: ``accelerometer.is_gesture('shake')``
 
@@ -56,12 +56,12 @@ MicroPython understands the following gesture names: ``"up"``, ``"down"``,
 ``"3g"``, ``"6g"``, ``"8g"``, ``"shake"``. Gestures are always
 represented as strings.
 
-:param name: (name) ジェスチャー名。
+:param name: ジェスチャー名。
 :return: ``True`` if the gesture is active, ``False`` otherwise."""
     ...
 
 def was_gesture(name: str) -> bool:
-    """直前の呼び出し以降に、指定した名前のジェスチャーがアクティブになったかどうかを確認します。 (was gesture)
+    """直前の呼び出し以降に、指定した名前のジェスチャーがアクティブになったかどうかを確認します。
 
 Example: ``accelerometer.was_gesture('shake')``
 
@@ -70,11 +70,11 @@ MicroPython understands the following gesture names: ``"up"``, ``"down"``,
 ``"3g"``, ``"6g"``, ``"8g"``, ``"shake"``. Gestures are always
 represented as strings.
 
-:param name: (name) ジェスチャー名。
+:param name: ジェスチャー名。
 :return: ``True`` if the gesture was active since the last call, ``False`` otherwise."""
 
 def get_gestures() -> Tuple[str, ...]:
-    """ジェスチャー履歴のタプルを返します。 (get gestures)
+    """ジェスチャー履歴のタプルを返します。
 
 Example: ``accelerometer.get_gestures()``
 

--- a/lang/ja/typeshed/stdlib/microbit/audio.pyi
+++ b/lang/ja/typeshed/stdlib/microbit/audio.pyi
@@ -1,20 +1,20 @@
-"""micro:bitでサウンドを再生します（V1との互換のために ``audio`` をインポートしてください）。 (audio)"""
+"""micro:bitでサウンドを再生します（V1との互換のために ``audio`` をインポートしてください）。"""
 from ..microbit import MicroBitDigitalPin, Sound, pin0
 from typing import Iterable, Union
 
 def play(source: Union[Iterable[AudioFrame], Sound], wait: bool=True, pin: MicroBitDigitalPin=pin0, return_pin: Union[MicroBitDigitalPin, None]=None) -> None:
-    """内蔵のサウンドまたはカスタムオーディオフレームを再生します。 (play)
+    """内蔵のサウンドまたはカスタムオーディオフレームを再生します。
 
 Example: ``audio.play(Sound.GIGGLE)``
 
-:param source: (source) ``Sound.GIGGLE`` などの内蔵 ``Sound``、または ``AudioFrame`` オブジェクトのイテラブルとしてのサンプルデータ。
-:param wait: (wait) ``wait`` が ``True`` の場合、サウンドの再生が終わるまでこの関数がブロックします。
+:param source: ``Sound.GIGGLE`` などの内蔵 ``Sound``、または ``AudioFrame`` オブジェクトのイテラブルとしてのサンプルデータ。
+:param wait: ``wait`` が ``True`` の場合、サウンドの再生が終わるまでこの関数がブロックします。
 :param pin: (ピン) 出力端子をデフォルトの ``pin0`` から変えるためのオプション引数です。音を鳴らしたくない場合は ``pin=None`` を指定します。
-:param return_pin: (return pin) グランドではなく外部スピーカーに接続する差動エッジコネクタの端子
+:param return_pin: グランドではなく外部スピーカーに接続する差動エッジコネクタの端子
 を指定します。**V2** ではこの指定を無視します。"""
 
 def is_playing() -> bool:
-    """オーディオが再生中であるかどうかを確認します。 (is playing)
+    """オーディオが再生中であるかどうかを確認します。
 
 Example: ``audio.is_playing()``
 
@@ -22,13 +22,13 @@ Example: ``audio.is_playing()``
     ...
 
 def stop() -> None:
-    """すべてのオーディオ再生を停止します。 (stop)
+    """すべてのオーディオ再生を停止します。
 
 Example: ``audio.stop()``"""
     ...
 
 class AudioFrame:
-    """``AudioFrame`` オブジェクトは32個のサンプルからなるリストです。それぞのサンプルは符号なしバイト（0〜255の整数）です。 (audioframe)
+    """``AudioFrame`` オブジェクトは32個のサンプルからなるリストです。それぞのサンプルは符号なしバイト（0〜255の整数）です。
 
 It takes just over 4 ms to play a single frame.
 

--- a/lang/ja/typeshed/stdlib/microbit/compass.pyi
+++ b/lang/ja/typeshed/stdlib/microbit/compass.pyi
@@ -1,7 +1,7 @@
 """内蔵のコンパスを使います。 (方位磁針（コンパス）)"""
 
 def calibrate() -> None:
-    """調整処理を開始します。 (calibrate)
+    """調整処理を開始します。
 
 Example: ``compass.calibrate()``
 
@@ -10,7 +10,7 @@ to rotate the device in order to draw a circle on the LED display."""
     ...
 
 def is_calibrated() -> bool:
-    """コンパスが調整されているかどうかを確認します。 (is calibrated)
+    """コンパスが調整されているかどうかを確認します。
 
 Example: ``compass.is_calibrated()``
 
@@ -18,13 +18,13 @@ Example: ``compass.is_calibrated()``
     ...
 
 def clear_calibration() -> None:
-    """調整を取り消し、コンパスを未調整状態にします。 (clear calibration)
+    """調整を取り消し、コンパスを未調整状態にします。
 
 Example: ``compass.clear_calibration()``"""
     ...
 
 def get_x() -> int:
-    """``x`` 軸の磁場強度を取得します。 (get x)
+    """``x`` 軸の磁場強度を取得します。
 
 Example: ``compass.get_x()``
 
@@ -34,7 +34,7 @@ Call ``calibrate`` first or the results will be inaccurate.
     ...
 
 def get_y() -> int:
-    """``y`` 軸の磁場強度を取得します。 (get y)
+    """``y`` 軸の磁場強度を取得します。
 
 Example: ``compass.get_y()``
 
@@ -44,7 +44,7 @@ Call ``calibrate`` first or the results will be inaccurate.
     ...
 
 def get_z() -> int:
-    """``z`` 軸の磁場強度を取得します。 (get z)
+    """``z`` 軸の磁場強度を取得します。
 
 Example: ``compass.get_z()``
 
@@ -54,7 +54,7 @@ Call ``calibrate`` first or the results will be inaccurate.
     ...
 
 def heading() -> int:
-    """コンパスの方位を取得します。 (heading)
+    """コンパスの方位を取得します。
 
 Example: ``compass.heading()``
 
@@ -62,7 +62,7 @@ Example: ``compass.heading()``
     ...
 
 def get_field_strength() -> int:
-    """デバイスのまわりの磁場の強さを取得します。 (get field strength)
+    """デバイスのまわりの磁場の強さを取得します。
 
 Example: ``compass.get_field_strength()``
 

--- a/lang/ja/typeshed/stdlib/microbit/display.pyi
+++ b/lang/ja/typeshed/stdlib/microbit/display.pyi
@@ -1,79 +1,79 @@
-"""5×5 LED ディスプレイ上にテキスト、イメージ、アニメーションを表示します。 (display)"""
+"""5×5 LED ディスプレイ上にテキスト、イメージ、アニメーションを表示します。"""
 from ..microbit import Image
 from typing import Union, overload, Iterable
 
 def get_pixel(x: int, y: int) -> int:
-    """``x`` 列 ``y`` 行の LEDの明るさを取得します。 (get pixel)
+    """``x`` 列 ``y`` 行の LEDの明るさを取得します。
 
 Example: ``display.get_pixel(0, 0)``
 
-:param x: (x) ディスプレイの列 (0..4)
-:param y: (y) ディスプレイの行 (0..4)
+:param x: ディスプレイの列 (0..4)
+:param y: ディスプレイの行 (0..4)
 :return: A number between 0 (off) and 9 (bright)"""
     ...
 
 def set_pixel(x: int, y: int, value: int) -> None:
-    """``x`` 列 ``y`` 行の LEDの明るさを設定します。  (set pixel)
+    """``x`` 列 ``y`` 行の LEDの明るさを設定します。
 
 Example: ``display.set_pixel(0, 0, 9)``
 
-:param x: (x) ディスプレイの列 (0..4)
-:param y: (y) ディスプレイの行 (0..4)
-:param value: (value) 0（オフ）から 9（明るい）までの明るさ"""
+:param x: ディスプレイの列 (0..4)
+:param y: ディスプレイの行 (0..4)
+:param value: 0（オフ）から 9（明るい）までの明るさ"""
     ...
 
 def clear() -> None:
-    """すべての LED の明るさを 0（オフ）に設定します。 (clear)
+    """すべての LED の明るさを 0（オフ）に設定します。
 
 Example: ``display.clear()``"""
     ...
 
 def show(image: Union[str, float, int, Image, Iterable[Image]], delay: int=400, wait: bool=True, loop: bool=False, clear: bool=False) -> None:
-    """イメージ、文字、数字をLEDディスプレイに表示します。 (show)
+    """イメージ、文字、数字をLEDディスプレイに表示します。
 
 Example: ``display.show(Image.HEART)``
 
 When ``image`` is an image or a list of images then each image is displayed in turn.
 If ``image`` is a string or number, each letter or digit is displayed in turn.
 
-:param image: (image) 表示する文字列、数値、イメージ、イメージのリスト。
-:param delay: (delay) それぞれの文字、数字、イメージは ``delay`` ミリ秒間隔で表示されます。
-:param wait: (wait) ``wait`` が ``True`` である場合、アニメーションが終了するまで関数がブロックし、 そうでない場合にはバックグラウンドで実行されます。
-:param loop: (loop) ``loop`` が ``True`` である場合、アニメーションを永遠に繰り返します。
-:param clear: (clear) ``clear`` が ``True`` である場合、シーケンスの終了後にディスプレイをクリアします。
+:param image: 表示する文字列、数値、イメージ、イメージのリスト。
+:param delay: それぞれの文字、数字、イメージは ``delay`` ミリ秒間隔で表示されます。
+:param wait: ``wait`` が ``True`` である場合、アニメーションが終了するまで関数がブロックし、 そうでない場合にはバックグラウンドで実行されます。
+:param loop: ``loop`` が ``True`` である場合、アニメーションを永遠に繰り返します。
+:param clear: ``clear`` が ``True`` である場合、シーケンスの終了後にディスプレイをクリアします。
 
 The ``wait``, ``loop`` and ``clear`` arguments must be specified using their keyword."""
     ...
 
 def scroll(text: Union[str, float, int], delay: int=150, wait: bool=True, loop: bool=False, monospace: bool=False) -> None:
-    """LEDディスプレィ上に数値やテキストをスクロール表示します。 (scroll)
+    """LEDディスプレィ上に数値やテキストをスクロール表示します。
 
 Example: ``display.scroll('micro:bit')``
 
-:param text: (text) スクロールする文字列。``text`` が整数か浮動小数点数であれば、まず ``str()`` を使って文字列に変換します。
-:param delay: (delay) ``delay`` パラメータはテキストのスクロール速度を制御します。
-:param wait: (wait) ``wait`` が ``True`` である場合、アニメーションが終了するまで関数がブロックし、 そうでない場合にはバックグラウンドで実行されます。
-:param loop: (loop) ``loop`` が ``True`` である場合、アニメーションを永遠に繰り返します。
-:param monospace: (monospace) ``monospace`` が ``True`` である場合、文字の幅が 5 ピクセルになり、そうでない場合にはスクロール時の文字間の幅が 1 ピクセルになります。
+:param text: スクロールする文字列。``text`` が整数か浮動小数点数であれば、まず ``str()`` を使って文字列に変換します。
+:param delay: ``delay`` パラメータはテキストのスクロール速度を制御します。
+:param wait: ``wait`` が ``True`` である場合、アニメーションが終了するまで関数がブロックし、 そうでない場合にはバックグラウンドで実行されます。
+:param loop: ``loop`` が ``True`` である場合、アニメーションを永遠に繰り返します。
+:param monospace: ``monospace`` が ``True`` である場合、文字の幅が 5 ピクセルになり、そうでない場合にはスクロール時の文字間の幅が 1 ピクセルになります。
 
 The ``wait``, ``loop`` and ``monospace`` arguments must be specified
 using their keyword."""
     ...
 
 def on() -> None:
-    """ディスプレイをオンにします。 (on)
+    """ディスプレイをオンにします。
 
 Example: ``display.on()``"""
     ...
 
 def off() -> None:
-    """LEDディスプレイをオフにします（ディスプレイを無効にすることにより、GPIO端子を他の目的に再利用できるようになります）。 (off)
+    """LEDディスプレイをオフにします（ディスプレイを無効にすることにより、GPIO端子を他の目的に再利用できるようになります）。
 
 Example: ``display.off()``"""
     ...
 
 def is_on() -> bool:
-    """LEDディスプレイが有効であるかどうかを確認します。 (is on)
+    """LEDディスプレイが有効であるかどうかを確認します。
 
 Example: ``display.is_on()``
 
@@ -81,7 +81,7 @@ Example: ``display.is_on()``
     ...
 
 def read_light_level() -> int:
-    """ディスプレイのまわりの光量を読み取ります。 (read light level)
+    """ディスプレイのまわりの光量を読み取ります。
 
 Example: ``display.read_light_level()``
 

--- a/lang/ja/typeshed/stdlib/microbit/i2c.pyi
+++ b/lang/ja/typeshed/stdlib/microbit/i2c.pyi
@@ -1,16 +1,16 @@
-"""I²C バスプロトコルでデバイスと通信します。 (i2c)"""
+"""I²C バスプロトコルでデバイスと通信します。"""
 from _typeshed import ReadableBuffer
 from ..microbit import MicroBitDigitalPin, pin19, pin20
 from typing import List
 
 def init(freq: int=100000, sda: MicroBitDigitalPin=pin20, scl: MicroBitDigitalPin=pin19) -> None:
-    """ペリフェラルを再初期化します。 (init)
+    """ペリフェラルを再初期化します。
 
 Example: ``i2c.init()``
 
-:param freq: (freq) クロック周波数
-:param sda: (sda) ``sda`` 端子（デフォルトは 20）
-:param scl: (scl) ``scl`` 端子（デフォルトは 19）
+:param freq: クロック周波数
+:param sda: ``sda`` 端子（デフォルトは 20）
+:param scl: ``scl`` 端子（デフォルトは 19）
 
 On a micro:bit V1 board, changing the I²C pins from defaults will make
 the accelerometer and compass stop working, as they are connected
@@ -20,7 +20,7 @@ for the motion sensors and the edge connector."""
     ...
 
 def scan() -> List[int]:
-    """バスをスキャンしてデバイスを探します。 (scan)
+    """バスをスキャンしてデバイスを探します。
 
 Example: ``i2c.scan()``
 
@@ -28,22 +28,22 @@ Example: ``i2c.scan()``
     ...
 
 def read(addr: int, n: int, repeat: bool=False) -> bytes:
-    """デバイスからバイト列を読み取ります。 (read)
+    """デバイスからバイト列を読み取ります。
 
 Example: ``i2c.read(0x50, 64)``
 
-:param addr: (addr) デバイスの7ビットアドレス
-:param n: (n) 読み取るバイト数
-:param repeat: (repeat) ``True`` にすると、ストップビットが送られません。
+:param addr: デバイスの7ビットアドレス
+:param n: 読み取るバイト数
+:param repeat: ``True`` にすると、ストップビットが送られません。
 :return: The bytes read"""
     ...
 
 def write(addr: int, buf: ReadableBuffer, repeat: bool=False) -> None:
-    """デバイスにバイト列を書き込みます。 (write)
+    """デバイスにバイト列を書き込みます。
 
 Example: ``i2c.write(0x50, bytes([1, 2, 3]))``
 
-:param addr: (addr) デバイスの7ビットアドレス
-:param buf: (buf) 書き込むバイトを含むバッファ
-:param repeat: (repeat) ``True`` にすると、ストップビットが送られません。"""
+:param addr: デバイスの7ビットアドレス
+:param buf: 書き込むバイトを含むバッファ
+:param repeat: ``True`` にすると、ストップビットが送られません。"""
     ...

--- a/lang/ja/typeshed/stdlib/microbit/microphone.pyi
+++ b/lang/ja/typeshed/stdlib/microbit/microphone.pyi
@@ -1,9 +1,9 @@
-"""内蔵マイクを使って音に応答します（V2 のみ）。 (microphone)"""
+"""内蔵マイクを使って音に応答します（V2 のみ）。"""
 from typing import Optional, Tuple
 from ..microbit import SoundEvent
 
 def current_event() -> Optional[SoundEvent]:
-    """記録されている最新のサウンドイベントを取得します。 (current event)
+    """記録されている最新のサウンドイベントを取得します。
 
 Example: ``microphone.current_event()``
 
@@ -11,29 +11,29 @@ Example: ``microphone.current_event()``
     ...
 
 def was_event(event: SoundEvent) -> bool:
-    """直前の呼び出しから少なくとも一度はサウンドイベントが発生したかどうかを確認します。 (was event)
+    """直前の呼び出しから少なくとも一度はサウンドイベントが発生したかどうかを確認します。
 
 Example: ``microphone.was_event(SoundEvent.LOUD)``
 
 This call clears the sound history before returning.
 
-:param event: (event) ``SoundEvent.LOUD`` や ``SoundEvent.QUIET`` などのイベント
+:param event: ``SoundEvent.LOUD`` や ``SoundEvent.QUIET`` などのイベント
 :return: ``True`` if sound was heard at least once since the last call, otherwise ``False``."""
     ...
 
 def is_event(event: SoundEvent) -> bool:
-    """直近に検出されたサウンドイベントを確認します。 (is event)
+    """直近に検出されたサウンドイベントを確認します。
 
 Example: ``microphone.is_event(SoundEvent.LOUD)``
 
 This call does not clear the sound event history.
 
-:param event: (event) ``SoundEvent.LOUD`` や ``SoundEvent.QUIET`` など、確認するサウンドイベント
+:param event: ``SoundEvent.LOUD`` や ``SoundEvent.QUIET`` など、確認するサウンドイベント
 :return: ``True`` if sound was the most recent heard, ``False`` otherwise."""
     ...
 
 def get_events() -> Tuple[SoundEvent, ...]:
-    """サウンドイベント履歴をタプルとして取得します。 (get events)
+    """サウンドイベント履歴をタプルとして取得します。
 
 Example: ``microphone.get_events()``
 
@@ -43,18 +43,18 @@ This call clears the sound history before returning.
     ...
 
 def set_threshold(event: SoundEvent, value: int) -> None:
-    """サウンドイベントのしきい値を設定します。 (set threshold)
+    """サウンドイベントのしきい値を設定します。
 
 Example: ``microphone.set_threshold(SoundEvent.LOUD, 250)``
 
 A high threshold means the event will only trigger if the sound is very loud (>= 250 in the example).
 
-:param event: (event) ``SoundEvent.LOUD`` や ``SoundEvent.QUIET`` などのサウンドイベント。
-:param value: (value) 0～255の範囲で指定するしきい値レベル。"""
+:param event: ``SoundEvent.LOUD`` や ``SoundEvent.QUIET`` などのサウンドイベント。
+:param value: 0～255の範囲で指定するしきい値レベル。"""
     ...
 
 def sound_level() -> int:
-    """音圧レベルを取得します。 (sound level)
+    """音圧レベルを取得します。
 
 Example: ``microphone.sound_level()``
 

--- a/lang/ja/typeshed/stdlib/microbit/speaker.pyi
+++ b/lang/ja/typeshed/stdlib/microbit/speaker.pyi
@@ -1,7 +1,7 @@
-"""内蔵スピーカーを制御します（V2のみ）。 (speaker)"""
+"""内蔵スピーカーを制御します（V2のみ）。"""
 
 def off() -> None:
-    """スピーカーをオフにします。 (off)
+    """スピーカーをオフにします。
 
 Example: ``speaker.off()``
 
@@ -9,7 +9,7 @@ This does not disable sound output to an edge connector pin."""
     ...
 
 def on() -> None:
-    """スピーカーをオンにします。 (on)
+    """スピーカーをオンにします。
 
 Example: ``speaker.on()``"""
     ...

--- a/lang/ja/typeshed/stdlib/microbit/spi.pyi
+++ b/lang/ja/typeshed/stdlib/microbit/spi.pyi
@@ -1,46 +1,46 @@
-"""シリアルペリフェラルインターフェイス（SPI）バスを使ってデバイスと通信します。 (spi)"""
+"""シリアルペリフェラルインターフェイス（SPI）バスを使ってデバイスと通信します。"""
 from _typeshed import ReadableBuffer, WriteableBuffer
 from ..microbit import pin13, pin14, pin15, MicroBitDigitalPin
 
 def init(baudrate: int=1000000, bits: int=8, mode: int=0, sclk: MicroBitDigitalPin=pin13, mosi: MicroBitDigitalPin=pin15, miso: MicroBitDigitalPin=pin14) -> None:
-    """SPI通信を初期化します。 (init)
+    """SPI通信を初期化します。
 
 Example: ``spi.init()``
 
 For correct communication, the parameters have to be the same on both communicating devices.
 
-:param baudrate: (baudrate) 通信速度。
-:param bits: (bits) 送信時のビット幅。現在のところは ``bits=8`` だけをサポート。しかし、これは将来的に変更するかもしれません。
-:param mode: (mode) クロックの極性と位相の組み合わせを決定します - `オンラインの表を参照 <https://microbit-micropython.readthedocs.io/ja/v2-docs/spi.html#microbit.spi.init>`_ 。
-:param sclk: (sclk) sclk 端子（デフォルトは 13）
-:param mosi: (mosi) mosi 端子（デフォルトは 15）
-:param miso: (miso) miso 端子（デフォルトは 14）"""
+:param baudrate: 通信速度。
+:param bits: 送信時のビット幅。現在のところは ``bits=8`` だけをサポート。しかし、これは将来的に変更するかもしれません。
+:param mode: クロックの極性と位相の組み合わせを決定します - `オンラインの表を参照 <https://microbit-micropython.readthedocs.io/ja/v2-docs/spi.html#microbit.spi.init>`_ 。
+:param sclk: sclk 端子（デフォルトは 13）
+:param mosi: mosi 端子（デフォルトは 15）
+:param miso: miso 端子（デフォルトは 14）"""
     ...
 
 def read(nbytes: int) -> bytes:
-    """バイト列を読み取ります。 (read)
+    """バイト列を読み取ります。
 
 Example: ``spi.read(64)``
 
-:param nbytes: (nbytes) 読み取る最大バイト数。
+:param nbytes: 読み取る最大バイト数。
 :return: The bytes read."""
     ...
 
 def write(buffer: ReadableBuffer) -> None:
-    """デバイスにバイト列を書き込みます。 (write)
+    """デバイスにバイト列を書き込みます。
 
 Example: ``spi.write(bytes([1, 2, 3]))``
 
-:param buffer: (buffer) データの読み取り元のバッファ。"""
+:param buffer: データの読み取り元のバッファ。"""
     ...
 
 def write_readinto(out: WriteableBuffer, in_: ReadableBuffer) -> None:
-    """``out`` バッファをバスに書き込み、任意のレスポンスを ``in_`` バッファに読み取ります。 (write readinto)
+    """``out`` バッファをバスに書き込み、任意のレスポンスを ``in_`` バッファに読み取ります。
 
 Example: ``spi.write_readinto(out_buffer, in_buffer)``
 
 The length of the buffers should be the same. The buffers can be the same object.
 
-:param out: (out) レスポンスの書き込みバッファ。
-:param in_: (in) データの読み取り元のバッファ。"""
+:param out: レスポンスの書き込みバッファ。
+:param in_: データの読み取り元のバッファ。"""
     ...

--- a/lang/ja/typeshed/stdlib/microbit/uart.pyi
+++ b/lang/ja/typeshed/stdlib/microbit/uart.pyi
@@ -1,23 +1,23 @@
-"""シリアルインタフェースを使ってデバイスと通信します。 (uart)"""
+"""シリアルインタフェースを使ってデバイスと通信します。"""
 from _typeshed import WriteableBuffer
 from ..microbit import MicroBitDigitalPin
 from typing import Optional, Union
 ODD: int
-"""奇数パリティ (odd)"""
+"""奇数パリティ"""
 EVEN: int
-"""偶数パリティ (even)"""
+"""偶数パリティ"""
 
 def init(baudrate: int=9600, bits: int=8, parity: Optional[int]=None, stop: int=1, tx: Optional[MicroBitDigitalPin]=None, rx: Optional[MicroBitDigitalPin]=None) -> None:
-    """シリアル通信を初期化します。 (init)
+    """シリアル通信を初期化します。
 
 Example: ``uart.init(115200, tx=pin0, rx=pin1)``
 
-:param baudrate: (baudrate) 通信速度。
-:param bits: (bits) 送信するビット幅。micro:bitは8だけをサポートしています。
-:param parity: (parity) パリティのチェック方法。``None``、``uart.ODD``、``uart.EVEN`` のいずれかを指定できます。
-:param stop: (stop) ストップビットの数はmicro:bitでは1にする必要があります。
-:param tx: (tx) 送信端子。
-:param rx: (rx) 受信端子。
+:param baudrate: 通信速度。
+:param bits: 送信するビット幅。micro:bitは8だけをサポートしています。
+:param parity: パリティのチェック方法。``None``、``uart.ODD``、``uart.EVEN`` のいずれかを指定できます。
+:param stop: ストップビットの数はmicro:bitでは1にする必要があります。
+:param tx: 送信端子。
+:param rx: 受信端子。
 
 Initializing the UART on external pins will cause the Python console on
 USB to become unaccessible, as it uses the same hardware. To bring the
@@ -29,7 +29,7 @@ For more details see `the online documentation <https://microbit-micropython.rea
     ...
 
 def any() -> bool:
-    """受信待ちのデータがあるかを確認します。 (any)
+    """受信待ちのデータがあるかを確認します。
 
 Example: ``uart.any()``
 
@@ -37,26 +37,26 @@ Example: ``uart.any()``
     ...
 
 def read(nbytes: Optional[int]=None) -> Optional[bytes]:
-    """バイト列を読み取ります。 (read)
+    """バイト列を読み取ります。
 
 Example: ``uart.read()``
 
-:param nbytes: (nbytes) ``nbytes`` が指定されていれば、そのバイト数まで読み込みます。指定されていなければ、できるだけ多く読み取ります
+:param nbytes: ``nbytes`` が指定されていれば、そのバイト数まで読み込みます。指定されていなければ、できるだけ多く読み取ります
 :return: A bytes object or ``None`` on timeout"""
     ...
 
 def readinto(buf: WriteableBuffer, nbytes: Optional[int]=None) -> Optional[int]:
-    """``buf`` にバイト列を読み取ります。 (readinto)
+    """``buf`` にバイト列を読み取ります。
 
 Example: ``uart.readinto(input_buffer)``
 
-:param buf: (buf) 書き込みバッファ。
-:param nbytes: (nbytes) ``nbytes`` が指定されていれば、そのバイト数まで読み込みます。指定されていなければ、``len(buf)`` を読み取ります。
+:param buf: 書き込みバッファ。
+:param nbytes: ``nbytes`` が指定されていれば、そのバイト数まで読み込みます。指定されていなければ、``len(buf)`` を読み取ります。
 :return: number of bytes read and stored into ``buf`` or ``None`` on timeout."""
     ...
 
 def readline() -> Optional[bytes]:
-    """改行文字で終わる行を読みます。 (readline)
+    """改行文字で終わる行を読みます。
 
 Example: ``uart.readline()``
 
@@ -64,11 +64,11 @@ Example: ``uart.readline()``
     ...
 
 def write(buf: Union[bytes, str]) -> Optional[int]:
-    """バスにバッファを書き込みます。 (write)
+    """バスにバッファを書き込みます。
 
 Example: ``uart.write('hello world')``
 
-:param buf: (buf) バイト列オブジェクトまたは文字列。
+:param buf: バイト列オブジェクトまたは文字列。
 :return: The number of bytes written, or ``None`` on timeout.
 
 Examples::

--- a/lang/ja/typeshed/stdlib/micropython.pyi
+++ b/lang/ja/typeshed/stdlib/micropython.pyi
@@ -1,9 +1,9 @@
-"""MicroPythonの内部。 (micropython)"""
+"""MicroPythonの内部。"""
 from typing import Any, TypeVar, overload
 _T = TypeVar('_T')
 
 def const(expr: _T) -> _T:
-    """コンパイルが最適化できるように、式が定数であることを宣言するために使います。 (const)
+    """コンパイルが最適化できるように、式が定数であることを宣言するために使います。
 
 The use of this function should be as follows::
 
@@ -16,12 +16,12 @@ outside the module they are declared in. On the other hand, if a constant
 begins with an underscore then it is hidden, it is not available as a
 global variable, and does not take up any memory during execution.
 
-:param expr: (expr) 定数式。"""
+:param expr: 定数式。"""
     ...
 
 @overload
 def opt_level() -> int:
-    """スクリプトの現在のコンパイル最適化レベルを取得します。 (opt level)
+    """スクリプトの現在のコンパイル最適化レベルを取得します。
 
 Example: ``micropython.opt_level()``
 
@@ -43,7 +43,7 @@ The optimisation level controls the following compilation features:
 
 @overload
 def opt_level(level: int) -> None:
-    """スクリプトの後続のコンパイル最適化レベルを設定します。 (opt level)
+    """スクリプトの後続のコンパイル最適化レベルを設定します。
 
 Example: ``micropython.opt_level(1)``
 
@@ -62,23 +62,23 @@ The optimisation level controls the following compilation features:
 
 The default optimisation level is usually level 0.
 
-:param level: (level) 最適化レベルを示す整数値。"""
+:param level: 最適化レベルを示す整数値。"""
     ...
 
 def mem_info(verbose: Any=None) -> None:
-    """現在使っているメモリに関する情報を表示します。  (mem info)
+    """現在使っているメモリに関する情報を表示します。
 
 Example: ``micropython.mem_info()``
 
-:param verbose: (verbose) ``verbose`` 引数を指定すると、詳しい情報を表示します。"""
+:param verbose: ``verbose`` 引数を指定すると、詳しい情報を表示します。"""
     ...
 
 def qstr_info(verbose: Any=None) -> None:
-    """現在インターンされている文字列に関する情報を表示します。  (qstr info)
+    """現在インターンされている文字列に関する情報を表示します。
 
 Example: ``micropython.qstr_info()``
 
-:param verbose: (verbose) ``verbose`` 引数を指定すると、詳しい情報を表示します。
+:param verbose: ``verbose`` 引数を指定すると、詳しい情報を表示します。
 
 The information that is printed is implementation dependent, but currently
 includes the number of interned strings and the amount of RAM they use.  In
@@ -86,7 +86,7 @@ verbose mode it prints out the names of all RAM-interned strings."""
     ...
 
 def stack_use() -> int:
-    """現在使われているスタックのサイズを表す整数を返します。 (stack use)
+    """現在使われているスタックのサイズを表す整数を返します。
 
 Example: ``micropython.stack_use()``
 
@@ -97,7 +97,7 @@ should be used to compute differences in stack usage at different points.
     ...
 
 def heap_lock() -> None:
-    """ヒープをロックします。 (heap lock)
+    """ヒープをロックします。
 
 Example: ``micropython.heap_lock()``
 
@@ -106,7 +106,7 @@ raised if any heap allocation is attempted."""
     ...
 
 def heap_unlock() -> None:
-    """ヒープのロックを解除します。 (heap unlock)
+    """ヒープのロックを解除します。
 
 Example: ``micropython.heap_unlock()``
 
@@ -115,11 +115,11 @@ raised if any heap allocation is attempted."""
     ...
 
 def kbd_intr(chr: int) -> None:
-    """``KeyboardInterrupt`` 例外を発生させる文字を設定します。 (kbd intr)
+    """``KeyboardInterrupt`` 例外を発生させる文字を設定します。
 
 Example: ``micropython.kbd_intr(-1)``
 
-:param chr: (chr) 割り込みを発生させる文字コード。あるいは、Ctrl-Cのキャプチャを無効にするには-1を指定します。
+:param chr: 割り込みを発生させる文字コード。あるいは、Ctrl-Cのキャプチャを無効にするには-1を指定します。
 
 By default this is set to 3 during script execution, corresponding to Ctrl-C.
 Passing -1 to this function will disable capture of Ctrl-C, and passing 3

--- a/lang/ja/typeshed/stdlib/music.pyi
+++ b/lang/ja/typeshed/stdlib/music.pyi
@@ -1,64 +1,64 @@
-"""メロディーの作成と再生。 (music)"""
+"""メロディーの作成と再生。"""
 from typing import Tuple, Union, List
 from .microbit import MicroBitDigitalPin, pin0
 DADADADUM: Tuple[str, ...]
-"""メロディ: ベートーヴェンの交響曲第5番ハ短調の冒頭。 (dadadadum)"""
+"""メロディ: ベートーヴェンの交響曲第5番ハ短調の冒頭。"""
 ENTERTAINER: Tuple[str, ...]
-"""メロディ: スコット・ジョプリンのラグタイム・クラシック『ジ・エンターテイナー 』の冒頭。 (entertainer)"""
+"""メロディ: スコット・ジョプリンのラグタイム・クラシック『ジ・エンターテイナー 』の冒頭。"""
 PRELUDE: Tuple[str, ...]
-"""メロディ: J・S・バッハの前奏曲とフーガ計48曲の前奏曲第1番ハ長調の冒頭。 (prelude)"""
+"""メロディ: J・S・バッハの前奏曲とフーガ計48曲の前奏曲第1番ハ長調の冒頭。"""
 ODE: Tuple[str, ...]
-"""メロディ: ベートーヴェンの交響曲第9番ニ短調より『歓喜の歌』のテーマ。 (ode)"""
+"""メロディ: ベートーヴェンの交響曲第9番ニ短調より『歓喜の歌』のテーマ。"""
 NYAN: Tuple[str, ...]
-"""メロディ: Nyan Cat テーマ (http://www.nyan.cat/)。 (nyan)
+"""メロディ: Nyan Cat テーマ (http://www.nyan.cat/)。
 
 The composer is unknown. This is fair use for educational porpoises (as they say in New York)."""
 RINGTONE: Tuple[str, ...]
-"""メロディ: 携帯電話の着信音のようなもの。 (ringtone)
+"""メロディ: 携帯電話の着信音のようなもの。
 
 To be used to indicate an incoming message.
 """
 FUNK: Tuple[str, ...]
-"""メロディ: スパイと犯罪の黒幕用のファンキーなベースライン。 (funk)"""
+"""メロディ: スパイと犯罪の黒幕用のファンキーなベースライン。"""
 BLUES: Tuple[str, ...]
-"""メロディ: ブギー・ウーギーの 12 小節のブルース・ウォーキング・ベース。 (blues)"""
+"""メロディ: ブギー・ウーギーの 12 小節のブルース・ウォーキング・ベース。"""
 BIRTHDAY: Tuple[str, ...]
-"""メロディ:『ハッピーバースディトゥユー ...』 (birthday)
+"""メロディ:『ハッピーバースディトゥユー ...』
 
 For copyright status see: http://www.bbc.co.uk/news/world-us-canada-34332853
 """
 WEDDING: Tuple[str, ...]
-"""メロディ: ワグナーのオペラ『ローエングリン』より婚礼の合唱。 (wedding)"""
+"""メロディ: ワグナーのオペラ『ローエングリン』より婚礼の合唱。"""
 FUNERAL: Tuple[str, ...]
-"""メロディ: フレデリック・ショパンのピアノソナタ第2番変ロ短調 作品35（別名『葬送』）。 (funeral)"""
+"""メロディ: フレデリック・ショパンのピアノソナタ第2番変ロ短調 作品35（別名『葬送』）。"""
 PUNCHLINE: Tuple[str, ...]
-"""メロディ: ジョークが言われたことを意味する楽しい音楽。 (punchline)"""
+"""メロディ: ジョークが言われたことを意味する楽しい音楽。"""
 PYTHON: Tuple[str, ...]
-"""メロディ: ジョン・フィリップ・スーザの『自由の鐘』（『空飛ぶモンティ・パイソン』のテーマともいう）（プログラミング言語Pythonの名前の由来となった）。 (python)"""
+"""メロディ: ジョン・フィリップ・スーザの『自由の鐘』（『空飛ぶモンティ・パイソン』のテーマともいう）（プログラミング言語Pythonの名前の由来となった）。"""
 BADDY: Tuple[str, ...]
-"""メロディ: 無声映画時代の悪役の登場。 (baddy)"""
+"""メロディ: 無声映画時代の悪役の登場。"""
 CHASE: Tuple[str, ...]
-"""メロディ: 無声映画時代のチェイスシーン。 (chase)"""
+"""メロディ: 無声映画時代のチェイスシーン。"""
 BA_DING: Tuple[str, ...]
-"""メロディ: 何かが起こったことを示す短い信号。 (ba ding)"""
+"""メロディ: 何かが起こったことを示す短い信号。"""
 WAWAWAWAA: Tuple[str, ...]
-"""メロディ: 非常に悲しいトロンボーン。 (wawawawaa)"""
+"""メロディ: 非常に悲しいトロンボーン。"""
 JUMP_UP: Tuple[str, ...]
-"""メロディ: ゲームでの使用で、上方向の動きを示します。 (jump up)"""
+"""メロディ: ゲームでの使用で、上方向の動きを示します。"""
 JUMP_DOWN: Tuple[str, ...]
-"""メロディ: ゲームでの使用で、下向きの動きを示します。 (jump down)"""
+"""メロディ: ゲームでの使用で、下向きの動きを示します。"""
 POWER_UP: Tuple[str, ...]
-"""メロディ: アチーブメントを達成したことを示すファンファーレ。 (power up)"""
+"""メロディ: アチーブメントを達成したことを示すファンファーレ。"""
 POWER_DOWN: Tuple[str, ...]
-"""メロディ: アチーブメントを達成しなかったことを示すファンファーレ。 (power down)"""
+"""メロディ: アチーブメントを達成しなかったことを示すファンファーレ。"""
 
 def set_tempo(ticks: int=4, bpm: int=120) -> None:
-    """再生するためのおおよそのテンポを設定します。 (set tempo)
+    """再生するためのおおよそのテンポを設定します。
 
 Example: ``music.set_tempo(bpm=120)``
 
-:param ticks: (ticks) 1ビートを構成するティック数。
-:param bpm: (bpm) 毎分のビート数を決定する整数。
+:param ticks: 1ビートを構成するティック数。
+:param bpm: 毎分のビート数を決定する整数。
 
 Suggested default values allow the following useful behaviour:
 
@@ -72,7 +72,7 @@ To work out the length of a tick in milliseconds is very simple arithmetic:
     ...
 
 def get_tempo() -> Tuple[int, int]:
-    """現在のテンポを整数のタプル ``(ticks, bpm)`` として取得します。 (get tempo)
+    """現在のテンポを整数のタプル ``(ticks, bpm)`` として取得します。
 
 Example: ``ticks, beats = music.get_tempo()``
 
@@ -80,27 +80,27 @@ Example: ``ticks, beats = music.get_tempo()``
     ...
 
 def play(music: Union[str, List[str], Tuple[str, ...]], pin: Union[MicroBitDigitalPin, None]=pin0, wait: bool=True, loop: bool=False) -> None:
-    """ミュージックを再生します。 (play)
+    """ミュージックを再生します。
 
 Example: ``music.play(music.NYAN)``
 
-:param music: (music) `特別な表記 <https://microbit-micropython.readthedocs.io/ja/v2-docs/music.html#musical-notation>`_ で指定されたミュージック
+:param music: `特別な表記 <https://microbit-micropython.readthedocs.io/ja/v2-docs/music.html#musical-notation>`_ で指定されたミュージック
 :param pin: (ピン) 外部スピーカー用出力端子（デフォルトは ``pin0``）。音を鳴らしたくない場合は ``None`` を指定します。
-:param wait: (wait) ``wait`` を ``True`` に設定した場合、この関数がブロックします。
-:param loop: (loop) ``loop`` が ``True`` の場合、曲は ``stop`` が呼び出されるか、ブロックコールが中断されるまで繰り返し再生されます。
+:param wait: ``wait`` を ``True`` に設定した場合、この関数がブロックします。
+:param loop: ``loop`` が ``True`` の場合、曲は ``stop`` が呼び出されるか、ブロックコールが中断されるまで繰り返し再生されます。
 
 Many built-in melodies are defined in this module."""
     ...
 
 def pitch(frequency: int, duration: int=-1, pin: MicroBitDigitalPin=pin0, wait: bool=True) -> None:
-    """音符を再生します。 (pitch)
+    """音符を再生します。
 
 Example: ``music.pitch(185, 1000)``
 
-:param frequency: (frequency) 周波数を示す整数値
-:param duration: (duration) 持続時間をミリ秒単位で指定します。負の場合、次の呼び出しか ``stop`` の呼び出しまで再生が続きます。
-:param pin: (pin) オプションの出力端子（デフォルトは ``pin0``）。
-:param wait: (wait) ``wait`` を ``True`` に設定した場合、この関数がブロックします。
+:param frequency: 周波数を示す整数値
+:param duration: 持続時間をミリ秒単位で指定します。負の場合、次の呼び出しか ``stop`` の呼び出しまで再生が続きます。
+:param pin: オプションの出力端子（デフォルトは ``pin0``）。
+:param wait: ``wait`` を ``True`` に設定した場合、この関数がブロックします。
 
 For example, if the frequency is set to 440 and the length to
 1000 then we hear a standard concert A for one second.
@@ -109,14 +109,14 @@ You can only play one pitch on one pin at any one time."""
     ...
 
 def stop(pin: MicroBitDigitalPin=pin0) -> None:
-    """内蔵スピーカーやサウンドを出力する端子から鳴らしているすべてのミュージック再生を停止します。 (stop)
+    """内蔵スピーカーやサウンドを出力する端子から鳴らしているすべてのミュージック再生を停止します。
 
 Example: ``music.stop()``
 
-:param pin: (pin) オプションの引数には、たとえば ``music.stop(pin1)`` などの端子を指定できます。"""
+:param pin: オプションの引数には、たとえば ``music.stop(pin1)`` などの端子を指定できます。"""
 
 def reset() -> None:
-    """ティック、bpm、持続時間、オクターブをデフォルト値にリセットします。 (reset)
+    """ティック、bpm、持続時間、オクターブをデフォルト値にリセットします。
 
 Example: ``music.reset()``
 

--- a/lang/ja/typeshed/stdlib/neopixel.pyi
+++ b/lang/ja/typeshed/stdlib/neopixel.pyi
@@ -1,11 +1,11 @@
-"""個別にアドレス可能な RGB/RGBW LED ストリップ。 (neopixel)"""
+"""個別にアドレス可能な RGB/RGBW LED ストリップ。"""
 from .microbit import MicroBitDigitalPin
 from typing import Tuple
 
 class NeoPixel:
 
     def __init__(self, pin: MicroBitDigitalPin, n: int, bpp: int=3) -> None:
-        """端子を介して制御するネオピクセルLEDの新しいストリップを初期化します。 (init)
+        """端子を介して制御するネオピクセルLEDの新しいストリップを初期化します。
 
 Example: ``np = neopixel.NeoPixel(pin0, 8)``
 
@@ -13,19 +13,19 @@ RGBW neopixels are only supported by micro:bit V2.
 
 See `the online docs <https://microbit-micropython.readthedocs.io/en/v2-docs/neopixel.html>`_ for warnings and other advice.
 
-:param pin: (pin) ネオピクセルストリップを制御する端子。
-:param n: (n) ストリップ内のネオピクセルの数。
-:param bpp: (bpp) ピクセルあたりのバイト数。micro:bit V2 の RGBW ネオピクセルに対応するには、RGBやGRBのデフォルト値の3ではなく、4 を指定します。"""
+:param pin: ネオピクセルストリップを制御する端子。
+:param n: ストリップ内のネオピクセルの数。
+:param bpp: ピクセルあたりのバイト数。micro:bit V2 の RGBW ネオピクセルに対応するには、RGBやGRBのデフォルト値の3ではなく、4 を指定します。"""
         ...
 
     def clear(self) -> None:
-        """すべてのピクセルをクリアします。 (clear)
+        """すべてのピクセルをクリアします。
 
 Example: ``np.clear()``"""
         ...
 
     def show(self) -> None:
-        """ピクセルを表示します。 (show)
+        """ピクセルを表示します。
 
 Example: ``np.show()``
 
@@ -33,7 +33,7 @@ Must be called for any updates to become visible."""
         ...
 
     def write(self) -> None:
-        """ピクセルを表示します（micro:bit V2 のみ）。 (write)
+        """ピクセルを表示します（micro:bit V2 のみ）。
 
 Example: ``np.write()``
 
@@ -43,32 +43,32 @@ Equivalent to ``show``."""
         ...
 
     def fill(self, colour: Tuple[int, ...]) -> None:
-        """指定した RGB/RGBW 値をすべてのピクセルに設定します。 (fill)
+        """指定した RGB/RGBW 値をすべてのピクセルに設定します。
 
 Example: ``np.fill((0, 0, 255))``
 
-:param colour: (colour) ピクセルあたりのバイト数（bpp）と同じ長さのタプル。
+:param colour: ピクセルあたりのバイト数（bpp）と同じ長さのタプル。
 
 Use in conjunction with ``show()`` to update the neopixels."""
         ...
 
     def __setitem__(self, key: int, value: Tuple[int, ...]) -> None:
-        """ピクセルの色を設定します。 (setitem)
+        """ピクセルの色を設定します。
 
 Example: ``np[0] = (255, 0, 0)``
 
-:param key: (key) ピクセル番号。
-:param value: (value) 色。"""
+:param key: ピクセル番号。
+:param value: 色。"""
 
     def __getitem__(self, key: int) -> Tuple[int, ...]:
-        """ピクセルの色を取得します。 (getitem)
+        """ピクセルの色を取得します。
 
 Example: ``r, g, b = np[0]``
 
-:param key: (key) ピクセル番号。
+:param key: ピクセル番号。
 :return: The colour tuple."""
 
     def __len__(self) -> int:
-        """このピクセルストリップの長さを取得します。 (len)
+        """このピクセルストリップの長さを取得します。
 
 Example: ``len(np)``"""

--- a/lang/ja/typeshed/stdlib/os.pyi
+++ b/lang/ja/typeshed/stdlib/os.pyi
@@ -1,11 +1,9 @@
-"""ファイルシステムにアクセスします。 (os)"""
+"""ファイルシステムにアクセスします。"""
 from typing import Tuple
 from typing import List
 
 def listdir() -> List[str]:
     """ファイルすべての名前のリストを取得します。
-
- (listdir)
 
 Example: ``os.listdir()``
 
@@ -14,40 +12,40 @@ persistent on-device file system."""
     ...
 
 def remove(filename: str) -> None:
-    """ファイルを削除します。 (remove)
+    """ファイルを削除します。
 
 Example: ``os.remove('data.txt')``
 
-:param filename: (filename) 削除するファイルの名前。
+:param filename: 削除するファイルの名前。
 
 If the file does not exist an ``OSError`` exception will occur."""
     ...
 
 def size(filename: str) -> int:
-    """ファイルのサイズを返します。 (size)
+    """ファイルのサイズを返します。
 
 Example: ``os.size('data.txt')``
 
-:param filename: (filename) ファイル
+:param filename: ファイル
 :return: The size in bytes.
 
 If the file does not exist an ``OSError`` exception will occur."""
 
 class uname_result(Tuple[str, str, str, str, str]):
-    """``os.uname()`` の結果 (uname result)"""
+    """``os.uname()`` の結果"""
     sysname: str
-    """オペレーティングシステム名。 (sysname)"""
+    """オペレーティングシステム名。"""
     nodename: str
-    """ネットワーク上のマシンの名前（実装定義）。 (nodename)"""
+    """ネットワーク上のマシンの名前（実装定義）。"""
     release: str
-    """オペレーティングシステムのリリース。 (release)"""
+    """オペレーティングシステムのリリース。"""
     version: str
-    """オペレーティングシステムのバージョン。 (version)"""
+    """オペレーティングシステムのバージョン。"""
     machine: str
-    """ハードウェア識別子。 (machine)"""
+    """ハードウェア識別子。"""
 
 def uname() -> uname_result:
-    """現在のオペレーティングシステムを識別する情報を返します。 (uname)
+    """現在のオペレーティングシステムを識別する情報を返します。
 
 Example: ``os.uname()``
 

--- a/lang/ja/typeshed/stdlib/radio.pyi
+++ b/lang/ja/typeshed/stdlib/radio.pyi
@@ -1,13 +1,13 @@
-"""内蔵の無線通信を使ったmicro:bit間の通信。 (radio)"""
+"""内蔵の無線通信を使ったmicro:bit間の通信。"""
 from _typeshed import WriteableBuffer
 from typing import Optional, Tuple
 RATE_1MBIT: int
-"""1 MBit/秒のスループットを示すために使われる定数。 (rate 1mbit)"""
+"""1 MBit/秒のスループットを示すために使われる定数。"""
 RATE_2MBIT: int
-"""2 MBit/秒のスループットを示すために使われる定数。 (rate 2mbit)"""
+"""2 MBit/秒のスループットを示すために使われる定数。"""
 
 def on() -> None:
-    """無線通信をオンにします。 (on)
+    """無線通信をオンにします。
 
 Example: ``radio.on()``
 
@@ -16,38 +16,37 @@ up memory that you may otherwise need."""
     ...
 
 def off() -> None:
-    """無線通信をオフにして、電力とメモリを節約します。 (off)
+    """無線通信をオフにして、電力とメモリを節約します。
 
 Example: ``radio.off()``"""
     ...
 
 def config(length: int=32, queue: int=3, channel: int=7, power: int=6, address: int=1969383796, group: int=0, data_rate: int=RATE_1MBIT) -> None:
-    """無線通信を設定します。 (config)
+    """無線通信を設定します。
 
 Example: ``radio.config(group=42)``
 
 The default configuration is suitable for most use.
 
-:param length: (length) (デフォルト=32)\u3000無線を介して送信されるメッセージのバイト単位の最大長を設定します。
+:param length: (デフォルト=32)\u3000無線を介して送信されるメッセージのバイト単位の最大長を設定します。
 最大で 251 バイト（S0、長さ、S1 プリアンブルは254 から 3 を引いたバイト数）に設定できます。
-:param queue: (queue) (デフォルト=3)\u3000受信メッセージキューに格納できるメッセージの数を指定します。
+:param queue: (デフォルト=3)\u3000受信メッセージキューに格納できるメッセージの数を指定します。
 着信メッセージのキューに空きがない場合、着信メッセージは捨てられます。
-:param channel: (channel) (デフォルト=7)\u3000無線が同調されている任意の「チャネル」を定義するもので、0 から 83 までの整数値を設定できます。メッセージはこのチャネル経由で送信され、このチャネル経由で受信したメッセージだけが受信メッセージキューに入れられます。各ステップは 1MHz 幅で、2400MHz を基準にしています。
-:param power: (power) (デフォルト=6)\u3000メッセージをブロードキャストするときに使用される信号の強度を示すもので、0 から 7 までの整数値（指定の値を含む。）を設定できです。
+:param channel: (デフォルト=7)\u3000無線が同調されている任意の「チャネル」を定義するもので、0 から 83 までの整数値を設定できます。メッセージはこのチャネル経由で送信され、このチャネル経由で受信したメッセージだけが受信メッセージキューに入れられます。各ステップは 1MHz 幅で、2400MHz を基準にしています。
+:param power: (デフォルト=6)\u3000メッセージをブロードキャストするときに使用される信号の強度を示すもので、0 から 7 までの整数値（指定の値を含む。）を設定できです。
 値が高いほど信号は強くなりますが、デバイスが消費する電力が大きくなります。指定の番号は次のリストの dBm（デシベルミリワット）値の位置に変換されます: -30, -20, -16, -12, -8, -4, 0, 4 。
-:param address: (address) (デフォルト=0x75626974)\u300032 ビットのアドレスとして表される任意の名前であり、ハードウェアレベルで着信パケットをフィルタリングするために使用されます。フィルタリングはユーザーが設定したアドレスと一致するもののみを維持します。
+:param address: (デフォルト=0x75626974)\u300032 ビットのアドレスとして表される任意の名前であり、ハードウェアレベルで着信パケットをフィルタリングするために使用されます。フィルタリングはユーザーが設定したアドレスと一致するもののみを維持します。
 他のmicro:bit関連のプラットフォームで使われるデフォルトは、ここで使われるデフォルト設定となっています。
-:param group: (group) (デフォルト=0)\u30008ビットの値（0〜255）であり、 ``address`` フィルタしたメッセージで使います。
+:param group: (デフォルト=0)\u30008ビットの値（0〜255）であり、 ``address`` フィルタしたメッセージで使います。
 概念的に「address」は自宅/事務所の住所のようなものであり、「group」はその住所のメッセージを受け取人のようなものです。
-:param data_rate: (data rate) (デフォルト=``radio.RATE_1MBIT``)\u3000データスループットが起こる速度を示しています。
+:param data_rate: (デフォルト=``radio.RATE_1MBIT``)\u3000データスループットが起こる速度を示しています。
 ``radio`` モジュールに定義されている定数 ``RATE_250KBIT``、``RATE_1MBIT``、``RATE_2MBIT`` のいずれかを指定します。
-
 
 If ``config`` is not called then the defaults described above are assumed."""
     ...
 
 def reset() -> None:
-    """設定をデフォルト値にリセットします。 (reset)
+    """設定をデフォルト値にリセットします。
 
 Example: ``radio.reset()``
 
@@ -55,15 +54,15 @@ The defaults as as per the ``config`` function above."""
     ...
 
 def send_bytes(message: bytes) -> None:
-    """バイト列を含んだメッセージを送信します。 (send bytes)
+    """バイト列を含んだメッセージを送信します。
 
 Example: ``radio.send_bytes(b'hello')``
 
-:param message: (message) 送信するバイト列。"""
+:param message: 送信するバイト列。"""
     ...
 
 def receive_bytes() -> Optional[bytes]:
-    """メッセージキューにある次の着信メッセージを受信します。 (receive bytes)
+    """メッセージキューにある次の着信メッセージを受信します。
 
 Example: ``radio.receive_bytes()``
 
@@ -71,27 +70,27 @@ Example: ``radio.receive_bytes()``
     ...
 
 def receive_bytes_into(buffer: WriteableBuffer) -> Optional[int]:
-    """メッセージキューにある次の着信メッセージをバッファにコピーします。 (receive bytes into)
+    """メッセージキューにある次の着信メッセージをバッファにコピーします。
 
 Example: ``radio.receive_bytes_info(buffer)``
 
-:param buffer: (buffer) メッセージを格納するバッファ。メッセージがバッファより大きい場合、メッセージの収まらない部分が切り捨てられます。
+:param buffer: メッセージを格納するバッファ。メッセージがバッファより大きい場合、メッセージの収まらない部分が切り捨てられます。
 :return: ``None`` if there are no pending messages, otherwise it returns the length of the message (which might be more than the length of the buffer)."""
     ...
 
 def send(message: str) -> None:
-    """メッセージ文字列を送信します。 (send)
+    """メッセージ文字列を送信します。
 
 Example: ``radio.send('hello')``
 
 This is the equivalent of ``radio.send_bytes(bytes(message, 'utf8'))`` but with ``b'\x01\x00\x01'``
 prepended to the front (to make it compatible with other platforms that target the micro:bit).
 
-:param message: (message) 送信する文字列。"""
+:param message: 送信する文字列。"""
     ...
 
 def receive() -> Optional[str]:
-    """``receive_bytes`` と同じように動作しますが、送信されてきたものはすべて返します。 (receive)
+    """``receive_bytes`` と同じように動作しますが、送信されてきたものはすべて返します。
 
 Example: ``radio.receive()``
 
@@ -105,7 +104,7 @@ A ``ValueError`` exception is raised if conversion to string fails."""
     ...
 
 def receive_full() -> Optional[Tuple[bytes, int, int]]:
-    """メッセージキューにある次の受信メッセージを表す3つの値をタプルで返します。 (receive full)
+    """メッセージキューにある次の受信メッセージを表す3つの値をタプルで返します。
 
 Example: ``radio.receive_full()``
 

--- a/lang/ja/typeshed/stdlib/random.pyi
+++ b/lang/ja/typeshed/stdlib/random.pyi
@@ -1,69 +1,69 @@
-"""乱数を生成します。 (random)"""
+"""乱数を生成します。"""
 from typing import TypeVar, Sequence, Union, overload
 
 def getrandbits(n: int) -> int:
-    """``n`` 乱数ビット数を持つ整数を生成します。 (getrandbits)
+    """``n`` 乱数ビット数を持つ整数を生成します。
 
 Example: ``random.getrandbits(1)``
 
-:param n: (n) 1～30の値（指定の値を含みます）。"""
+:param n: 1～30の値（指定の値を含みます）。"""
     ...
 
 def seed(n: int) -> None:
-    """乱数ジェネレータを初期化します。 (seed)
+    """乱数ジェネレータを初期化します。
 
 Example: ``random.seed(0)``
 
-:param n: (n) 整数シード
+:param n: 整数シード
 
 This will give you reproducibly deterministic randomness from a given starting
 state (``n``)."""
     ...
 
 def randint(a: int, b: int) -> int:
-    """``a``  から ``b`` の区間内のランダムな整数値を返します（指定の値を含みます）。 (randint)
+    """``a``  から ``b`` の区間内のランダムな整数値を返します（指定の値を含みます）。
 
 Example: ``random.randint(0, 9)``
 
 :param a: (A) 乱数区間の開始値（指定の値を含みます）
-:param b: (b) 乱数区間の終了値（指定の値を含みます）
+:param b: 乱数区間の終了値（指定の値を含みます）
 
 Alias for ``randrange(a, b + 1)``."""
     ...
 
 @overload
 def randrange(stop: int) -> int:
-    """0 から ``stop`` 未満までの間で無作為に選択された整数を返します。 (randrange)
+    """0 から ``stop`` 未満までの間で無作為に選択された整数を返します。
 
 Example: ``random.randrange(10)``
 
-:param stop: (stop) 乱数区間の終了値（指定の値を含みません）"""
+:param stop: 乱数区間の終了値（指定の値を含みません）"""
     ...
 
 @overload
 def randrange(start: int, stop: int, step: int=1) -> int:
-    """``range(start, stop, step)`` から無作為に選択された整数を返します。 (randrange)
+    """``range(start, stop, step)`` から無作為に選択された整数を返します。
 
 Example: ``random.randrange(0, 10)``
 
-:param start: (start) 乱数区間の開始値（指定の値を含みます）
-:param stop: (stop) 乱数区間の終了値（指定の値を含みません）
-:param step: (step) ステップ値。"""
+:param start: 乱数区間の開始値（指定の値を含みます）
+:param stop: 乱数区間の終了値（指定の値を含みません）
+:param step: ステップ値。"""
     ...
 _T = TypeVar('_T')
 
 def choice(seq: Sequence[_T]) -> _T:
-    """空でないシーケンス ``seq`` からランダムな要素を返します。 (choice)
+    """空でないシーケンス ``seq`` からランダムな要素を返します。
 
 Example: ``random.choice([Image.HAPPY, Image.SAD])``
 
-:param seq: (seq) シーケンス。
+:param seq: シーケンス。
 
 If ``seq`` is  empty, raises ``IndexError``."""
     ...
 
 def random() -> float:
-    """0.0 以上、1.0 未満の区間から無作為に選択された浮動小数点数を生成します。 (random)
+    """0.0 以上、1.0 未満の区間から無作為に選択された浮動小数点数を生成します。
 
 Example: ``random.random()``
 
@@ -71,10 +71,10 @@ Example: ``random.random()``
     ...
 
 def uniform(a: float, b: float) -> float:
-    """``a`` から ``b`` の区間内のランダムな浮動小数点数を返します（指定の値を含みます）。 (uniform)
+    """``a`` から ``b`` の区間内のランダムな浮動小数点数を返します（指定の値を含みます）。
 
 Example: ``random.uniform(0, 9)``
 
 :param a: (A) 乱数区間の開始値（指定の値を含みます）
-:param b: (b) 乱数区間の終了値（指定の値を含みます）"""
+:param b: 乱数区間の終了値（指定の値を含みます）"""
     ...

--- a/lang/ja/typeshed/stdlib/speech.pyi
+++ b/lang/ja/typeshed/stdlib/speech.pyi
@@ -1,13 +1,13 @@
-"""micro:bit に話させたり、歌わせたり、その他の音声のようなサウンドを作らせたりします。 (speech)"""
+"""micro:bit に話させたり、歌わせたり、その他の音声のようなサウンドを作らせたりします。"""
 from typing import Optional
 from .microbit import MicroBitDigitalPin, pin0
 
 def translate(words: str) -> str:
-    """英単語の並びを音素に変換します。 (translate)
+    """英単語の並びを音素に変換します。
 
 Example: ``speech.translate('hello world')``
 
-:param words: (words) 英単語の並びの文字列。
+:param words: 英単語の並びの文字列。
 :return: A string containing a best guess at the appropriate phonemes to pronounce.
 The output is generated from this `text to phoneme translation table <https://github.com/s-macke/SAM/wiki/Text-to-phoneme-translation-table>`_.
 
@@ -19,15 +19,15 @@ See `the online documentation <https://microbit-micropython.readthedocs.io/en/v2
     ...
 
 def pronounce(phonemes: str, pitch: int=64, speed: int=72, mouth: int=128, throat: int=128, pin: Optional[MicroBitDigitalPin]=pin0) -> None:
-    """音素を発声します。 (pronounce)
+    """音素を発声します。
 
 Example: ``speech.pronounce(' /HEHLOW WERLD')``
 
-:param phonemes: (phonemes) 発音する音素の文字列
-:param pitch: (pitch) 音声の音高を表す数値
-:param speed: (speed) 音声の速度を表す数値
-:param mouth: (mouth) 音声の口の動きを表す数値
-:param throat: (throat) 音声の喉の動きを表す数値
+:param phonemes: 発音する音素の文字列
+:param pitch: 音声の音高を表す数値
+:param speed: 音声の速度を表す数値
+:param mouth: 音声の口の動きを表す数値
+:param throat: 音声の喉の動きを表す数値
 :param pin: (ピン) 出力端子をデフォルトの ``pin0`` から変えるためのオプション引数。
 音を鳴らしたくない場合は ``pin=None`` を指定します。micro:bit V2 のみで使えます。
 
@@ -38,15 +38,15 @@ See `the online documentation <https://microbit-micropython.readthedocs.io/en/v2
     ...
 
 def say(words: str, pitch: int=64, speed: int=72, mouth: int=128, throat: int=128, pin: MicroBitDigitalPin=pin0) -> None:
-    """英単語の並びを発声します。 (say)
+    """英単語の並びを発声します。
 
 Example: ``speech.say('hello world')``
 
-:param words: (words) 発声する言葉の文字列。
-:param pitch: (pitch) 音声の音高を表す数値
-:param speed: (speed) 音声の速度を表す数値
-:param mouth: (mouth) 音声の口の動きを表す数値
-:param throat: (throat) 音声の喉の動きを表す数値
+:param words: 発声する言葉の文字列。
+:param pitch: 音声の音高を表す数値
+:param speed: 音声の速度を表す数値
+:param mouth: 音声の口の動きを表す数値
+:param throat: 音声の喉の動きを表す数値
 :param pin: (ピン) 出力端子をデフォルトの ``pin0`` から変えるためのオプション引数。
 音を鳴らしたくない場合は ``pin=None`` を指定します。micro:bit V2 のみで使えます。
 
@@ -60,15 +60,15 @@ See `the online documentation <https://microbit-micropython.readthedocs.io/en/v2
     ...
 
 def sing(phonemes: str, pitch: int=64, speed: int=72, mouth: int=128, throat: int=128, pin: MicroBitDigitalPin=pin0) -> None:
-    """音素を歌います。 (sing)
+    """音素を歌います。
 
 Example: ``speech.sing(' /HEHLOW WERLD')``
 
-:param phonemes: (phonemes) 歌う言葉の文字列。
-:param pitch: (pitch) 音声の音高を表す数値
-:param speed: (speed) 音声の速度を表す数値
-:param mouth: (mouth) 音声の口の動きを表す数値
-:param throat: (throat) 音声の喉の動きを表す数値
+:param phonemes: 歌う言葉の文字列。
+:param pitch: 音声の音高を表す数値
+:param speed: 音声の速度を表す数値
+:param mouth: 音声の口の動きを表す数値
+:param throat: 音声の喉の動きを表す数値
 :param pin: (ピン) 出力端子をデフォルトの ``pin0`` から変えるためのオプション引数。
 音を鳴らしたくない場合は ``pin=None`` を指定します。micro:bit V2 のみで使えます。
 

--- a/lang/ja/typeshed/stdlib/struct.pyi
+++ b/lang/ja/typeshed/stdlib/struct.pyi
@@ -1,56 +1,56 @@
-"""プリミティブデータ型のパックとアンパック。 (struct)"""
+"""プリミティブデータ型のパックとアンパック。"""
 from _typeshed import ReadableBuffer, WriteableBuffer
 from typing import Any, Tuple, Union
 
 def calcsize(fmt: str) -> int:
-    """指定した ``fmt`` で格納するために必要なバイト数を取得します。 (calcsize)
+    """指定した ``fmt`` で格納するために必要なバイト数を取得します。
 
 Example: ``struct.calcsize('hf')``
 
-:param fmt: (fmt) フォーマット文字列。
+:param fmt: フォーマット文字列。
 :return The number of bytes needed to store such a value."""
     ...
 
 def pack(fmt: str, v1: Any, *vn: Any) -> bytes:
-    """フォーマット文字列にしたがって複数の値をパックします。 (pack)
+    """フォーマット文字列にしたがって複数の値をパックします。
 
 Example: ``struct.pack('hf', 1, 3.1415)``
 
-:param fmt: (fmt) フォーマット文字列。
-:param v1: (v1) 先頭の値。
-:param *vn: (*vn) 残りの値。
+:param fmt: フォーマット文字列。
+:param v1: 先頭の値。
+:param *vn: 残りの値。
 :return A bytes object encoding the values."""
     ...
 
 def pack_into(fmt: str, buffer: WriteableBuffer, offset: int, v1: Any, *vn: Any) -> None:
-    """フォーマット文字列にしたがって複数の値をパックします。 (pack into)
+    """フォーマット文字列にしたがって複数の値をパックします。
 
 Example: ``struct.pack_info('hf', buffer, 1, 3.1415)``
 
-:param fmt: (fmt) フォーマット文字列。
-:param buffer: (buffer) 書き込み先のバッファ。
-:param offset: (offset) バッファのオフセット。負の場合はバッファの最後からのオフセットになります。
-:param v1: (v1) 先頭の値。
-:param *vn: (*vn) 残りの値。"""
+:param fmt: フォーマット文字列。
+:param buffer: 書き込み先のバッファ。
+:param offset: バッファのオフセット。負の場合はバッファの最後からのオフセットになります。
+:param v1: 先頭の値。
+:param *vn: 残りの値。"""
     ...
 
 def unpack(fmt: str, data: ReadableBuffer) -> Tuple[Any, ...]:
-    """フォーマット文字列にしたがってデータをアンパックします。 (unpack)
+    """フォーマット文字列にしたがってデータをアンパックします。
 
 Example: ``v1, v2 = struct.unpack('hf', buffer)``
 
-:param fmt: (fmt) フォーマット文字列。
-:param data: (data) データ。
+:param fmt: フォーマット文字列。
+:param data: データ。
 :return: A tuple of the unpacked values."""
     ...
 
 def unpack_from(fmt: str, buffer: ReadableBuffer, offset: int=0) -> Tuple:
-    """フォーマット文字列にしたがってバッファからデータをアンパックします。 (unpack from)
+    """フォーマット文字列にしたがってバッファからデータをアンパックします。
 
 Example: ``v1, v2 = struct.unpack_from('hf', buffer)``
 
-:param fmt: (fmt) フォーマット文字列。
-:param buffer: (buffer) 読み込み元のバッファ。
-:param offset: (offset) バッファのオフセット。負の場合はバッファの最後からのオフセットになります。
+:param fmt: フォーマット文字列。
+:param buffer: 読み込み元のバッファ。
+:param offset: バッファのオフセット。負の場合はバッファの最後からのオフセットになります。
 :return: A tuple of the unpacked values."""
     ...

--- a/lang/ja/typeshed/stdlib/sys.pyi
+++ b/lang/ja/typeshed/stdlib/sys.pyi
@@ -1,36 +1,36 @@
-"""システム固有関数。 (sys)"""
+"""システム固有関数。"""
 from typing import Any, Dict, List, NoReturn, TextIO, Tuple
 
 def exit(retval: object=...) -> NoReturn:
-    """与えた終了コードで現在のプログラムを終了します。 (exit)
+    """与えた終了コードで現在のプログラムを終了します。
 
 Example: ``sys.exit(1)``
 
 This function raises a ``SystemExit`` exception. If an argument is given, its
 value given as an argument to ``SystemExit``.
 
-:param retval: (retval) 終了コードまたはメッセージ。"""
+:param retval: 終了コードまたはメッセージ。"""
     ...
 
 def print_exception(exc: Exception) -> None:
-    """例外をトレースバック付きで出力します。 (print exception)
+    """例外をトレースバック付きで出力します。
 
 Example: ``sys.print_exception(e)``
 
-:param exc: (exc) 表示する例外
+:param exc: 表示する例外
 
 This is simplified version of a function which appears in the
 ``traceback`` module in CPython."""
 argv: List[str]
-"""現在のプログラム開始時の引数の変更可能なリスト。 (argv)"""
+"""現在のプログラム開始時の引数の変更可能なリスト。"""
 byteorder: str
-"""システムのバイト順（``"little"`` または ``"big"``）。 (byteorder)"""
+"""システムのバイト順（``"little"`` または ``"big"``）。"""
 
 class _implementation:
     name: str
     version: Tuple[int, int, int]
 implementation: _implementation
-"""現在の Python 処理系に関する情報を持つオブジェクト。 (implementation)
+"""現在の Python 処理系に関する情報を持つオブジェクト。
 
 For MicroPython, it has following attributes:
 
@@ -45,7 +45,8 @@ CPython mandates more attributes for this object, but the actual useful
 bare minimum is implemented in MicroPython.
 """
 maxsize: int
-"""現在のプラットフォームでネイティブ整数型が保持できる最大値、またはプラットフォームの最大値より小さい場合は MicroPython 整数型で表現可能な最大値(MicroPython ポートで 長整数をサポートしないとした場合)。 (maxsize)
+"""
+現在のプラットフォームでネイティブ整数型が保持できる最大値、またはプラットフォームの最大値より小さい場合は MicroPython 整数型で表現可能な最大値(MicroPython ポートで 長整数をサポートしないとした場合)。
 
 This attribute is useful for detecting "bitness" of a platform (32-bit vs
 64-bit, etc.). It's recommended to not compare this attribute to some
@@ -66,13 +67,13 @@ value directly, but instead count number of bits in it::
         # "> 32", "> 64" style of comparisons.
 """
 modules: Dict[str, Any]
-"""読み込まれたモジュールの辞書。 (modules)
+"""読み込まれたモジュールの辞書。 
 
 On some ports, it may not include builtin modules."""
 path: List[str]
-"""インポートするモジュールを検索するディレクトリの変更可能なリスト。 (path)"""
+"""インポートするモジュールを検索するディレクトリの変更可能なリスト。"""
 platform: str
-"""MicroPython が実行されているプラ\u200b\u200bットフォーム。 (platform)
+"""MicroPython が実行されているプラ\u200b\u200bットフォーム。 
 
 For OS/RTOS ports, this is usually an identifier of the OS, e.g. ``"linux"``.
 For baremetal ports it is an identifier of a board, e.g. ``"pyboard"`` for 
@@ -83,9 +84,9 @@ If you need to check whether your program runs on MicroPython (vs other
 Python implementation), use ``sys.implementation`` instead.
 """
 version: str
-"""この処理系が準拠するPython言語バージョンを表す文字列。 (version)"""
+"""この処理系が準拠するPython言語バージョンを表す文字列。"""
 version_info: Tuple[int, int, int]
-"""この実装が準拠しているPython言語バージョンを表すintのタプル。 (version info)
+"""この実装が準拠しているPython言語バージョンを表すintのタプル。
 
 Only the first three version numbers (major, minor, micro) are supported and
 they can be referenced only by index, not by name.

--- a/lang/ja/typeshed/stdlib/time.pyi
+++ b/lang/ja/typeshed/stdlib/time.pyi
@@ -1,32 +1,32 @@
-"""時間を測定とプログラムの遅延。 (time)"""
+"""時間を測定とプログラムの遅延。"""
 from typing import Union
 
 def sleep(seconds: Union[int, float]) -> None:
-    """指定した秒数だけ遅延します。 (sleep)
+    """指定した秒数だけ遅延します。
 
 Example: ``time.sleep(1)``
 
-:param seconds: (seconds) 遅延する秒数。秒より細かい精度で指定したい場合は浮動小数点数を使ってください。"""
+:param seconds: 遅延する秒数。秒より細かい精度で指定したい場合は浮動小数点数を使ってください。"""
     ...
 
 def sleep_ms(ms: int) -> None:
-    """指定したミリ秒だけ遅延します。 (sleep ms)
+    """指定したミリ秒だけ遅延します。
 
 Example: ``time.sleep_ms(1_000_000)``
 
-:param ms: (ms) 遅延するミリ秒数（>= 0）。"""
+:param ms: 遅延するミリ秒数（>= 0）。"""
     ...
 
 def sleep_us(us: int) -> None:
-    """指定したマイクロ秒だけ遅延します。 (sleep us)
+    """指定したマイクロ秒だけ遅延します。
 
 Example: ``time.sleep_us(1000)``
 
-:param us: (us) 遅延するマイクロ秒数（>= 0）。"""
+:param us: 遅延するマイクロ秒数（>= 0）。"""
     ...
 
 def ticks_ms() -> int:
-    """呼出し時点での稼働時間をミリ秒単位で返します。稼働時間は最大値に達するとラップアラウンドします(一周して最小値に戻ります)。 (ticks ms)
+    """呼出し時点での稼働時間をミリ秒単位で返します。稼働時間は最大値に達するとラップアラウンドします(一周して最小値に戻ります)。
 
 Example: ``time.ticks_ms()``
 
@@ -34,7 +34,7 @@ Example: ``time.ticks_ms()``
     ...
 
 def ticks_us() -> int:
-    """呼出し時点での稼働時間をマイクロ秒単位で返します。稼働時間は最大値に達するとラップアラウンドします(一周して最小値に戻ります)。 (ticks us)
+    """呼出し時点での稼働時間をマイクロ秒単位で返します。稼働時間は最大値に達するとラップアラウンドします(一周して最小値に戻ります)。
 
 Example: ``time.ticks_us()``
 
@@ -42,7 +42,7 @@ Example: ``time.ticks_us()``
     ...
 
 def ticks_add(ticks: int, delta: int) -> int:
-    """与えた数をティック値からのオフセットとして加算した値を返します。引数の値は正でも負でもかまいません。 (ticks add)
+    """与えた数をティック値からのオフセットとして加算した値を返します。引数の値は正でも負でもかまいません。
 
 Example: ``time.ticks_add(time.ticks_ms(), 200)``
 
@@ -50,8 +50,8 @@ Given a ticks value, this function allows to calculate ticks
 value delta ticks before or after it, following modular-arithmetic
 definition of tick values.
 
-:param ticks: (ticks) ティック値
-:param delta: (delta) 整数オフセット
+:param ticks: ティック値
+:param delta: 整数オフセット
 
 Example::
 
@@ -68,12 +68,12 @@ Example::
     ...
 
 def ticks_diff(ticks1: int, ticks2: int) -> int:
-    """``time.ticks_ms()`` や ``ticks_us()`` 関数の戻り値（ラップアラウンドする可能性のある符号付きの値）の間のティック値の差を計算します。 (ticks diff)
+    """``time.ticks_ms()`` や ``ticks_us()`` 関数の戻り値（ラップアラウンドする可能性のある符号付きの値）の間のティック値の差を計算します。
 
 Example: ``time.ticks_diff(scheduled_time, now)``
 
-:param ticks1: (ticks1) 引かられる方の値
-:param ticks2: (ticks2) 引く方の値
+:param ticks1: 引かられる方の値
+:param ticks2: 引く方の値
 
 The argument order is the same as for subtraction operator,
 ``ticks_diff(ticks1, ticks2)`` has the same meaning as ``ticks1 - ticks2``.

--- a/lang/ko/typeshed/stdlib/gc.pyi
+++ b/lang/ko/typeshed/stdlib/gc.pyi
@@ -1,22 +1,22 @@
-"""가비지 컬렉터 제어 (gc)"""
+"""가비지 컬렉터 제어"""
 from typing import overload
 
 def enable() -> None:
-    """자동 가비지 컬렉션을 활성화합니다. (enable)"""
+    """자동 가비지 컬렉션을 활성화합니다."""
     ...
 
 def disable() -> None:
-    """자동 가비지 컬렉션을 비활성화합니다. (disable)
+    """자동 가비지 컬렉션을 비활성화합니다.
 
 Heap memory can still be allocated,
 and garbage collection can still be initiated manually using ``gc.collect``."""
 
 def collect() -> None:
-    """가비지 컬렉션을 실행합니다. (collect)"""
+    """가비지 컬렉션을 실행합니다."""
     ...
 
 def mem_alloc() -> int:
-    """할당된 힙 RAM의 바이트 수를 불러옵니다. (mem alloc)
+    """할당된 힙 RAM의 바이트 수를 불러옵니다.
 
 :return: The number of bytes allocated.
 
@@ -24,7 +24,7 @@ This function is MicroPython extension."""
     ...
 
 def mem_free() -> int:
-    """이용 가능한 힙 RAM의 바이트 수를 불러옵니다. 값을 알 수 없는 경우 -1을 반환합니다. (mem free)
+    """이용 가능한 힙 RAM의 바이트 수를 불러옵니다. 값을 알 수 없는 경우 -1을 반환합니다.
 
 :return: The number of bytes free.
 
@@ -33,7 +33,7 @@ This function is MicroPython extension."""
 
 @overload
 def threshold() -> int:
-    """추가 GC 할당 임계값을 요청합니다. (threshold)
+    """추가 GC 할당 임계값을 요청합니다.
 
 :return: The GC allocation threshold.
 
@@ -44,7 +44,7 @@ implementations, its signature and semantics are different."""
 
 @overload
 def threshold(amount: int) -> None:
-    """추가 GC 할당 임계값을 설정합니다. (threshold)
+    """추가 GC 할당 임계값을 설정합니다.
 
 Normally, a collection is triggered only when a new allocation
 cannot be satisfied, i.e. on an  out-of-memory (OOM) condition.
@@ -64,5 +64,5 @@ This function is a MicroPython extension. CPython has a similar
 function - ``set_threshold()``, but due to different GC
 implementations, its signature and semantics are different.
 
-:param amount: (amount) 가비지 컬렉션이 트리거되는 바이트 수입니다."""
+:param amount: 가비지 컬렉션이 트리거되는 바이트 수입니다."""
     ...

--- a/lang/ko/typeshed/stdlib/log.pyi
+++ b/lang/ko/typeshed/stdlib/log.pyi
@@ -1,18 +1,18 @@
-"""micro:bit V2에 데이터를 기록합니다. (log)"""
+"""micro:bit V2에 데이터를 기록합니다."""
 from typing import Literal, Optional, Union, overload
 MILLISECONDS = 1
-"""밀리초 타임스탬프 형식입니다. (milliseconds)"""
+"""밀리초 타임스탬프 형식입니다."""
 SECONDS = 10
-"""초 타임스탬프 형식입니다. (seconds)"""
+"""초 타임스탬프 형식입니다."""
 MINUTES = 600
-"""분 타임스탬프 형식입니다. (minutes)"""
+"""분 타임스탬프 형식입니다."""
 HOURS = 36000
-"""시간 타임스탬프 형식입니다. (hours)"""
+"""시간 타임스탬프 형식입니다."""
 DAYS = 864000
-"""일 타임스탬프 형식입니다. (days)"""
+"""일 타임스탬프 형식입니다."""
 
 def set_labels(*args: str, timestamp: Optional[Literal[1, 10, 36000, 864000]]=SECONDS) -> None:
-    """로그 파일 헤더를 설정합니다. (set labels)
+    """로그 파일 헤더를 설정합니다.
 
 Example: ``log.set_labels('x', 'y', 'z', timestamp=log.MINUTES)``
 
@@ -24,13 +24,13 @@ labels set up by this function call to the last headers declared in the
 file. If the headers are different it will add a new header entry at the
 end of the file.
 
-:param *args: (*args) 각 로그 헤더의 위치 매개변수입니다.
+:param *args: 각 로그 헤더의 위치 매개변수입니다.
 :param timestamp: (타임스탬프) 모든 행의 첫 번째 열에 자동으로 타임스탬프 유닛이 추가됩니다. 이 인자를 ``None``으로 설정하면 타임스탬프가 비활성화됩니다. 이 모듈에 정해진 값에 따라 ``log.MILLISECONDS``, ``log.SECONDS``, ``log.MINUTES``, ``log.HOURS``, ``log.DAYS``를 패스합니다. 올바르지 않은 값은 예외 처리가 발생합니다."""
     ...
 
 @overload
 def add(log_data: Optional[dict[str, Union[str, int, float]]]) -> None:
-    """헤더 및 값의 딕셔너리를 패스해 로그에 데이터 행을 추가합니다. (add)
+    """헤더 및 값의 딕셔너리를 패스해 로그에 데이터 행을 추가합니다.
 
 Example: ``log.add({ 'temp': temperature() })``
 
@@ -43,12 +43,12 @@ entry to be added to the log with the extra label.
 Labels previously specified and not present in this function call will be
 skipped with an empty value in the log row.
 
-:param log_data: (log data) 각 헤더의 키가 있는 딕셔너리로 데이터를 로그합니다."""
+:param log_data: 각 헤더의 키가 있는 딕셔너리로 데이터를 로그합니다."""
     ...
 
 @overload
 def add(**kwargs: Union[str, int, float]) -> None:
-    """키워드 인자를 사용해 로그에 데이터 행을 추가합니다. (add)
+    """키워드 인자를 사용해 로그에 데이터 행을 추가합니다.
 
 Example: ``log.add(temp=temperature())``
 
@@ -63,23 +63,23 @@ skipped with an empty value in the log row."""
     ...
 
 def delete(full=False):
-    """헤더를 포함한 로그의 내용을 삭제합니다. (delete)
+    """헤더를 포함한 로그의 내용을 삭제합니다.
 
 Example: ``log.delete()``
 
 To add the log headers the ``set_labels`` function has to be called again
 after this.
 
-:param full: (full) 'full' 제거 형식을 선택해 플래시 저장소에서 데이터를 제거합니다.
+:param full: 'full' 제거 형식을 선택해 플래시 저장소에서 데이터를 제거합니다.
 만약 ``False``로 설정된 경우 'fast' 방식을 사용해 속도가 느린 전체 제거를 수행하는 대신 데이터를 무효화합니다."""
     ...
 
 def set_mirroring(serial: bool):
-    """데이터 로깅 활동을 시리얼 출력으로 미러링합니다. (set mirroring)
+    """데이터 로깅 활동을 시리얼 출력으로 미러링합니다.
 
 Example: ``log.set_mirroring(True)``
 
 Mirroring is disabled by default.
 
-:param serial: (serial) ``True``를 패스하면 데이터 로깅 활동을 시리얼 출력으로, ``False``를 패스하면 미러링을 비활성화합니다."""
+:param serial: ``True``를 패스하면 데이터 로깅 활동을 시리얼 출력으로, ``False``를 패스하면 미러링을 비활성화합니다."""
     ...

--- a/lang/ko/typeshed/stdlib/machine.pyi
+++ b/lang/ko/typeshed/stdlib/machine.pyi
@@ -1,9 +1,9 @@
-"""로우 레벨 유틸리티입니다. (machine)"""
+"""로우 레벨 유틸리티입니다."""
 from typing import Any
 from .microbit import MicroBitDigitalPin
 
 def unique_id() -> bytes:
-    """보드의 고유 식별자가 있는 바이트 문자열을 불러옵니다. (unique id)
+    """보드의 고유 식별자가 있는 바이트 문자열을 불러옵니다.
 
 Example: ``machine.unique_id()``
 
@@ -11,13 +11,13 @@ Example: ``machine.unique_id()``
     ...
 
 def reset() -> None:
-    """외부 초기화 버튼을 누른 것과 유사한 방식으로 기기를 초기화합니다. (reset)
+    """외부 초기화 버튼을 누른 것과 유사한 방식으로 기기를 초기화합니다.
 
 Example: ``machine.reset()``"""
     ...
 
 def freq() -> int:
-    """헤르츠로 표시된 CPU 진동수를 불러옵니다. (freq)
+    """헤르츠로 표시된 CPU 진동수를 불러옵니다.
 
 Example: ``machine.freq()``
 
@@ -25,7 +25,7 @@ Example: ``machine.freq()``
     ...
 
 def disable_irq() -> Any:
-    """인터럽트 요청을 비활성화합니다. (disable irq)
+    """인터럽트 요청을 비활성화합니다.
 
 Example: ``interrupt_state = machine.disable_irq()``
 
@@ -36,15 +36,15 @@ interrupts to their original state."""
     ...
 
 def enable_irq(state: Any) -> None:
-    """인터럽트 요청을 재활성화합니다. (enable irq)
+    """인터럽트 요청을 재활성화합니다.
 
 Example: ``machine.enable_irq(interrupt_state)``
 
-:param state: (state) ``disable_irq`` 함수에서 가장 최근에 호출된 값을 반환합니다."""
+:param state: ``disable_irq`` 함수에서 가장 최근에 호출된 값을 반환합니다."""
     ...
 
 def time_pulse_us(pin: MicroBitDigitalPin, pulse_level: int, timeout_us: int=1000000) -> int:
-    """핀 펄스 시간을 측정합니다. (time pulse us)
+    """핀 펄스 시간을 측정합니다.
 
 Example: ``time_pulse_us(pin0, 1)``
 
@@ -56,29 +56,29 @@ starts straight away.
 
 :param pin: (핀) 사용할 핀
 :param pulse_level: (펄스 레벨) 로우 펄스의 시간을 측정하려면 0, 하이 펄스는 1
-:param timeout_us: (timeout us) 마이크로초 시간 초과
+:param timeout_us: 마이크로초 시간 초과
 :return: The duration of the pulse in microseconds, or -1 for a timeout waiting for the level to match ``pulse_level``, or -2 on timeout waiting for the pulse to end"""
     ...
 
 class mem:
-    """``mem8``, ``mem16``, ``mem32`` 메모리 뷰 클래스 (mem)"""
+    """``mem8``, ``mem16``, ``mem32`` 메모리 뷰 클래스"""
 
     def __getitem__(self, address: int) -> int:
-        """메모리 값에 액세스합니다. (getitem)
+        """메모리 값에 액세스합니다.
 
-:param address: (address) 메모리 주소입니다.
+:param address: 메모리 주소입니다.
 :return: The value at that address as an integer."""
         ...
 
     def __setitem__(self, address: int, value: int) -> None:
-        """제공된 주소에 값을 설정합니다. (setitem)
+        """제공된 주소에 값을 설정합니다.
 
-:param address: (address) 메모리 주소입니다.
-:param value: (value) 설정할 정수값입니다."""
+:param address: 메모리 주소입니다.
+:param value: 설정할 정수값입니다."""
         ...
 mem8: mem
-"""8비트(바이트) 메모리 뷰입니다. (mem8)"""
+"""8비트(바이트) 메모리 뷰입니다."""
 mem16: mem
-"""16비트 메모리 뷰입니다. (mem16)"""
+"""16비트 메모리 뷰입니다."""
 mem32: mem
-"""32비트 메모리 뷰입니다. (mem32)"""
+"""32비트 메모리 뷰입니다."""

--- a/lang/ko/typeshed/stdlib/math.pyi
+++ b/lang/ko/typeshed/stdlib/math.pyi
@@ -1,68 +1,68 @@
-"""수학 함수입니다. (math)"""
+"""수학 함수입니다."""
 from typing import Tuple
 
 def acos(x: float) -> float:
-    """코사인의 역을 계산합니다. (acos)
+    """코사인의 역을 계산합니다.
 
 Example: ``math.acos(1)``
 
-:param x: (x) 숫자
+:param x: 숫자
 :return: The inverse cosine of ``x``"""
     ...
 
 def asin(x: float) -> float:
-    """사인의 역을 계산합니다. (asin)
+    """사인의 역을 계산합니다.
 
 Example: ``math.asin(0)``
 
-:param x: (x) 숫자
+:param x: 숫자
 :return: The inverse sine of ``x``"""
     ...
 
 def atan(x: float) -> float:
-    """탄젠트의 역을 계산합니다. (atan)
+    """탄젠트의 역을 계산합니다.
 
 Example: ``math.atan(0)``
 
-:param x: (x) 숫자
+:param x: 숫자
 :return: The inverse tangent of ``x``"""
     ...
 
 def atan2(y: float, x: float) -> float:
-    """``y/x``의 역 탄젠트의 주 값을 계산합니다. (atan2)
+    """``y/x``의 역 탄젠트의 주 값을 계산합니다.
 
 Example: ``math.atan2(0, -1)``
 
-:param y: (x) 숫자
-:param x: (x) 숫자
+:param y: 숫자
+:param x: 숫자
 :return: The principal value of the inverse tangent of ``y/x``"""
     ...
 
 def ceil(x: float) -> float:
-    """양의 무한대로 숫자를 반올림합니다. (ceil)
+    """양의 무한대로 숫자를 반올림합니다.
 
 Example: ``math.ceil(0.1)``
 
-:param x: (x) 숫자
+:param x: 숫자
 :return: ``x`` rounded towards positive infinity."""
     ...
 
 def copysign(x: float, y: float) -> float:
-    """``y``의 사인 값으로 ``x``를 계산합니다. (copysign)
+    """``y``의 사인 값으로 ``x``를 계산합니다.
 
 Example: ``math.copysign(1, -1)``
 
-:param x: (x) 숫자
-:param y: (y) 반환값의 사인의 출처
+:param x: 숫자
+:param y: 반환값의 사인의 출처
 :return: ``x`` with the sign of ``y``"""
     ...
 
 def cos(x: float) -> float:
-    """``x``의 코사인을 계산합니다. (cos)
+    """``x``의 코사인을 계산합니다.
 
 Example: ``math.cos(0)``
 
-:param x: (x) 숫자
+:param x: 숫자
 :return: The cosine of ``x``"""
     ...
 
@@ -71,48 +71,48 @@ def degrees(x: float) -> float:
 
 Example: ``math.degrees(2 * math.pi)``
 
-:param x: (x) 호도법 값
+:param x: 호도법 값
 :return: The value converted to degrees"""
     ...
 
 def exp(x: float) -> float:
-    """``x``의 지수를 계산합니다. (exp)
+    """``x``의 지수를 계산합니다.
 
 Example: ``math.exp(1)``
 
-:param x: (x) 숫자
+:param x: 숫자
 :return: The exponential of ``x``."""
     ...
 
 def fabs(x: float) -> float:
-    """``x``의 절댓값을 반환합니다. (fabs)
+    """``x``의 절댓값을 반환합니다.
 
 Example: ``math.fabs(-0.1)``
 
-:param x: (x) 숫자
+:param x: 숫자
 :return: The absolute value of ``x``"""
     ...
 
 def floor(x: float) -> int:
-    """음의 무한대로 숫자를 반올림합니다. (floor)
+    """음의 무한대로 숫자를 반올림합니다.
 
 Example: ``math.floor(0.9)``
 
-:param x: (x) 숫자
+:param x: 숫자
 :return: ``x`` rounded towards negative infinity."""
     ...
 
 def fmod(x: float, y: float) -> float:
-    """``x/y``의 나머지를 계산합니다. (fmod)
+    """``x/y``의 나머지를 계산합니다.
 
 Example: ``math.fmod(10, 3)``
 
-:param x: (x) 분자
-:param y: (y) 분모"""
+:param x: 분자
+:param y: 분모"""
     ...
 
 def frexp(x: float) -> Tuple[float, int]:
-    """부동 소수점 수를 가수와 지수로 분해합니다. (frexp)
+    """부동 소수점 수를 가수와 지수로 분해합니다.
 
 Example: ``mantissa, exponent = math.frexp(2)``
 
@@ -120,49 +120,49 @@ The returned value is the tuple ``(m, e)`` such that ``x == m * 2**e``
 exactly.  If ``x == 0`` then the function returns ``(0.0, 0)``, otherwise
 the relation ``0.5 <= abs(m) < 1`` holds.
 
-:param x: (x) 부동 소수점 수
+:param x: 부동 소수점 수
 :return: A tuple of length two containing its mantissa then exponent"""
     ...
 
 def isfinite(x: float) -> bool:
-    """값이 유한값인지 확인합니다. (isfinite)
+    """값이 유한값인지 확인합니다.
 
 Example: ``math.isfinite(float('inf'))``
 
-:param x: (x) 숫자입니다.
+:param x: 숫자입니다.
 :return: ``True`` if ``x`` is finite, ``False`` otherwise."""
     ...
 
 def isinf(x: float) -> bool:
-    """값이 무한인지 확인합니다. (isinf)
+    """값이 무한인지 확인합니다.
 
 Example: ``math.isinf(float('-inf'))``
 
-:param x: (x) 숫자입니다.
+:param x: 숫자입니다.
 :return: ``True`` if ``x`` is infinite, ``False`` otherwise."""
     ...
 
 def isnan(x: float) -> bool:
-    """값이 숫자가 아닌 값(NaN)인지 확인합니다. (isnan)
+    """값이 숫자가 아닌 값(NaN)인지 확인합니다.
 
 Example: ``math.isnan(float('nan'))``
 
-:param x: (x) 숫자
+:param x: 숫자
 :return: ``True`` if ``x`` is not-a-number (NaN), ``False`` otherwise."""
     ...
 
 def ldexp(x: float, exp: int) -> float:
-    """``x * (2**exp)``를 계산합니다. (ldexp)
+    """``x * (2**exp)``를 계산합니다.
 
 Example: ``math.ldexp(0.5, 2)``
 
-:param x: (x) 숫자
-:param exp: (exp) 정수 지수
+:param x: 숫자
+:param exp: 정수 지수
 :return: ``x * (2**exp)``"""
     ...
 
 def log(x: float, base: float=e) -> float:
-    """``x``의 로그를 주어진 베이스에 따라 계산합니다(자연로그가 기본값). (log)
+    """``x``의 로그를 주어진 베이스에 따라 계산합니다(자연로그가 기본값).
 
 Example: ``math.log(math.e)``
 
@@ -170,77 +170,77 @@ With one argument, return the natural logarithm of x (to base e).
 
 With two arguments, return the logarithm of x to the given base, calculated as ``log(x)/log(base)``.
 
-:param x: (x) 숫자
-:param base: (base) 사용할 베이스
+:param x: 숫자
+:param base: 사용할 베이스
 :return: The natural logarithm of ``x``"""
     ...
 
 def modf(x: float) -> Tuple[float, float]:
-    """``x``의 분수 및 정수 부분을 계산합니다. (modf)
+    """``x``의 분수 및 정수 부분을 계산합니다.
 
 Example: ``fractional, integral = math.modf(1.5)``
 
-:param x: (x) 숫자
+:param x: 숫자
 :return: A tuple of two floats representing the fractional then integral parts of ``x``.
 
 Both the fractional and integral values have the same sign as ``x``."""
     ...
 
 def pow(x: float, y: float) -> float:
-    """``y``의 제곱을 ``x``(으)로 반환합니다. (pow)
+    """``y``의 제곱을 ``x``(으)로 반환합니다.
 
 Example: ``math.pow(4, 0.5)``
 
-:param x: (x) 숫자
-:param y: (y) 지수
+:param x: 숫자
+:param y: 지수
 :return: ``x`` to the power of ``y``"""
     ...
 
 def radians(x: float) -> float:
-    """각도법을 호도법으로 변환합니다. (radians)
+    """각도법을 호도법으로 변환합니다.
 
 Example: ``math.radians(360)``
 
-:param x: (x) 각도법 값
+:param x: 각도법 값
 :return: The value converted to radians"""
     ...
 
 def sin(x: float) -> float:
-    """``x``의 사인을 계산합니다. (sin)
+    """``x``의 사인을 계산합니다.
 
 Example: ``math.sin(math.pi/2)``
 
-:param x: (x) 숫자
+:param x: 숫자
 :return: The sine of ``x``"""
     ...
 
 def sqrt(x: float) -> float:
-    """``x``의 제곱근을 계산합니다. (sqrt)
+    """``x``의 제곱근을 계산합니다.
 
 Example: ``math.sqrt(4)``
 
-:param x: (x) 숫자
+:param x: 숫자
 :return: The square root of ``x``"""
     ...
 
 def tan(x: float) -> float:
-    """``x``의 탄젠트를 계산합니다. (tan)
+    """``x``의 탄젠트를 계산합니다.
 
 Example: ``math.tan(0)``
 
-:param x: (x) 숫자
+:param x: 숫자
 :return: The tangent of ``x``."""
     ...
 
 def trunc(x: float) -> int:
-    """숫자를 0으로 반올림합니다. (trunc)
+    """숫자를 0으로 반올림합니다.
 
 Example: ``math.trunc(-0.9)``
 
-:param x: (x) 숫자
+:param x: 숫자
 :return: ``x`` rounded towards zero."""
     ...
 e: float
-"""자연 알고리즘 베이스 (e)"""
+"""자연 알고리즘 베이스"""
 pi: float
-"""원의 원주와 지름의 비율 (pi)"""
+"""원의 원주와 지름의 비율"""

--- a/lang/ko/typeshed/stdlib/microbit/__init__.pyi
+++ b/lang/ko/typeshed/stdlib/microbit/__init__.pyi
@@ -1,4 +1,4 @@
-"""핀, 이미지, 소리, 온도 및 음량입니다. (microbit)"""
+"""핀, 이미지, 소리, 온도 및 음량입니다."""
 from _typeshed import ReadableBuffer
 from typing import Any, Callable, List, Optional, overload
 from . import accelerometer as accelerometer
@@ -12,7 +12,7 @@ from . import uart as uart
 from . import audio as audio
 
 def run_every(callback: Optional[Callable[[], None]]=None, days: int=0, h: int=0, min: int=0, s: int=0, ms: int=0) -> Callable[[Callable[[], None]], Callable[[], None]]:
-    """주어진 주기에 따라 함수 호출 일정을 설정합니다 **V2 전용**. (run every)
+    """주어진 주기에 따라 함수 호출 일정을 설정합니다 **V2 전용**.
 
 Example: ``run_every(my_logging, min=5)``
 
@@ -28,31 +28,31 @@ or used as a decorator::
 
 Arguments with different time units are additive.
 
-:param callback: (callback) 인보크(원격 실행) 기능을 호출합니다. 데코레이터(장식자)로 사용할 때는 생략합니다.
-:param days: (days) 일 단위 주기입니다.
-:param h: (h) 시간 단위 주기입니다.
-:param min: (min) 분 단위 주기입니다.
-:param s: (s) 초 주기입니다.
-:param ms: (ms) 밀리초 주기입니다."""
+:param callback: 인보크(원격 실행) 기능을 호출합니다. 데코레이터(장식자)로 사용할 때는 생략합니다.
+:param days: 일 단위 주기입니다.
+:param h: 시간 단위 주기입니다.
+:param min: 분 단위 주기입니다.
+:param s: 초 주기입니다.
+:param ms: 밀리초 주기입니다."""
 
 def panic(n: int) -> None:
-    """패닉 모드를 활성화합니다. (panic)
+    """패닉 모드를 활성화합니다.
 
 Example: ``panic(127)``
 
-:param n: (n) <= 255의 임의 정수로 상태를 표시합니다.
+:param n: <= 255의 임의 정수로 상태를 표시합니다.
 
 Requires restart."""
 
 def reset() -> None:
-    """보드를 재시작합니다. (reset)"""
+    """보드를 재시작합니다."""
 
 def sleep(n: float) -> None:
-    """``n``밀리초 동안 대기합니다. (sleep)
+    """``n``밀리초 동안 대기합니다.
 
 Example: ``sleep(1000)``
 
-:param n: (n) 대기할 밀리초 수
+:param n: 대기할 밀리초 수
 
 One second is 1000 milliseconds, so::
 
@@ -61,7 +61,7 @@ One second is 1000 milliseconds, so::
 will pause the execution for one second."""
 
 def running_time() -> int:
-    """보드의 실행 시간을 불러옵니다. (running time)
+    """보드의 실행 시간을 불러옵니다.
 
 :return: The number of milliseconds since the board was switched on or restarted."""
 
@@ -69,11 +69,11 @@ def temperature() -> int:
     """섭씨로 micro:bit의 온도를 불러옵니다. (온도)"""
 
 def set_volume(v: int) -> None:
-    """음량을 설정합니다. (set volume)
+    """음량을 설정합니다.
 
 Example: ``set_volume(127)``
 
-:param v: (v) 0(낮음) 및 255(높음) 사이의 값입니다.
+:param v: 0(낮음) 및 255(높음) 사이의 값입니다.
 
 Out of range values will be clamped to 0 or 255.
 
@@ -81,16 +81,16 @@ Out of range values will be clamped to 0 or 255.
     ...
 
 class Button:
-    """``button_a`` 및 ``button_b`` 버튼 클래스입니다. (button)"""
+    """``button_a`` 및 ``button_b`` 버튼 클래스입니다."""
 
     def is_pressed(self) -> bool:
-        """해당 버튼이 눌렸는지 확인합니다. (is pressed)
+        """해당 버튼이 눌렸는지 확인합니다.
 
 :return: ``True`` if the specified button ``button`` is pressed, and ``False`` otherwise."""
         ...
 
     def was_pressed(self) -> bool:
-        """장치가 시작한 후 또는 이 메서드가 호출된 후 해당 버튼이 눌렸는지 확인합니다. (was pressed)
+        """장치가 시작한 후 또는 이 메서드가 호출된 후 해당 버튼이 눌렸는지 확인합니다.
 
 Calling this method will clear the press state so
 that the button must be pressed again before this method will return
@@ -100,17 +100,17 @@ that the button must be pressed again before this method will return
         ...
 
     def get_presses(self) -> int:
-        """버튼이 눌린 총 횟수를 불러오고, 총값을 반환하기 전 초기화합니다. (get presses)
+        """버튼이 눌린 총 횟수를 불러오고, 총값을 반환하기 전 초기화합니다.
 
 :return: The number of presses since the device started or the last time this method was called"""
         ...
 button_a: Button
-"""좌측 버튼 ``Button`` 개체입니다. (button a)"""
+"""좌측 버튼 ``Button`` 개체입니다."""
 button_b: Button
-"""우측 버튼 ``Button`` 개체입니다. (button b)"""
+"""우측 버튼 ``Button`` 개체입니다."""
 
 class MicroBitDigitalPin:
-    """디지털 핀입니다. (microbitdigitalpin)
+    """디지털 핀입니다.
 
 Some pins support analog and touch features using the ``MicroBitAnalogDigitalPin`` and ``MicroBitTouchPin`` subclasses."""
     NO_PULL: int
@@ -118,7 +118,7 @@ Some pins support analog and touch features using the ``MicroBitAnalogDigitalPin
     PULL_DOWN: int
 
     def read_digital(self) -> int:
-        """핀의 디지털 값을 불러옵니다. (read digital)
+        """핀의 디지털 값을 불러옵니다.
 
 Example: ``value = pin0.read_digital()``
 
@@ -126,23 +126,23 @@ Example: ``value = pin0.read_digital()``
         ...
 
     def write_digital(self, value: int) -> None:
-        """핀의 디지털 값을 설정합니다. (write digital)
+        """핀의 디지털 값을 설정합니다.
 
 Example: ``pin0.write_digital(1)``
 
-:param value: (value) 핀을 하이로 설정하려면 1, 로우로 설정하려면 0"""
+:param value: 핀을 하이로 설정하려면 1, 로우로 설정하려면 0"""
         ...
 
     def set_pull(self, value: int) -> None:
-        """다음 중 하나의 값으로 풀 상태를 설정: ``PULL_UP``, ``PULL_DOWN`` 또는 ``NO_PULL`` (set pull)
+        """다음 중 하나의 값으로 풀 상태를 설정: ``PULL_UP``, ``PULL_DOWN`` 또는 ``NO_PULL``
 
 Example: ``pin0.set_pull(pin0.PULL_UP)``
 
-:param value: (value) 관련 핀의 풀 상태입니다. (예: ``pin0.PULL_UP``)"""
+:param value: 관련 핀의 풀 상태입니다. (예: ``pin0.PULL_UP``)"""
         ...
 
     def get_pull(self) -> int:
-        """핀의 풀 상태를 불러옵니다. (get pull)
+        """핀의 풀 상태를 불러옵니다.
 
 Example: ``pin0.get_pull()``
 
@@ -153,7 +153,7 @@ when a pin mode requires it."""
         ...
 
     def get_mode(self) -> str:
-        """핀 모드를 반환합니다. (get mode)
+        """핀 모드를 반환합니다.
 
 Example: ``pin0.get_mode()``
 
@@ -165,43 +165,43 @@ changes.
         ...
 
     def write_analog(self, value: int) -> None:
-        """핀의 PWM 신호를 출력하고 ``value``와(과) 비례해 듀티 사이클을 설정합니다. (write analog)
+        """핀의 PWM 신호를 출력하고 ``value``와(과) 비례해 듀티 사이클을 설정합니다.
 
 Example: ``pin0.write_analog(254)``
 
-:param value: (value) 0(0% 듀티 사이클) 및 1023(100% 듀티) 사이의 정수 또는 부동 소수점 수입니다."""
+:param value: 0(0% 듀티 사이클) 및 1023(100% 듀티) 사이의 정수 또는 부동 소수점 수입니다."""
 
     def set_analog_period(self, period: int) -> None:
-        """PWM 신호가 출력되는 주기를 ``period``밀리초로 설정합니다. (set analog period)
+        """PWM 신호가 출력되는 주기를 ``period``밀리초로 설정합니다.
 
 Example: ``pin0.set_analog_period(10)``
 
-:param period: (period) 유효한 최소값이 1ms인 밀리초 주기입니다."""
+:param period: 유효한 최소값이 1ms인 밀리초 주기입니다."""
 
     def set_analog_period_microseconds(self, period: int) -> None:
-        """PWM 신호가 출력되는 주기를 ``period``마이크로초로 설정합니다. (set analog period microseconds)
+        """PWM 신호가 출력되는 주기를 ``period``마이크로초로 설정합니다.
 
 Example: ``pin0.set_analog_period_microseconds(512)``
 
-:param period: (period) 유효한 최소값이 256µs인 마이크로초 주기입니다."""
+:param period: 유효한 최소값이 256µs인 마이크로초 주기입니다."""
 
 class MicroBitAnalogDigitalPin(MicroBitDigitalPin):
-    """아날로그 및 디지털 기능이 있는 핀입니다. (microbitanalogdigitalpin)"""
+    """아날로그 및 디지털 기능이 있는 핀입니다."""
 
     def read_analog(self) -> int:
-        """핀에 적용된 전압을 읽습니다. (read analog)
+        """핀에 적용된 전압을 읽습니다.
 
 Example: ``pin0.read_analog()``
 
 :return: An integer between 0 (meaning 0V) and 1023 (meaning 3.3V)."""
 
 class MicroBitTouchPin(MicroBitAnalogDigitalPin):
-    """아날로그, 디지털, 터치 기능이 있는 핀입니다. (microbittouchpin)"""
+    """아날로그, 디지털, 터치 기능이 있는 핀입니다."""
     CAPACITIVE: int
     RESISTIVE: int
 
     def is_touched(self) -> bool:
-        """핀이 접촉 상태인지 확인합니다. (is touched)
+        """핀이 접촉 상태인지 확인합니다.
 
 Example: ``pin0.is_touched()``
 
@@ -224,53 +224,53 @@ does not require you to make a ground connection as part of a circuit.
         ...
 
     def set_touch_mode(self, value: int) -> None:
-        """핀의 터치 모드를 설정합니다. (set touch mode)
+        """핀의 터치 모드를 설정합니다.
 
 Example: ``pin0.set_touch_mode(pin0.CAPACITIVE)``
 
 The default touch mode for the pins on the edge connector is
 ``resistive``. The default for the logo pin **V2** is ``capacitive``.
 
-:param value: (value) 관련 핀의 ``CAPACITIVE`` 또는 ``RESISTIVE``입니다."""
+:param value: 관련 핀의 ``CAPACITIVE`` 또는 ``RESISTIVE``입니다."""
         ...
 pin0: MicroBitTouchPin
-"""디지털 및 아날로그, 터치 기능이 있는 핀입니다. (pin0)"""
+"""디지털 및 아날로그, 터치 기능이 있는 핀입니다."""
 pin1: MicroBitTouchPin
-"""디지털 및 아날로그, 터치 기능이 있는 핀입니다. (pin1)"""
+"""디지털 및 아날로그, 터치 기능이 있는 핀입니다."""
 pin2: MicroBitTouchPin
-"""디지털 및 아날로그, 터치 기능이 있는 핀입니다. (pin2)"""
+"""디지털 및 아날로그, 터치 기능이 있는 핀입니다."""
 pin3: MicroBitAnalogDigitalPin
-"""디지털 및 아날로그 기능이 있는 핀입니다. (pin3)"""
+"""디지털 및 아날로그 기능이 있는 핀입니다."""
 pin4: MicroBitAnalogDigitalPin
-"""디지털 및 아날로그 기능이 있는 핀입니다. (pin4)"""
+"""디지털 및 아날로그 기능이 있는 핀입니다."""
 pin5: MicroBitDigitalPin
 """디지털 기능이 있는 핀입니다. (pin speaker)"""
 pin6: MicroBitDigitalPin
-"""디지털 기능이 있는 핀입니다. (pin6)"""
+"""디지털 기능이 있는 핀입니다."""
 pin7: MicroBitDigitalPin
-"""디지털 기능이 있는 핀입니다. (pin7)"""
+"""디지털 기능이 있는 핀입니다."""
 pin8: MicroBitDigitalPin
-"""디지털 기능이 있는 핀입니다. (pin8)"""
+"""디지털 기능이 있는 핀입니다."""
 pin9: MicroBitDigitalPin
-"""디지털 기능이 있는 핀입니다. (pin9)"""
+"""디지털 기능이 있는 핀입니다."""
 pin10: MicroBitAnalogDigitalPin
-"""디지털 및 아날로그 기능이 있는 핀입니다. (pin10)"""
+"""디지털 및 아날로그 기능이 있는 핀입니다."""
 pin11: MicroBitDigitalPin
-"""디지털 기능이 있는 핀입니다. (pin11)"""
+"""디지털 기능이 있는 핀입니다."""
 pin12: MicroBitDigitalPin
-"""디지털 기능이 있는 핀입니다. (pin12)"""
+"""디지털 기능이 있는 핀입니다."""
 pin13: MicroBitDigitalPin
-"""디지털 기능이 있는 핀입니다. (pin13)"""
+"""디지털 기능이 있는 핀입니다."""
 pin14: MicroBitDigitalPin
-"""디지털 기능이 있는 핀입니다. (pin14)"""
+"""디지털 기능이 있는 핀입니다."""
 pin15: MicroBitDigitalPin
-"""디지털 기능이 있는 핀입니다. (pin15)"""
+"""디지털 기능이 있는 핀입니다."""
 pin16: MicroBitDigitalPin
-"""디지털 기능이 있는 핀입니다. (pin16)"""
+"""디지털 기능이 있는 핀입니다."""
 pin19: MicroBitDigitalPin
-"""디지털 기능이 있는 핀입니다. (pin19)"""
+"""디지털 기능이 있는 핀입니다."""
 pin20: MicroBitDigitalPin
-"""디지털 기능이 있는 핀입니다. (pin20)"""
+"""디지털 기능이 있는 핀입니다."""
 pin_logo: MicroBitTouchPin
 """micro:bit 전면의 터치 감지 로고 핀으로, 기본값은 정전식 터치 모드입니다. (핀 로고)"""
 pin_speaker: MicroBitAnalogDigitalPin
@@ -280,141 +280,141 @@ This API is intended only for use in Pulse-Width Modulation pin operations e.g. 
 """
 
 class Image:
-    """micro:bit LED 디스플레이에 표시할 이미지입니다. (image)
+    """micro:bit LED 디스플레이에 표시할 이미지입니다.
 
 Given an image object it's possible to display it via the ``display`` API::
 
     display.show(Image.HAPPY)"""
     HEART: Image
-    """하트 이미지입니다. (heart)"""
+    """하트 이미지입니다."""
     HEART_SMALL: Image
-    """작은 하트 이미지입니다. (heart small)"""
+    """작은 하트 이미지입니다."""
     HAPPY: Image
-    """행복한 얼굴 이미지입니다. (happy)"""
+    """행복한 얼굴 이미지입니다."""
     SMILE: Image
-    """미소 짓는 얼굴 이미지입니다. (smile)"""
+    """미소 짓는 얼굴 이미지입니다."""
     SAD: Image
-    """슬픈 얼굴 이미지입니다. (sad)"""
+    """슬픈 얼굴 이미지입니다."""
     CONFUSED: Image
-    """혼란스러운 얼굴 이미지입니다. (confused)"""
+    """혼란스러운 얼굴 이미지입니다."""
     ANGRY: Image
-    """화난 얼굴 이미지입니다. (angry)"""
+    """화난 얼굴 이미지입니다."""
     ASLEEP: Image
-    """자는 얼굴 이미지입니다. (asleep)"""
+    """자는 얼굴 이미지입니다."""
     SURPRISED: Image
-    """놀란 얼굴 이미지입니다. (surprised)"""
+    """놀란 얼굴 이미지입니다."""
     SILLY: Image
-    """우스꽝스러운 얼굴 이미지입니다. (silly)"""
+    """우스꽝스러운 얼굴 이미지입니다."""
     FABULOUS: Image
-    """선글라스를 쓴 얼굴 이미지입니다. (fabulous)"""
+    """선글라스를 쓴 얼굴 이미지입니다."""
     MEH: Image
-    """지루한 얼굴 이미지입니다. (meh)"""
+    """지루한 얼굴 이미지입니다."""
     YES: Image
-    """체크 표시 이미지입니다. (yes)"""
+    """체크 표시 이미지입니다."""
     NO: Image
-    """엑스 표시 이미지입니다. (no)"""
+    """엑스 표시 이미지입니다."""
     CLOCK12: Image
-    """12시 정각을 가리키는 이미지입니다. (clock12)"""
+    """12시 정각을 가리키는 이미지입니다."""
     CLOCK11: Image
-    """11시 정각을 가리키는 이미지입니다. (clock11)"""
+    """11시 정각을 가리키는 이미지입니다."""
     CLOCK10: Image
-    """10시 정각을 가리키는 이미지입니다. (clock10)"""
+    """10시 정각을 가리키는 이미지입니다."""
     CLOCK9: Image
-    """9시 정각을 가리키는 이미지입니다. (clock9)"""
+    """9시 정각을 가리키는 이미지입니다."""
     CLOCK8: Image
-    """8시 정각을 가리키는 이미지입니다. (clock8)"""
+    """8시 정각을 가리키는 이미지입니다."""
     CLOCK7: Image
-    """7시 정각을 가리키는 이미지입니다. (clock7)"""
+    """7시 정각을 가리키는 이미지입니다."""
     CLOCK6: Image
-    """6시 정각을 가리키는 이미지입니다. (clock6)"""
+    """6시 정각을 가리키는 이미지입니다."""
     CLOCK5: Image
-    """5시 정각을 가리키는 이미지입니다. (clock5)"""
+    """5시 정각을 가리키는 이미지입니다."""
     CLOCK4: Image
-    """4시 정각을 가리키는 이미지입니다. (clock4)"""
+    """4시 정각을 가리키는 이미지입니다."""
     CLOCK3: Image
-    """3시 정각을 가리키는 이미지입니다. (clock3)"""
+    """3시 정각을 가리키는 이미지입니다."""
     CLOCK2: Image
-    """2시 정각을 가리키는 이미지입니다. (clock2)"""
+    """2시 정각을 가리키는 이미지입니다."""
     CLOCK1: Image
-    """1시 정각을 가리키는 이미지입니다. (clock1)"""
+    """1시 정각을 가리키는 이미지입니다."""
     ARROW_N: Image
-    """북쪽을 가리키는 화살표 이미지입니다. (arrow n)"""
+    """북쪽을 가리키는 화살표 이미지입니다."""
     ARROW_NE: Image
-    """북동쪽을 가리키는 화살표 이미지입니다. (arrow ne)"""
+    """북동쪽을 가리키는 화살표 이미지입니다."""
     ARROW_E: Image
-    """동쪽을 가리키는 화살표 이미지입니다. (arrow e)"""
+    """동쪽을 가리키는 화살표 이미지입니다."""
     ARROW_SE: Image
-    """남동쪽을 가리키는 화살표 이미지입니다. (arrow se)"""
+    """남동쪽을 가리키는 화살표 이미지입니다."""
     ARROW_S: Image
-    """남쪽을 가리키는 화살표 이미지입니다. (arrow s)"""
+    """남쪽을 가리키는 화살표 이미지입니다."""
     ARROW_SW: Image
-    """남서쪽을 가리키는 화살표 이미지입니다. (arrow sw)"""
+    """남서쪽을 가리키는 화살표 이미지입니다."""
     ARROW_W: Image
-    """서쪽을 가리키는 화살표 이미지입니다. (arrow w)"""
+    """서쪽을 가리키는 화살표 이미지입니다."""
     ARROW_NW: Image
-    """북서쪽을 가리키는 화살표 이미지입니다. (arrow nw)"""
+    """북서쪽을 가리키는 화살표 이미지입니다."""
     TRIANGLE: Image
-    """위쪽을 가리키는 삼각형 이미지입니다. (triangle)"""
+    """위쪽을 가리키는 삼각형 이미지입니다."""
     TRIANGLE_LEFT: Image
-    """좌측 구석의 삼각형 이미지입니다. (triangle left)"""
+    """좌측 구석의 삼각형 이미지입니다."""
     CHESSBOARD: Image
-    """체스판 패턴으로 깜빡이는 LED 불빛입니다. (chessboard)"""
+    """체스판 패턴으로 깜빡이는 LED 불빛입니다."""
     DIAMOND: Image
-    """다이아몬드 이미지입니다. (diamond)"""
+    """다이아몬드 이미지입니다."""
     DIAMOND_SMALL: Image
-    """작은 다이아몬드 이미지입니다. (diamond small)"""
+    """작은 다이아몬드 이미지입니다."""
     SQUARE: Image
-    """사각형 이미지입니다. (square)"""
+    """사각형 이미지입니다."""
     SQUARE_SMALL: Image
-    """작은 사각형 이미지입니다. (square small)"""
+    """작은 사각형 이미지입니다."""
     RABBIT: Image
-    """토끼 이미지입니다. (rabbit)"""
+    """토끼 이미지입니다."""
     COW: Image
-    """소 이미지입니다. (cow)"""
+    """소 이미지입니다."""
     MUSIC_CROTCHET: Image
-    """사분음표 이미지입니다. (music crotchet)"""
+    """사분음표 이미지입니다."""
     MUSIC_QUAVER: Image
-    """팔분음표 이미지입니다. (music quaver)"""
+    """팔분음표 이미지입니다."""
     MUSIC_QUAVERS: Image
-    """두 개의 팔분음표 이미지입니다. (music quavers)"""
+    """두 개의 팔분음표 이미지입니다."""
     PITCHFORK: Image
-    """쇠스랑 이미지입니다. (pitchfork)"""
+    """쇠스랑 이미지입니다."""
     XMAS: Image
-    """크리스마스 나무 이미지입니다. (xmas)"""
+    """크리스마스 나무 이미지입니다."""
     PACMAN: Image
-    """오락실 캐릭터 Pac-Man 이미지입니다. (pacman)"""
+    """오락실 캐릭터 Pac-Man 이미지입니다."""
     TARGET: Image
-    """표적 이미지입니다. (target)"""
+    """표적 이미지입니다."""
     TSHIRT: Image
-    """티셔츠 이미지입니다. (tshirt)"""
+    """티셔츠 이미지입니다."""
     ROLLERSKATE: Image
-    """롤러스케이트 이미지입니다. (rollerskate)"""
+    """롤러스케이트 이미지입니다."""
     DUCK: Image
-    """오리 이미지입니다. (duck)"""
+    """오리 이미지입니다."""
     HOUSE: Image
-    """집 이미지입니다. (house)"""
+    """집 이미지입니다."""
     TORTOISE: Image
-    """거북이 이미지입니다. (tortoise)"""
+    """거북이 이미지입니다."""
     BUTTERFLY: Image
-    """나비 이미지입니다. (butterfly)"""
+    """나비 이미지입니다."""
     STICKFIGURE: Image
-    """막대인간 이미지입니다. (stickfigure)"""
+    """막대인간 이미지입니다."""
     GHOST: Image
-    """유령 이미지입니다. (ghost)"""
+    """유령 이미지입니다."""
     SWORD: Image
-    """칼 이미지입니다. (sword)"""
+    """칼 이미지입니다."""
     GIRAFFE: Image
-    """기린 이미지입니다. (giraffe)"""
+    """기린 이미지입니다."""
     SKULL: Image
-    """해골 이미지입니다. (skull)"""
+    """해골 이미지입니다."""
     UMBRELLA: Image
-    """우산 이미지입니다. (umbrella)"""
+    """우산 이미지입니다."""
     SNAKE: Image
-    """뱀 이미지입니다. (snake)"""
+    """뱀 이미지입니다."""
     ALL_CLOCKS: List[Image]
-    """모든 CLOCK_ 이미지를 순서대로 나열한 리스트입니다. (all clocks)"""
+    """모든 CLOCK_ 이미지를 순서대로 나열한 리스트입니다."""
     ALL_ARROWS: List[Image]
-    """모든 ARROW_ 이미지를 순서대로 나열한 리스트입니다. (all arrows)"""
+    """모든 ARROW_ 이미지를 순서대로 나열한 리스트입니다."""
 
     @overload
     def __init__(self, string: str) -> None:
@@ -432,16 +432,16 @@ describing the image, for example::
 will create a 5×5 image of an X. The end of a line is indicated by a
 colon. It's also possible to use newlines (\\n) insead of the colons.
 
-:param string: (string) 이미지를 설명하는 문자열입니다."""
+:param string: 이미지를 설명하는 문자열입니다."""
         ...
 
     @overload
     def __init__(self, width: int=5, height: int=5, buffer: ReadableBuffer=None) -> None:
-        """``width`` 열과 ``height`` 행의 비어있는 이미지를 생성합니다. (init)
+        """``width`` 열과 ``height`` 행의 비어있는 이미지를 생성합니다.
 
-:param width: (width) 이미지 너비(선택 사항)
-:param height: (height) 이미지 높이(선택 사항)
-:param buffer: (buffer) 0~9의 범위에 속하는 정수로 구성된 ``width``x``height`` 배열 또는 바이트(선택 사항)
+:param width: 이미지 너비(선택 사항)
+:param height: 이미지 높이(선택 사항)
+:param buffer: 0~9의 범위에 속하는 정수로 구성된 ``width``x``height`` 배열 또는 바이트(선택 사항)
 
 Examples::
 
@@ -452,90 +452,90 @@ These create 2 x 2 pixel images at full brightness."""
         ...
 
     def width(self) -> int:
-        """열의 수를 불러옵니다. (width)
+        """열의 수를 불러옵니다.
 
 :return: The number of columns in the image"""
         ...
 
     def height(self) -> int:
-        """행의 수를 불러옵니다. (height)
+        """행의 수를 불러옵니다.
 
 :return: The number of rows in the image"""
         ...
 
     def set_pixel(self, x: int, y: int, value: int) -> None:
-        """픽셀의 밝기를 설정합니다. (set pixel)
+        """픽셀의 밝기를 설정합니다.
 
 Example: ``my_image.set_pixel(0, 0, 9)``
 
-:param x: (x) 열 번호
-:param y: (y) 행 번호
-:param value: (value) 0(어두움)과 9(밝음) 사이의 정수로 밝기를 설정합니다.
+:param x: 열 번호
+:param y: 행 번호
+:param value: 0(어두움)과 9(밝음) 사이의 정수로 밝기를 설정합니다.
 
 This method will raise an exception when called on any of the built-in
 read-only images, like ``Image.HEART``."""
         ...
 
     def get_pixel(self, x: int, y: int) -> int:
-        """픽셀의 밝기를 불러옵니다. (get pixel)
+        """픽셀의 밝기를 불러옵니다.
 
 Example: ``my_image.get_pixel(0, 0)``
 
-:param x: (x) 열 번호
-:param y: (y) 행 번호
+:param x: 열 번호
+:param y: 행 번호
 :return: The brightness as an integer between 0 and 9."""
         ...
 
     def shift_left(self, n: int) -> Image:
-        """사진을 좌측으로 옮겨 새로운 이미지를 생성합니다. (shift left)
+        """사진을 좌측으로 옮겨 새로운 이미지를 생성합니다.
 
 Example: ``Image.HEART_SMALL.shift_left(1)``
 
-:param n: (n) 옮길 열의 수
+:param n: 옮길 열의 수
 :return: The shifted image"""
         ...
 
     def shift_right(self, n: int) -> Image:
-        """사진을 우측으로 옮겨 새로운 이미지를 생성합니다. (shift right)
+        """사진을 우측으로 옮겨 새로운 이미지를 생성합니다.
 
 Example: ``Image.HEART_SMALL.shift_right(1)``
 
-:param n: (n) 옮길 열의 수
+:param n: 옮길 열의 수
 :return: The shifted image"""
         ...
 
     def shift_up(self, n: int) -> Image:
-        """사진을 상단으로 옮겨 새로운 이미지를 생성합니다. (shift up)
+        """사진을 상단으로 옮겨 새로운 이미지를 생성합니다.
 
 Example: ``Image.HEART_SMALL.shift_up(1)``
 
-:param n: (n) 옮길 행의 수
+:param n: 옮길 행의 수
 :return: The shifted image"""
         ...
 
     def shift_down(self, n: int) -> Image:
-        """사진을 하단으로 옮겨 새로운 이미지를 생성합니다. (shift down)
+        """사진을 하단으로 옮겨 새로운 이미지를 생성합니다.
 
 Example: ``Image.HEART_SMALL.shift_down(1)``
 
-:param n: (n) 옮길 행의 수
+:param n: 옮길 행의 수
 :return: The shifted image"""
         ...
 
     def crop(self, x: int, y: int, w: int, h: int) -> Image:
-        """사진을 잘라 내 새로운 이미지를 생성합니다. (crop)
+        """사진을 잘라 내 새로운 이미지를 생성합니다.
 
 Example: ``Image.HEART.crop(1, 1, 3, 3)``
 
-:param x: (x) 자르기 오프셋 열
-:param y: (y) 자르기 오프셋 행
-:param w: (w) 자르기 너비
-:param h: (h) 자르기 높이
+:param x: 자르기 오프셋 열
+:param y: 자르기 오프셋 행
+:param w: 자르기 너비
+:param h: 자르기 높이
 :return: The new image"""
         ...
 
     def copy(self) -> Image:
-        """이미지와 동일한 사본을 생성합니다. (copy)
+        """이미지와 동일한 사본을 생성합니다.
 
 Example: ``Image.HEART.copy()``
 
@@ -543,7 +543,7 @@ Example: ``Image.HEART.copy()``
         ...
 
     def invert(self) -> Image:
-        """소스 이미지에 있는 픽셀을 밝기를 반전해 새로운 이미지를 생성합니다. (invert)
+        """소스 이미지에 있는 픽셀을 밝기를 반전해 새로운 이미지를 생성합니다.
 
 Example: ``Image.SMALL_HEART.invert()``
 
@@ -551,28 +551,28 @@ Example: ``Image.SMALL_HEART.invert()``
         ...
 
     def fill(self, value: int) -> None:
-        """이미지의 모든 픽셀의 밝기를 설정합니다. (fill)
+        """이미지의 모든 픽셀의 밝기를 설정합니다.
 
 Example: ``my_image.fill(5)``
 
-:param value: (value) 새로운 밝기를 0(어두움)과 9(밝기) 사이로 설정합니다.
+:param value: 새로운 밝기를 0(어두움)과 9(밝기) 사이로 설정합니다.
 
 This method will raise an exception when called on any of the built-in
 read-only images, like ``Image.HEART``."""
         ...
 
     def blit(self, src: Image, x: int, y: int, w: int, h: int, xdest: int=0, ydest: int=0) -> None:
-        """다른 이미지로부터 영역을 복사해 이 이미지로 가져옵니다. (blit)
+        """다른 이미지로부터 영역을 복사해 이 이미지로 가져옵니다.
 
 Example: ``my_image.blit(Image.HEART, 1, 1, 3, 3, 1, 1)``
 
-:param src: (src) 소스 이미지
-:param x: (x) 소스 이미지 내 시작 열 오프셋
-:param y: (y) 소스 이미지 내 시작 행 오프셋
-:param w: (w) 복사할 열의 수
-:param h: (h) 복사할 행 번호
-:param xdest: (xdest) 이 이미지에서 수정할 열의 오프셋
-:param ydest: (ydest) 이 이미지에서 수정할 행의 오프셋
+:param src: 소스 이미지
+:param x: 소스 이미지 내 시작 열 오프셋
+:param y: 소스 이미지 내 시작 행 오프셋
+:param w: 복사할 열의 수
+:param h: 복사할 행 번호
+:param xdest: 이 이미지에서 수정할 열의 오프셋
+:param ydest: 이 이미지에서 수정할 행의 오프셋
 
 Pixels outside the source image are treated as having a brightness of 0.
 
@@ -588,70 +588,70 @@ For example, img.crop(x, y, w, h) can be implemented as::
         ...
 
     def __repr__(self) -> str:
-        """이미지에 해당하는 컴팩트 스트링을 불러옵니다. (repr)"""
+        """이미지에 해당하는 컴팩트 스트링을 불러옵니다."""
         ...
 
     def __str__(self) -> str:
-        """이미지에 해당하는 읽기 가능 문자열을 불러옵니다. (str)"""
+        """이미지에 해당하는 읽기 가능 문자열을 불러옵니다."""
         ...
 
     def __add__(self, other: Image) -> Image:
-        """두 이미지의 각 픽셀의 밝기 값을 더해 새로운 이미지를 생성합니다. (add)
+        """두 이미지의 각 픽셀의 밝기 값을 더해 새로운 이미지를 생성합니다.
 
 Example: ``Image.HEART + Image.HAPPY``
 
-:param other: (other) 더할 이미지입니다."""
+:param other: 더할 이미지입니다."""
         ...
 
     def __sub__(self, other: Image) -> Image:
-        """두 이미지의 각 픽셀의 밝기 값을 빼 새로운 이미지를 생성합니다. (sub)
+        """두 이미지의 각 픽셀의 밝기 값을 빼 새로운 이미지를 생성합니다.
 
 Example: ``Image.HEART - Image.HEART_SMALL``
 
-:param other: (other) 뺄 이미지입니다."""
+:param other: 뺄 이미지입니다."""
         ...
 
     def __mul__(self, n: float) -> Image:
-        """각 픽셀의 밝기 값을 ``n``만큼 곱해 새로운 이미지를 생성합니다. (mul)
+        """각 픽셀의 밝기 값을 ``n``만큼 곱해 새로운 이미지를 생성합니다.
 
 Example: ``Image.HEART * 0.5``
 
-:param n: (n) 곱할 값입니다."""
+:param n: 곱할 값입니다."""
         ...
 
     def __truediv__(self, n: float) -> Image:
-        """각 픽셀의 밝기 값을 ``n``만큼 나누어 새로운 이미지를 생성합니다. (truediv)
+        """각 픽셀의 밝기 값을 ``n``만큼 나누어 새로운 이미지를 생성합니다.
 
 Example: ``Image.HEART / 2``
 
-:param n: (n) 나눌 값입니다."""
+:param n: 나눌 값입니다."""
         ...
 
 class SoundEvent:
     LOUD: SoundEvent
-    """``quiet``에서 박수 또는 함성 등 ``loud``로 소리 이벤트의 변화를 나타냅니다. (loud)"""
+    """``quiet``에서 박수 또는 함성 등 ``loud``로 소리 이벤트의 변화를 나타냅니다."""
     QUIET: SoundEvent
-    """``loud``에서 말소리 또는 배경 음악 등 ``quiet``로 소리 이벤트의 변화를 나타냅니다. (quiet)"""
+    """``loud``에서 말소리 또는 배경 음악 등 ``quiet``로 소리 이벤트의 변화를 나타냅니다."""
 
 class Sound:
-    """``audio.play(Sound.NAME)``을 사용해 내장된 소리를 호출합니다. (sound)"""
+    """``audio.play(Sound.NAME)``을 사용해 내장된 소리를 호출합니다."""
     GIGGLE: Sound
-    """웃는 소리입니다. (giggle)"""
+    """웃는 소리입니다."""
     HAPPY: Sound
-    """행복해하는 소리입니다. (happy)"""
+    """행복해하는 소리입니다."""
     HELLO: Sound
-    """인사 소리입니다. (hello)"""
+    """인사 소리입니다."""
     MYSTERIOUS: Sound
-    """신비한 소리입니다. (mysterious)"""
+    """신비한 소리입니다."""
     SAD: Sound
-    """슬퍼하는 소리입니다. (sad)"""
+    """슬퍼하는 소리입니다."""
     SLIDE: Sound
-    """슬라이드 소리입니다. (slide)"""
+    """슬라이드 소리입니다."""
     SOARING: Sound
-    """솟아오르는 소리입니다. (soaring)"""
+    """솟아오르는 소리입니다."""
     SPRING: Sound
-    """스프링 소리입니다. (spring)"""
+    """스프링 소리입니다."""
     TWINKLE: Sound
-    """반짝이는 소리입니다. (twinkle)"""
+    """반짝이는 소리입니다."""
     YAWN: Sound
-    """하품 소리입니다. (yawn)"""
+    """하품 소리입니다."""

--- a/lang/ko/typeshed/stdlib/microbit/accelerometer.pyi
+++ b/lang/ko/typeshed/stdlib/microbit/accelerometer.pyi
@@ -1,8 +1,8 @@
-"""micro:bit의 가속도를 측정하고 제스쳐를 인식합니다. (accelerometer)"""
+"""micro:bit의 가속도를 측정하고 제스쳐를 인식합니다."""
 from typing import Tuple
 
 def get_x() -> int:
-    """``x`` 축의 가속도 측정값을 milli-g로 불러옵니다. (get x)
+    """``x`` 축의 가속도 측정값을 milli-g로 불러옵니다.
 
 Example: ``accelerometer.get_x()``
 
@@ -10,7 +10,7 @@ Example: ``accelerometer.get_x()``
     ...
 
 def get_y() -> int:
-    """``y`` 축의 가속도 측정값을 milli-g로 불러옵니다. (get y)
+    """``y`` 축의 가속도 측정값을 milli-g로 불러옵니다.
 
 Example: ``accelerometer.get_y()``
 
@@ -18,7 +18,7 @@ Example: ``accelerometer.get_y()``
     ...
 
 def get_z() -> int:
-    """``z`` 축의 가속도 측정값을 milli-g로 불러옵니다. (get z)
+    """``z`` 축의 가속도 측정값을 milli-g로 불러옵니다.
 
 Example: ``accelerometer.get_z()``
 
@@ -26,7 +26,7 @@ Example: ``accelerometer.get_z()``
     ...
 
 def get_values() -> Tuple[int, int, int]:
-    """한 번에 모든 축의 가속도 측정값을 튜플로 불러옵니다. (get values)
+    """한 번에 모든 축의 가속도 측정값을 튜플로 불러옵니다.
 
 Example: ``x, y, z = accelerometer.get_values()``
 
@@ -34,7 +34,7 @@ Example: ``x, y, z = accelerometer.get_values()``
     ...
 
 def current_gesture() -> str:
-    """현재 제스처의 이름을 불러옵니다. (current gesture)
+    """현재 제스처의 이름을 불러옵니다.
 
 Example: ``accelerometer.current_gesture()``
 
@@ -47,7 +47,7 @@ represented as strings.
     ...
 
 def is_gesture(name: str) -> bool:
-    """해당 이름의 제스처가 현재 활성화 상태인지 확인합니다. (is gesture)
+    """해당 이름의 제스처가 현재 활성화 상태인지 확인합니다.
 
 Example: ``accelerometer.is_gesture('shake')``
 
@@ -56,12 +56,12 @@ MicroPython understands the following gesture names: ``"up"``, ``"down"``,
 ``"3g"``, ``"6g"``, ``"8g"``, ``"shake"``. Gestures are always
 represented as strings.
 
-:param name: (name) 제스쳐 이름.
+:param name: 제스쳐 이름.
 :return: ``True`` if the gesture is active, ``False`` otherwise."""
     ...
 
 def was_gesture(name: str) -> bool:
-    """해당 이름의 제스처가 마지막 호출 이후로 활성화된 적이 있는지 확인합니다. (was gesture)
+    """해당 이름의 제스처가 마지막 호출 이후로 활성화된 적이 있는지 확인합니다.
 
 Example: ``accelerometer.was_gesture('shake')``
 
@@ -70,11 +70,11 @@ MicroPython understands the following gesture names: ``"up"``, ``"down"``,
 ``"3g"``, ``"6g"``, ``"8g"``, ``"shake"``. Gestures are always
 represented as strings.
 
-:param name: (name) 제스처 이름입니다.
+:param name: 제스처 이름입니다.
 :return: ``True`` if the gesture was active since the last call, ``False`` otherwise."""
 
 def get_gestures() -> Tuple[str, ...]:
-    """제스처 기록의 튜플을 반환합니다. (get gestures)
+    """제스처 기록의 튜플을 반환합니다.
 
 Example: ``accelerometer.get_gestures()``
 

--- a/lang/ko/typeshed/stdlib/microbit/audio.pyi
+++ b/lang/ko/typeshed/stdlib/microbit/audio.pyi
@@ -1,19 +1,19 @@
-"""micro:bit을 활용해 소리를 재생합니다(V1 호환을 위해서는 ``audio``를 가져오세요). (audio)"""
+"""micro:bit을 활용해 소리를 재생합니다(V1 호환을 위해서는 ``audio``를 가져오세요)."""
 from ..microbit import MicroBitDigitalPin, Sound, pin0
 from typing import Iterable, Union
 
 def play(source: Union[Iterable[AudioFrame], Sound], wait: bool=True, pin: MicroBitDigitalPin=pin0, return_pin: Union[MicroBitDigitalPin, None]=None) -> None:
-    """내장된 소리 또는 커스텀 오디오 프레임을 재생합니다. (play)
+    """내장된 소리 또는 커스텀 오디오 프레임을 재생합니다.
 
 Example: ``audio.play(Sound.GIGGLE)``
 
-:param source: (source) ``Sound.GIGGLE`` 등의 내장된 ``Sound`` 또는 ``AudioFrame`` 오브젝트의 연속형 자료 샘플 데이터입니다.
-:param wait: (wait) ``wait``이 ``True``인 경우 사운드 재생이 완료될 때까지 이 함수가 차단됩니다.
+:param source: ``Sound.GIGGLE`` 등의 내장된 ``Sound`` 또는 ``AudioFrame`` 오브젝트의 연속형 자료 샘플 데이터입니다.
+:param wait: ``wait``이 ``True``인 경우 사운드 재생이 완료될 때까지 이 함수가 차단됩니다.
 :param pin: (핀) ``pin0``의 기본값을 덮어쓰는 데 사용할 출력 핀을 특정하는 인자입니다(선택 사항). 사운드를 재생하고 싶지 않다면 ``pin=None``을 사용할 수 있습니다.
-:param return_pin: (return pin) 접지 대신 외부 스피커에 연결할 차동 엣지 커넥터 핀을 특정합니다. **V2** 수정 버전에서는 무시합니다."""
+:param return_pin: 접지 대신 외부 스피커에 연결할 차동 엣지 커넥터 핀을 특정합니다. **V2** 수정 버전에서는 무시합니다."""
 
 def is_playing() -> bool:
-    """소리가 재생 중인지 체크합니다. (is playing)
+    """소리가 재생 중인지 체크합니다.
 
 Example: ``audio.is_playing()``
 
@@ -21,13 +21,13 @@ Example: ``audio.is_playing()``
     ...
 
 def stop() -> None:
-    """모든 오디오 플레이백을 중지합니다. (stop)
+    """모든 오디오 플레이백을 중지합니다.
 
 Example: ``audio.stop()``"""
     ...
 
 class AudioFrame:
-    """``AudioFrame`` 오브젝트는 부호 없는 바이트 샘플 32개의 리스트입니다(0에서 255 사이의 모든 숫자). (audioframe)
+    """``AudioFrame`` 오브젝트는 부호 없는 바이트 샘플 32개의 리스트입니다(0에서 255 사이의 모든 숫자).
 
 It takes just over 4 ms to play a single frame.
 

--- a/lang/ko/typeshed/stdlib/microbit/compass.pyi
+++ b/lang/ko/typeshed/stdlib/microbit/compass.pyi
@@ -1,7 +1,7 @@
 """내장된 나침반을 사용합니다. (나침반)"""
 
 def calibrate() -> None:
-    """보정 프로세스를 시작합니다. (calibrate)
+    """보정 프로세스를 시작합니다.
 
 Example: ``compass.calibrate()``
 
@@ -10,7 +10,7 @@ to rotate the device in order to draw a circle on the LED display."""
     ...
 
 def is_calibrated() -> bool:
-    """나침반이 보정되었는지 확인합니다. (is calibrated)
+    """나침반이 보정되었는지 확인합니다.
 
 Example: ``compass.is_calibrated()``
 
@@ -18,13 +18,13 @@ Example: ``compass.is_calibrated()``
     ...
 
 def clear_calibration() -> None:
-    """보정을 해제해 나침반을 보정하지 않은 상태로 설정합니다. (clear calibration)
+    """보정을 해제해 나침반을 보정하지 않은 상태로 설정합니다.
 
 Example: ``compass.clear_calibration()``"""
     ...
 
 def get_x() -> int:
-    """``x`` 축의 자기장 강도를 불러옵니다. (get x)
+    """``x`` 축의 자기장 강도를 불러옵니다.
 
 Example: ``compass.get_x()``
 
@@ -34,7 +34,7 @@ Call ``calibrate`` first or the results will be inaccurate.
     ...
 
 def get_y() -> int:
-    """``y`` 축의 자기장 강도를 불러옵니다. (get y)
+    """``y`` 축의 자기장 강도를 불러옵니다.
 
 Example: ``compass.get_y()``
 
@@ -44,7 +44,7 @@ Call ``calibrate`` first or the results will be inaccurate.
     ...
 
 def get_z() -> int:
-    """``z`` 축의 자기장 강도를 불러옵니다. (get z)
+    """``z`` 축의 자기장 강도를 불러옵니다.
 
 Example: ``compass.get_z()``
 
@@ -54,7 +54,7 @@ Call ``calibrate`` first or the results will be inaccurate.
     ...
 
 def heading() -> int:
-    """나침반의 방향을 불러옵니다. (heading)
+    """나침반의 방향을 불러옵니다.
 
 Example: ``compass.heading()``
 
@@ -62,7 +62,7 @@ Example: ``compass.heading()``
     ...
 
 def get_field_strength() -> int:
-    """장치 주변의 자기장 규모를 불러옵니다. (get field strength)
+    """장치 주변의 자기장 규모를 불러옵니다.
 
 Example: ``compass.get_field_strength()``
 

--- a/lang/ko/typeshed/stdlib/microbit/display.pyi
+++ b/lang/ko/typeshed/stdlib/microbit/display.pyi
@@ -1,79 +1,79 @@
-"""5×5 LED 디스플레이에 텍스트, 이미지, 애니메이션을 표시합니다. (display)"""
+"""5×5 LED 디스플레이에 텍스트, 이미지, 애니메이션을 표시합니다."""
 from ..microbit import Image
 from typing import Union, overload, Iterable
 
 def get_pixel(x: int, y: int) -> int:
-    """열 ``x``와 행 ``y``의 LED의 밝기를 불러옵니다. (get pixel)
+    """열 ``x``와 행 ``y``의 LED의 밝기를 불러옵니다.
 
 Example: ``display.get_pixel(0, 0)``
 
-:param x: (x) 디스플레이 열(0..4)
-:param y: (y) 디스플레이 행(0..4)
+:param x: 디스플레이 열(0..4)
+:param y: 디스플레이 행(0..4)
 :return: A number between 0 (off) and 9 (bright)"""
     ...
 
 def set_pixel(x: int, y: int, value: int) -> None:
-    """열 ``x``와 행 ``y``의 LED의 밝기를 설정합니다. (set pixel)
+    """열 ``x``와 행 ``y``의 LED의 밝기를 설정합니다.
 
 Example: ``display.set_pixel(0, 0, 9)``
 
-:param x: (x) 디스플레이 열(0..4)
-:param y: (y) 디스플레이 행(0..4)
-:param value: (value) 0(꺼짐)과 9(밝음) 사이의 밝기"""
+:param x: 디스플레이 열(0..4)
+:param y: 디스플레이 행(0..4)
+:param value: 0(꺼짐)과 9(밝음) 사이의 밝기"""
     ...
 
 def clear() -> None:
-    """모든 LED의 밝기를 0(꺼짐)으로 설정합니다. (clear)
+    """모든 LED의 밝기를 0(꺼짐)으로 설정합니다.
 
 Example: ``display.clear()``"""
     ...
 
 def show(image: Union[str, float, int, Image, Iterable[Image]], delay: int=400, wait: bool=True, loop: bool=False, clear: bool=False) -> None:
-    """LED 디스플레이에 이미지, 글자 또는 숫자를 표시합니다. (show)
+    """LED 디스플레이에 이미지, 글자 또는 숫자를 표시합니다.
 
 Example: ``display.show(Image.HEART)``
 
 When ``image`` is an image or a list of images then each image is displayed in turn.
 If ``image`` is a string or number, each letter or digit is displayed in turn.
 
-:param image: (image) 표시할 문자열, 숫자, 이미지 또는 이미지 리스트입니다.
-:param delay: (delay) ``delay``밀리초의 지연 시간을 두고 각 글자, 숫자 또는 이미지가 표시됩니다.
-:param wait: (wait) ``wait``가 ``True``인 경우 이 기능은 애니메이션이 종료될 때까지 차단됩니다. 그렇지 않은 경우 애니메이션이 백그라운드에서 재생됩니다.
-:param loop: (loop) ``loop``가 ``True``인 경우 애니메이션이 무한 반복됩니다.
-:param clear: (clear) ``clear``가 ``True``인 경우 디스플레이는 시퀀스가 종료된 후 내용을 지웁니다.
+:param image: 표시할 문자열, 숫자, 이미지 또는 이미지 리스트입니다.
+:param delay: ``delay``밀리초의 지연 시간을 두고 각 글자, 숫자 또는 이미지가 표시됩니다.
+:param wait: ``wait``가 ``True``인 경우 이 기능은 애니메이션이 종료될 때까지 차단됩니다. 그렇지 않은 경우 애니메이션이 백그라운드에서 재생됩니다.
+:param loop: ``loop``가 ``True``인 경우 애니메이션이 무한 반복됩니다.
+:param clear: ``clear``가 ``True``인 경우 디스플레이는 시퀀스가 종료된 후 내용을 지웁니다.
 
 The ``wait``, ``loop`` and ``clear`` arguments must be specified using their keyword."""
     ...
 
 def scroll(text: Union[str, float, int], delay: int=150, wait: bool=True, loop: bool=False, monospace: bool=False) -> None:
-    """LED 디스플레이의 숫자 또는 텍스트를 스크롤합니다. (scroll)
+    """LED 디스플레이의 숫자 또는 텍스트를 스크롤합니다.
 
 Example: ``display.scroll('micro:bit')``
 
-:param text: (text) 스크롤할 문자열. 만약 ``text``가 정수 또는 부동수인 경우 먼저 ``str()``을 사용해 변환됩니다.
-:param delay: (delay) ``delay`` 매개변수는 텍스트 스크롤링 속도를 조절합니다.
-:param wait: (wait) ``wait``가 ``True``인 경우 이 기능은 애니메이션이 종료될 때까지 차단됩니다. 그렇지 않은 경우 애니메이션이 백그라운드에서 재생됩니다.
-:param loop: (loop) ``loop``가 ``True``인 경우 애니메이션이 무한 반복됩니다.
-:param monospace: (monospace) ``monospace``가 ``True``인 경우 스크롤 중에 모든 글자는 5열의 픽셀만큼의 너비를 소모하며, 그렇지 않은 경우 글자 사이에 정확히 1열의 픽셀의 공백이 존재합니다.
+:param text: 스크롤할 문자열. 만약 ``text``가 정수 또는 부동수인 경우 먼저 ``str()``을 사용해 변환됩니다.
+:param delay: ``delay`` 매개변수는 텍스트 스크롤링 속도를 조절합니다.
+:param wait: ``wait``가 ``True``인 경우 이 기능은 애니메이션이 종료될 때까지 차단됩니다. 그렇지 않은 경우 애니메이션이 백그라운드에서 재생됩니다.
+:param loop: ``loop``가 ``True``인 경우 애니메이션이 무한 반복됩니다.
+:param monospace: ``monospace``가 ``True``인 경우 스크롤 중에 모든 글자는 5열의 픽셀만큼의 너비를 소모하며, 그렇지 않은 경우 글자 사이에 정확히 1열의 픽셀의 공백이 존재합니다.
 
 The ``wait``, ``loop`` and ``monospace`` arguments must be specified
 using their keyword."""
     ...
 
 def on() -> None:
-    """LED 디스플레이를 켭니다. (on)
+    """LED 디스플레이를 켭니다.
 
 Example: ``display.on()``"""
     ...
 
 def off() -> None:
-    """LED 디스플레이를 끕니다(디스플레이를 비활성화하면 GPIO 핀을 다른 목적으로 재사용할 수 있습니다). (off)
+    """LED 디스플레이를 끕니다(디스플레이를 비활성화하면 GPIO 핀을 다른 목적으로 재사용할 수 있습니다).
 
 Example: ``display.off()``"""
     ...
 
 def is_on() -> bool:
-    """LED 디스플레이가 활성화되어있는지 확인합니다. (is on)
+    """LED 디스플레이가 활성화되어있는지 확인합니다.
 
 Example: ``display.is_on()``
 
@@ -81,7 +81,7 @@ Example: ``display.is_on()``
     ...
 
 def read_light_level() -> int:
-    """밝기 레벨을 읽습니다. (read light level)
+    """밝기 레벨을 읽습니다.
 
 Example: ``display.read_light_level()``
 

--- a/lang/ko/typeshed/stdlib/microbit/i2c.pyi
+++ b/lang/ko/typeshed/stdlib/microbit/i2c.pyi
@@ -1,16 +1,16 @@
-"""I²C 버스 프로토콜을 사용해 기기와 통신합니다. (i2c)"""
+"""I²C 버스 프로토콜을 사용해 기기와 통신합니다."""
 from _typeshed import ReadableBuffer
 from ..microbit import MicroBitDigitalPin, pin19, pin20
 from typing import List
 
 def init(freq: int=100000, sda: MicroBitDigitalPin=pin20, scl: MicroBitDigitalPin=pin19) -> None:
-    """주변 장치를 다시 초기화합니다. (init)
+    """주변 장치를 다시 초기화합니다.
 
 Example: ``i2c.init()``
 
-:param freq: (freq) 클럭 진동수
-:param sda: (sda) ``scl`` 핀(기본값 20)
-:param scl: (scl) ``scl`` 핀(기본값 19)
+:param freq: 클럭 진동수
+:param sda: ``scl`` 핀(기본값 20)
+:param scl: ``scl`` 핀(기본값 19)
 
 On a micro:bit V1 board, changing the I²C pins from defaults will make
 the accelerometer and compass stop working, as they are connected
@@ -20,7 +20,7 @@ for the motion sensors and the edge connector."""
     ...
 
 def scan() -> List[int]:
-    """버스에서 장치를 스캔합니다. (scan)
+    """버스에서 장치를 스캔합니다.
 
 Example: ``i2c.scan()``
 
@@ -28,22 +28,22 @@ Example: ``i2c.scan()``
     ...
 
 def read(addr: int, n: int, repeat: bool=False) -> bytes:
-    """장치에서 바이트 값을 읽습니다.. (read)
+    """장치에서 바이트 값을 읽습니다..
 
 Example: ``i2c.read(0x50, 64)``
 
-:param addr: (addr) 장치의 7비트 주소
-:param n: (n) 읽을 바이트 수
-:param repeat: (repeat) ``True``인 경우 스톱 비트가 전송되지 않습니다
+:param addr: 장치의 7비트 주소
+:param n: 읽을 바이트 수
+:param repeat: ``True``인 경우 스톱 비트가 전송되지 않습니다
 :return: The bytes read"""
     ...
 
 def write(addr: int, buf: ReadableBuffer, repeat: bool=False) -> None:
-    """장치에 바이트를 작성합니다. (write)
+    """장치에 바이트를 작성합니다.
 
 Example: ``i2c.write(0x50, bytes([1, 2, 3]))``
 
-:param addr: (addr) 장치의 7비트 주소
-:param buf: (buf) 작성할 바이트가 포함된 버퍼
-:param repeat: (repeat) ``True``인 경우 스톱 비트가 전송되지 않습니다"""
+:param addr: 장치의 7비트 주소
+:param buf: 작성할 바이트가 포함된 버퍼
+:param repeat: ``True``인 경우 스톱 비트가 전송되지 않습니다"""
     ...

--- a/lang/ko/typeshed/stdlib/microbit/microphone.pyi
+++ b/lang/ko/typeshed/stdlib/microbit/microphone.pyi
@@ -1,9 +1,9 @@
-"""내장 마이크를 사용해 소리에 반응합니다(V2 전용). (microphone)"""
+"""내장 마이크를 사용해 소리에 반응합니다(V2 전용)."""
 from typing import Optional, Tuple
 from ..microbit import SoundEvent
 
 def current_event() -> Optional[SoundEvent]:
-    """마지막으로 기록된 소리 이벤트 (current event)
+    """마지막으로 기록된 소리 이벤트
 
 Example: ``microphone.current_event()``
 
@@ -11,29 +11,29 @@ Example: ``microphone.current_event()``
     ...
 
 def was_event(event: SoundEvent) -> bool:
-    """마지막 호출 이후로 소리가 들렸는지 확인합니다. (was event)
+    """마지막 호출 이후로 소리가 들렸는지 확인합니다.
 
 Example: ``microphone.was_event(SoundEvent.LOUD)``
 
 This call clears the sound history before returning.
 
-:param event: (event) ``SoundEvent.LOUD`` 또는 ``SoundEvent.QUIET`` 등을 확인하기 위한 이벤트
+:param event: ``SoundEvent.LOUD`` 또는 ``SoundEvent.QUIET`` 등을 확인하기 위한 이벤트
 :return: ``True`` if sound was heard at least once since the last call, otherwise ``False``."""
     ...
 
 def is_event(event: SoundEvent) -> bool:
-    """가장 최근 탐지된 소리 이벤트를 확인합니다. (is event)
+    """가장 최근 탐지된 소리 이벤트를 확인합니다.
 
 Example: ``microphone.is_event(SoundEvent.LOUD)``
 
 This call does not clear the sound event history.
 
-:param event: (event) ``SoundEvent.LOUD`` 또는 ``SoundEvent.QUIET`` 등을 확인하기 위한 이벤트
+:param event: ``SoundEvent.LOUD`` 또는 ``SoundEvent.QUIET`` 등을 확인하기 위한 이벤트
 :return: ``True`` if sound was the most recent heard, ``False`` otherwise."""
     ...
 
 def get_events() -> Tuple[SoundEvent, ...]:
-    """소리 이벤트 기록을 튜플로 가져옵니다. (get events)
+    """소리 이벤트 기록을 튜플로 가져옵니다.
 
 Example: ``microphone.get_events()``
 
@@ -43,18 +43,18 @@ This call clears the sound history before returning.
     ...
 
 def set_threshold(event: SoundEvent, value: int) -> None:
-    """소리 이벤트 임계값을 설정합니다. (set threshold)
+    """소리 이벤트 임계값을 설정합니다.
 
 Example: ``microphone.set_threshold(SoundEvent.LOUD, 250)``
 
 A high threshold means the event will only trigger if the sound is very loud (>= 250 in the example).
 
-:param event: (event) ``SoundEvent.LOUD`` 또는 ``SoundEvent.QUIET`` 등의 소리 이벤트입니다.
-:param value: (value) 0~255의 범위로 된 임계값입니다."""
+:param event: ``SoundEvent.LOUD`` 또는 ``SoundEvent.QUIET`` 등의 소리 이벤트입니다.
+:param value: 0~255의 범위로 된 임계값입니다."""
     ...
 
 def sound_level() -> int:
-    """음압 레벨을 불러옵니다. (sound level)
+    """음압 레벨을 불러옵니다.
 
 Example: ``microphone.sound_level()``
 

--- a/lang/ko/typeshed/stdlib/microbit/speaker.pyi
+++ b/lang/ko/typeshed/stdlib/microbit/speaker.pyi
@@ -1,7 +1,7 @@
-"""내장 스피커를 제어합니다(V2 전용). (speaker)"""
+"""내장 스피커를 제어합니다(V2 전용)."""
 
 def off() -> None:
-    """스피커를 끕니다. (off)
+    """스피커를 끕니다.
 
 Example: ``speaker.off()``
 
@@ -9,7 +9,7 @@ This does not disable sound output to an edge connector pin."""
     ...
 
 def on() -> None:
-    """스피커를 켭니다. (on)
+    """스피커를 켭니다.
 
 Example: ``speaker.on()``"""
     ...

--- a/lang/ko/typeshed/stdlib/microbit/spi.pyi
+++ b/lang/ko/typeshed/stdlib/microbit/spi.pyi
@@ -1,4 +1,4 @@
-"""직렬 주변 장치 인터페이스(SPI) 버스를 사용해 장치와 통신합니다. (spi)"""
+"""직렬 주변 장치 인터페이스(SPI) 버스를 사용해 장치와 통신합니다."""
 from _typeshed import ReadableBuffer, WriteableBuffer
 from ..microbit import pin13, pin14, pin15, MicroBitDigitalPin
 
@@ -9,38 +9,38 @@ Example: ``spi.init()``
 
 For correct communication, the parameters have to be the same on both communicating devices.
 
-:param baudrate: (baudrate) 통신 속도입니다.
-:param bits: (bits) 각 전송의 비트의 너비입니다. 현재 ``bits=8``만 지원되나 향후 변경될 수 있습니다.
-:param mode: (mode) 클럭 극성과 페이즈의 조합을 결정합니다. 온라인 테이블을 참조하세요 <https://microbit-micropython.readthedocs.io/en/v2-docs/spi.html#microbit.spi.init>`_.
-:param sclk: (sclk) sclk 핀(기본값 13)
-:param mosi: (mosi) mosi 핀(기본값 15)
-:param miso: (miso) miso 핀(기본값 14)"""
+:param baudrate: 통신 속도입니다.
+:param bits: 각 전송의 비트의 너비입니다. 현재 ``bits=8``만 지원되나 향후 변경될 수 있습니다.
+:param mode: 클럭 극성과 페이즈의 조합을 결정합니다. 온라인 테이블을 참조하세요 <https://microbit-micropython.readthedocs.io/en/v2-docs/spi.html#microbit.spi.init>`_.
+:param sclk: sclk 핀(기본값 13)
+:param mosi: mosi 핀(기본값 15)
+:param miso: miso 핀(기본값 14)"""
     ...
 
 def read(nbytes: int) -> bytes:
-    """바이트를 읽습니다. (read)
+    """바이트를 읽습니다.
 
 Example: ``spi.read(64)``
 
-:param nbytes: (nbytes) 읽을 바이트의 최대 수입니다.
+:param nbytes: 읽을 바이트의 최대 수입니다.
 :return: The bytes read."""
     ...
 
 def write(buffer: ReadableBuffer) -> None:
-    """버스에 바이트를 작성합니다. (write)
+    """버스에 바이트를 작성합니다.
 
 Example: ``spi.write(bytes([1, 2, 3]))``
 
-:param buffer: (buffer) 데이터를 읽을 버퍼입니다."""
+:param buffer: 데이터를 읽을 버퍼입니다."""
     ...
 
 def write_readinto(out: WriteableBuffer, in_: ReadableBuffer) -> None:
-    """버스에 ``out`` 버퍼를 작성하고 발생하는 ``in_`` 버퍼의 모든 응답을 읽습니다. (write readinto)
+    """버스에 ``out`` 버퍼를 작성하고 발생하는 ``in_`` 버퍼의 모든 응답을 읽습니다.
 
 Example: ``spi.write_readinto(out_buffer, in_buffer)``
 
 The length of the buffers should be the same. The buffers can be the same object.
 
-:param out: (out) 응답을 작성할 버퍼입니다.
-:param in_: (in) 데이터를 읽을 버퍼입니다."""
+:param out: 응답을 작성할 버퍼입니다.
+:param in_: 데이터를 읽을 버퍼입니다."""
     ...

--- a/lang/ko/typeshed/stdlib/microbit/uart.pyi
+++ b/lang/ko/typeshed/stdlib/microbit/uart.pyi
@@ -1,23 +1,23 @@
-"""직렬 인터페이스를 사용해 장치와 통신합니다. (uart)"""
+"""직렬 인터페이스를 사용해 장치와 통신합니다."""
 from _typeshed import WriteableBuffer
 from ..microbit import MicroBitDigitalPin
 from typing import Optional, Union
 ODD: int
-""" 홀수 패리티 (odd)"""
+"""홀수 패리티"""
 EVEN: int
-"""짝수 패리티 (even)"""
+"""짝수 패리티"""
 
 def init(baudrate: int=9600, bits: int=8, parity: Optional[int]=None, stop: int=1, tx: Optional[MicroBitDigitalPin]=None, rx: Optional[MicroBitDigitalPin]=None) -> None:
     """직렬 통신을 시작합니다. (string)
 
 Example: ``uart.init(115200, tx=pin0, rx=pin1)``
 
-:param baudrate: (baudrate) 통신 속도입니다.
-:param bits: (bits) 전송되는 바이트의 크기입니다. micro:bit는 8바이트만 지원합니다.
+:param baudrate: 통신 속도입니다.
+:param bits: 전송되는 바이트의 크기입니다. micro:bit는 8바이트만 지원합니다.
 :param parity: (패리티) 패리티가 체크되는 방식으로 ``None``, ``uart.ODD`` 또는 ``uart.EVEN``을 사용합니다.
-:param stop: (stop) 스톱 비트의 번호입니다. micro:bit는 1이어야 합니다.
-:param tx: (tx) 전송하는 핀입니다.
-:param rx: (rx) 수신하는 핀입니다.
+:param stop: 스톱 비트의 번호입니다. micro:bit는 1이어야 합니다.
+:param tx: 전송하는 핀입니다.
+:param rx: 수신하는 핀입니다.
 
 Initializing the UART on external pins will cause the Python console on
 USB to become unaccessible, as it uses the same hardware. To bring the
@@ -29,7 +29,7 @@ For more details see `the online documentation <https://microbit-micropython.rea
     ...
 
 def any() -> bool:
-    """Check if any data is waiting. (any)
+    """Check if any data is waiting.
 
 Example: ``uart.any()``
 
@@ -37,26 +37,26 @@ Example: ``uart.any()``
     ...
 
 def read(nbytes: Optional[int]=None) -> Optional[bytes]:
-    """바이트를 읽습니다. (read)
+    """바이트를 읽습니다.
 
 Example: ``uart.read()``
 
-:param nbytes: (nbytes) ``nbytes``가 특정되어 있다면 해당 바이트 수만큼 읽습니다. 특정되지 않은 경우 최대한 많은 바이트를 읽습니다.
+:param nbytes: ``nbytes``가 특정되어 있다면 해당 바이트 수만큼 읽습니다. 특정되지 않은 경우 최대한 많은 바이트를 읽습니다.
 :return: A bytes object or ``None`` on timeout"""
     ...
 
 def readinto(buf: WriteableBuffer, nbytes: Optional[int]=None) -> Optional[int]:
-    """``buf``로 바이트를 읽습니다. (readinto)
+    """``buf``로 바이트를 읽습니다.
 
 Example: ``uart.readinto(input_buffer)``
 
-:param buf: (buf) 바이트를 기록할 버퍼입니다.
-:param nbytes: (nbytes) ``nbytes``가 특정되어 있다면 해당 바이트 수만큼 읽습니다. 특정되지 않은 경우 ``len(buf)``바이트를 읽습니다.
+:param buf: 바이트를 기록할 버퍼입니다.
+:param nbytes: ``nbytes``가 특정되어 있다면 해당 바이트 수만큼 읽습니다. 특정되지 않은 경우 ``len(buf)``바이트를 읽습니다.
 :return: number of bytes read and stored into ``buf`` or ``None`` on timeout."""
     ...
 
 def readline() -> Optional[bytes]:
-    """새로운 줄 문자로 끝나는 줄을 읽습니다. (readline)
+    """새로운 줄 문자로 끝나는 줄을 읽습니다.
 
 Example: ``uart.readline()``
 
@@ -64,11 +64,11 @@ Example: ``uart.readline()``
     ...
 
 def write(buf: Union[bytes, str]) -> Optional[int]:
-    """버스에 버퍼를 기록합니다. (write)
+    """버스에 버퍼를 기록합니다.
 
 Example: ``uart.write('hello world')``
 
-:param buf: (buf) 바이트 오브젝트 또는 문자열입니다.
+:param buf: 바이트 오브젝트 또는 문자열입니다.
 :return: The number of bytes written, or ``None`` on timeout.
 
 Examples::

--- a/lang/ko/typeshed/stdlib/micropython.pyi
+++ b/lang/ko/typeshed/stdlib/micropython.pyi
@@ -1,9 +1,9 @@
-"""MicroPython 내부 정보입니다. (micropython)"""
+"""MicroPython 내부 정보입니다."""
 from typing import Any, TypeVar, overload
 _T = TypeVar('_T')
 
 def const(expr: _T) -> _T:
-    """컴파일러가 최적화할 수 있도록 해당 수식이 상수임을 선언합니다. (const)
+    """컴파일러가 최적화할 수 있도록 해당 수식이 상수임을 선언합니다.
 
 The use of this function should be as follows::
 
@@ -16,12 +16,12 @@ outside the module they are declared in. On the other hand, if a constant
 begins with an underscore then it is hidden, it is not available as a
 global variable, and does not take up any memory during execution.
 
-:param expr: (expr) 상수 표현식입니다."""
+:param expr: 상수 표현식입니다."""
     ...
 
 @overload
 def opt_level() -> int:
-    """스크립트의 현재 컴파일 최적화 레벨을 불러옵니다. (opt level)
+    """스크립트의 현재 컴파일 최적화 레벨을 불러옵니다.
 
 Example: ``micropython.opt_level()``
 
@@ -43,7 +43,7 @@ The optimisation level controls the following compilation features:
 
 @overload
 def opt_level(level: int) -> None:
-    """스크립트의 후속 컴파일 최적화 레벨을 설정합니다. (opt level)
+    """스크립트의 후속 컴파일 최적화 레벨을 설정합니다.
 
 Example: ``micropython.opt_level(1)``
 
@@ -62,23 +62,23 @@ The optimisation level controls the following compilation features:
 
 The default optimisation level is usually level 0.
 
-:param level: (level) 정수로 된 최적화 레벨입니다."""
+:param level: 정수로 된 최적화 레벨입니다."""
     ...
 
 def mem_info(verbose: Any=None) -> None:
-    """현재 사용 중인 메모리에 대한 정보를 프린트합니다. (mem info)
+    """현재 사용 중인 메모리에 대한 정보를 프린트합니다.
 
 Example: ``micropython.mem_info()``
 
-:param verbose: (verbose) ``verbose`` 인자가 주어지면 추가 정보를 프린트합니다."""
+:param verbose: ``verbose`` 인자가 주어지면 추가 정보를 프린트합니다."""
     ...
 
 def qstr_info(verbose: Any=None) -> None:
-    """현재 반환된 문자열에 대한 정보를 프린트합니다. (qstr info)
+    """현재 반환된 문자열에 대한 정보를 프린트합니다.
 
 Example: ``micropython.qstr_info()``
 
-:param verbose: (verbose) ``verbose`` 인자가 주어지면 추가 정보를 프린트합니다.
+:param verbose: ``verbose`` 인자가 주어지면 추가 정보를 프린트합니다.
 
 The information that is printed is implementation dependent, but currently
 includes the number of interned strings and the amount of RAM they use.  In
@@ -86,7 +86,7 @@ verbose mode it prints out the names of all RAM-interned strings."""
     ...
 
 def stack_use() -> int:
-    """현재 사용 중인 스택의 수를 나타내는 정수를 반환합니다. (stack use)
+    """현재 사용 중인 스택의 수를 나타내는 정수를 반환합니다.
 
 Example: ``micropython.stack_use()``
 
@@ -97,7 +97,7 @@ should be used to compute differences in stack usage at different points.
     ...
 
 def heap_lock() -> None:
-    """힙을 잠급니다. (heap lock)
+    """힙을 잠급니다.
 
 Example: ``micropython.heap_lock()``
 
@@ -106,7 +106,7 @@ raised if any heap allocation is attempted."""
     ...
 
 def heap_unlock() -> None:
-    """힙을 잠금 해제합니다. (heap unlock)
+    """힙을 잠금 해제합니다.
 
 Example: ``micropython.heap_unlock()``
 
@@ -115,11 +115,11 @@ raised if any heap allocation is attempted."""
     ...
 
 def kbd_intr(chr: int) -> None:
-    """``KeyboardInterrupt`` 예외를 제기할 문자를 설정합니다. (kbd intr)
+    """``KeyboardInterrupt`` 예외를 제기할 문자를 설정합니다.
 
 Example: ``micropython.kbd_intr(-1)``
 
-:param chr: (chr) 인터럽트를 제기하기 위한 문자 코드입니다. -1은 Ctrl-C 캡처를 비활성화합니다.
+:param chr: 인터럽트를 제기하기 위한 문자 코드입니다. -1은 Ctrl-C 캡처를 비활성화합니다.
 
 By default this is set to 3 during script execution, corresponding to Ctrl-C.
 Passing -1 to this function will disable capture of Ctrl-C, and passing 3

--- a/lang/ko/typeshed/stdlib/music.pyi
+++ b/lang/ko/typeshed/stdlib/music.pyi
@@ -1,64 +1,64 @@
-"""멜로디를 생성하고 재생합니다. (music)"""
+"""멜로디를 생성하고 재생합니다."""
 from typing import Tuple, Union, List
 from .microbit import MicroBitDigitalPin, pin0
 DADADADUM: Tuple[str, ...]
-"""멜로디: 베토벤의 교향곡 제5번 다 단조 도입부입니다. (dadadadum)"""
+"""멜로디: 베토벤의 교향곡 제5번 다 단조 도입부입니다."""
 ENTERTAINER: Tuple[str, ...]
-"""멜로디: 스콧 조플린의 래그타임 고전 “The Entertainer” 도입부 일부입니다. (entertainer)"""
+"""멜로디: 스콧 조플린의 래그타임 고전 “The Entertainer” 도입부 일부입니다."""
 PRELUDE: Tuple[str, ...]
-"""멜로디: 요한 제바스티안 바흐의 48 Preludes and Fugues 다 장조 첫 전주곡 도입부입니다. (prelude)"""
+"""멜로디: 요한 제바스티안 바흐의 48 Preludes and Fugues 다 장조 첫 전주곡 도입부입니다."""
 ODE: Tuple[str, ...]
-"""멜로디: 베토벤의 교향곡 제9번 라 단조 “Ode to Joy” 테마입니다. (ode)"""
+"""멜로디: 베토벤의 교향곡 제9번 라 단조 “Ode to Joy” 테마입니다."""
 NYAN: Tuple[str, ...]
-"""멜로디: Nyan Cat 테마입니다(http://www.nyan.cat/). (nyan)
+"""멜로디: Nyan Cat 테마입니다(http://www.nyan.cat/).
 
 The composer is unknown. This is fair use for educational porpoises (as they say in New York)."""
 RINGTONE: Tuple[str, ...]
-"""멜로디: 휴대폰 벨소리와 유사한 소리입니다. (ringtone)
+"""멜로디: 휴대폰 벨소리와 유사한 소리입니다.
 
 To be used to indicate an incoming message.
 """
 FUNK: Tuple[str, ...]
-"""멜로디: 비밀 요원과 천재 범죄자에 어울리는 펑키 베이스 라인입니다. (funk)"""
+"""멜로디: 비밀 요원과 천재 범죄자에 어울리는 펑키 베이스 라인입니다."""
 BLUES: Tuple[str, ...]
-"""멜로디: 부기 우기 12바 블루스 워킹 베이스입니다. (blues)"""
+"""멜로디: 부기 우기 12바 블루스 워킹 베이스입니다."""
 BIRTHDAY: Tuple[str, ...]
-"""멜로디: 생일 축하 노래입니다. (birthday)
+"""멜로디: 생일 축하 노래입니다.
 
 For copyright status see: http://www.bbc.co.uk/news/world-us-canada-34332853
 """
 WEDDING: Tuple[str, ...]
-"""Melody: 바그너의 오페라 “로엔그린”의 결혼식 합창입니다. (wedding)"""
+"""Melody: 바그너의 오페라 “로엔그린”의 결혼식 합창입니다."""
 FUNERAL: Tuple[str, ...]
-"""멜로디: “장송행진곡”이라고도 알려진 프레데리크 쇼팽의 피아노 소나타 제2번 B♭ 단조 Op. 35입니다. (funeral)"""
+"""멜로디: “장송행진곡”이라고도 알려진 프레데리크 쇼팽의 피아노 소나타 제2번 B♭ 단조 Op. 35입니다."""
 PUNCHLINE: Tuple[str, ...]
-"""멜로디: 농담할 때 나오는 재미있는 멜로디입니다. (punchline)"""
+"""멜로디: 농담할 때 나오는 재미있는 멜로디입니다."""
 PYTHON: Tuple[str, ...]
-"""멜로디: 존 필립 수자의 “자유의 종” 행진곡입니다. “몬티 파이튼의 비행 서커스” 테마곡으로도 알려져 있습니다(Python 프로그래밍 언어는 몬티 파이튼의 이름에서 유래했습니다). (python)"""
+"""멜로디: 존 필립 수자의 “자유의 종” 행진곡입니다. “몬티 파이튼의 비행 서커스” 테마곡으로도 알려져 있습니다(Python 프로그래밍 언어는 몬티 파이튼의 이름에서 유래했습니다)."""
 BADDY: Tuple[str, ...]
-"""멜로디: 무성 영화 시대의 악당 등장 멜로디입니다. (baddy)"""
+"""멜로디: 무성 영화 시대의 악당 등장 멜로디입니다."""
 CHASE: Tuple[str, ...]
-"""멜로디: 무성 영화 시대의 추격 장면 멜로디입니다. (chase)"""
+"""멜로디: 무성 영화 시대의 추격 장면 멜로디입니다."""
 BA_DING: Tuple[str, ...]
-"""멜로디:어떤 일이 일어났다는 것을 알려주는 짧은 신호음입니다. (ba ding)"""
+"""멜로디:어떤 일이 일어났다는 것을 알려주는 짧은 신호음입니다."""
 WAWAWAWAA: Tuple[str, ...]
-"""멜로디: 아주 슬픈 트럼본 소리입니다. (wawawawaa)"""
+"""멜로디: 아주 슬픈 트럼본 소리입니다."""
 JUMP_UP: Tuple[str, ...]
-"""멜로디: 게임에서 위로 움직이는 것을 표현하는 소리입니다. (jump up)"""
+"""멜로디: 게임에서 위로 움직이는 것을 표현하는 소리입니다."""
 JUMP_DOWN: Tuple[str, ...]
-"""멜로디: 게임에서 아래로 움직이는 것을 표현하는 소리입니다. (jump down)"""
+"""멜로디: 게임에서 아래로 움직이는 것을 표현하는 소리입니다."""
 POWER_UP: Tuple[str, ...]
-"""멜로디: 업적 달성을 알리는 팡파르 소리입니다. (power up)"""
+"""멜로디: 업적 달성을 알리는 팡파르 소리입니다."""
 POWER_DOWN: Tuple[str, ...]
-"""멜로디: 업적 달성 실패를 의미하는 슬픈 팡파르 소리입니다. (power down)"""
+"""멜로디: 업적 달성 실패를 의미하는 슬픈 팡파르 소리입니다."""
 
 def set_tempo(ticks: int=4, bpm: int=120) -> None:
-    """플레이백의 빠르기를 대략적으로 설정합니다. (set tempo)
+    """플레이백의 빠르기를 대략적으로 설정합니다.
 
 Example: ``music.set_tempo(bpm=120)``
 
-:param ticks: (ticks) 비트 하나를 구성하는 틱의 수입니다.
-:param bpm: (bpm) 분당 비트 수를 결정하는 정수입니다.
+:param ticks: 비트 하나를 구성하는 틱의 수입니다.
+:param bpm: 분당 비트 수를 결정하는 정수입니다.
 
 Suggested default values allow the following useful behaviour:
 
@@ -72,7 +72,7 @@ To work out the length of a tick in milliseconds is very simple arithmetic:
     ...
 
 def get_tempo() -> Tuple[int, int]:
-    """현재 빠르기를 정수 튜플로 가져옵니다: ``(ticks, bpm)``. (get tempo)
+    """현재 빠르기를 정수 튜플로 가져옵니다: ``(ticks, bpm)``.
 
 Example: ``ticks, beats = music.get_tempo()``
 
@@ -80,14 +80,14 @@ Example: ``ticks, beats = music.get_tempo()``
     ...
 
 def play(music: Union[str, List[str], Tuple[str, ...]], pin: Union[MicroBitDigitalPin, None]=pin0, wait: bool=True, loop: bool=False) -> None:
-    """음악을 재생합니다. (play)
+    """음악을 재생합니다.
 
 Example: ``music.play(music.NYAN)``
 
-:param music: (music) `별첨 <https://microbit-micropython.readthedocs.io/en/v2-docs/music.html#musical-notation>`_에 명시된 음악
+:param music: `별첨 <https://microbit-micropython.readthedocs.io/en/v2-docs/music.html#musical-notation>`_에 명시된 음악
 :param pin: (핀) 외장 스피커에 사용할 출력 핀입니다(기본값 ``pin0``). ``None``으로 설정하면 소리가 재생되지 않습니다.
-:param wait: (wait) ``wait``이 ``True``로 설정된 경우 이 기능은 블로킹 상태가 됩니다.
-:param loop: (loop) ``loop``가 ``True``인 경우 ``stop``이 호출되거나 블로킹 호출이 인터럽트되기 전까지 계속 반복됩니다.
+:param wait: ``wait``이 ``True``로 설정된 경우 이 기능은 블로킹 상태가 됩니다.
+:param loop: ``loop``가 ``True``인 경우 ``stop``이 호출되거나 블로킹 호출이 인터럽트되기 전까지 계속 반복됩니다.
 
 Many built-in melodies are defined in this module."""
     ...
@@ -98,9 +98,9 @@ def pitch(frequency: int, duration: int=-1, pin: MicroBitDigitalPin=pin0, wait: 
 Example: ``music.pitch(185, 1000)``
 
 :param frequency: (진동수) 정수 진동수입니다.
-:param duration: (duration) 밀리초 단위의 기간입니다. 음수인 경우 소리가 다음 호출 또는 ``stop`` 호출까지 계속 재생됩니다.
+:param duration: 밀리초 단위의 기간입니다. 음수인 경우 소리가 다음 호출 또는 ``stop`` 호출까지 계속 재생됩니다.
 :param pin: (핀) 출력 핀입니다(기본값 ``pin0``)(선택 사항).
-:param wait: (wait) ``wait``이 ``True``로 설정된 경우 이 기능은 블로킹 상태가 됩니다.
+:param wait: ``wait``이 ``True``로 설정된 경우 이 기능은 블로킹 상태가 됩니다.
 
 For example, if the frequency is set to 440 and the length to
 1000 then we hear a standard concert A for one second.
@@ -109,14 +109,14 @@ You can only play one pitch on one pin at any one time."""
     ...
 
 def stop(pin: MicroBitDigitalPin=pin0) -> None:
-    """내장 스피커와 핀으로 출력되는 모든 음악 플레이백을 멈춥니다. (stop)
+    """내장 스피커와 핀으로 출력되는 모든 음악 플레이백을 멈춥니다.
 
 Example: ``music.stop()``
 
 :param pin: (핀) 핀을 특정하기 위한 인자입니다(예: ``music.stop(pin1)``)(선택 사항)."""
 
 def reset() -> None:
-    """틱, bpm, 기간 및 옥타브를 기본값으로 초기화합니다. (reset)
+    """틱, bpm, 기간 및 옥타브를 기본값으로 초기화합니다.
 
 Example: ``music.reset()``
 

--- a/lang/ko/typeshed/stdlib/neopixel.pyi
+++ b/lang/ko/typeshed/stdlib/neopixel.pyi
@@ -1,4 +1,4 @@
-"""개별 주소를 지정할 수 있는 RGB 및 RGBW LED 스트립입니다. (neopixel)"""
+"""개별 주소를 지정할 수 있는 RGB 및 RGBW LED 스트립입니다."""
 from .microbit import MicroBitDigitalPin
 from typing import Tuple
 
@@ -14,18 +14,18 @@ RGBW neopixels are only supported by micro:bit V2.
 See `the online docs <https://microbit-micropython.readthedocs.io/en/v2-docs/neopixel.html>`_ for warnings and other advice.
 
 :param pin: (핀) 네오픽셀 스트립을 제어하는 핀입니다.
-:param n: (n) 스트립의 네오픽셀 수입니다.
-:param bpp: (bpp) 픽셀당 바이트입니다. micro:bit V2 RGBW 네오픽셀 지원을 위해서는 RGB 및 GRB의 기본값 3 대신 4를 패스해야 합니다."""
+:param n: 스트립의 네오픽셀 수입니다.
+:param bpp: 픽셀당 바이트입니다. micro:bit V2 RGBW 네오픽셀 지원을 위해서는 RGB 및 GRB의 기본값 3 대신 4를 패스해야 합니다."""
         ...
 
     def clear(self) -> None:
-        """모든 픽셀을 지웁니다. (clear)
+        """모든 픽셀을 지웁니다.
 
 Example: ``np.clear()``"""
         ...
 
     def show(self) -> None:
-        """픽셀을 표시합니다. (show)
+        """픽셀을 표시합니다.
 
 Example: ``np.show()``
 
@@ -33,7 +33,7 @@ Must be called for any updates to become visible."""
         ...
 
     def write(self) -> None:
-        """픽셀을 표시합니다(micro:bit V2 전용). (write)
+        """픽셀을 표시합니다(micro:bit V2 전용).
 
 Example: ``np.write()``
 
@@ -43,32 +43,32 @@ Equivalent to ``show``."""
         ...
 
     def fill(self, colour: Tuple[int, ...]) -> None:
-        """모든 픽셀에 주어진 RGB/RGBW 값을 칠합니다. (fill)
+        """모든 픽셀에 주어진 RGB/RGBW 값을 칠합니다.
 
 Example: ``np.fill((0, 0, 255))``
 
-:param colour: (colour) 픽셀 당 바이트 수(bpp)와 같은 길이의 튜플입니다.
+:param colour: 픽셀 당 바이트 수(bpp)와 같은 길이의 튜플입니다.
 
 Use in conjunction with ``show()`` to update the neopixels."""
         ...
 
     def __setitem__(self, key: int, value: Tuple[int, ...]) -> None:
-        """픽셀 색상을 설정합니다. (setitem)
+        """픽셀 색상을 설정합니다.
 
 Example: ``np[0] = (255, 0, 0)``
 
-:param key: (key) 픽셀 번호입니다.
-:param value: (value) 색상입니다."""
+:param key: 픽셀 번호입니다.
+:param value: 색상입니다."""
 
     def __getitem__(self, key: int) -> Tuple[int, ...]:
-        """픽셀 색상을 불러옵니다. (getitem)
+        """픽셀 색상을 불러옵니다.
 
 Example: ``r, g, b = np[0]``
 
-:param key: (key) 픽셀 번호입니다.
+:param key: 픽셀 번호입니다.
 :return: The colour tuple."""
 
     def __len__(self) -> int:
-        """이 픽셀 스트립의 길이를 불러옵니다. (len)
+        """이 픽셀 스트립의 길이를 불러옵니다.
 
 Example: ``len(np)``"""

--- a/lang/ko/typeshed/stdlib/os.pyi
+++ b/lang/ko/typeshed/stdlib/os.pyi
@@ -1,9 +1,9 @@
-"""파일 시스템에 액세스합니다. (os)"""
+"""파일 시스템에 액세스합니다."""
 from typing import Tuple
 from typing import List
 
 def listdir() -> List[str]:
-    """파일을 나열합니다. (listdir)
+    """파일을 나열합니다.
 
 Example: ``os.listdir()``
 
@@ -12,40 +12,40 @@ persistent on-device file system."""
     ...
 
 def remove(filename: str) -> None:
-    """파일을 제거(삭제)합니다. (remove)
+    """파일을 제거(삭제)합니다.
 
 Example: ``os.remove('data.txt')``
 
-:param filename: (filename) 삭제할 파일입니다.
+:param filename: 삭제할 파일입니다.
 
 If the file does not exist an ``OSError`` exception will occur."""
     ...
 
 def size(filename: str) -> int:
-    """파일의 크기를 반환합니다. (size)
+    """파일의 크기를 반환합니다.
 
 Example: ``os.size('data.txt')``
 
-:param filename: (filename) 파일
+:param filename: 파일
 :return: The size in bytes.
 
 If the file does not exist an ``OSError`` exception will occur."""
 
 class uname_result(Tuple[str, str, str, str, str]):
-    """``os.uname()``의 결과 (uname result)"""
+    """``os.uname()``의 결과"""
     sysname: str
-    """운영 체제 이름입니다. (sysname)"""
+    """운영 체제 이름입니다."""
     nodename: str
-    """네트워크상의 머신 이름입니다(구현 방법에 따라 정의됨). (nodename)"""
+    """네트워크상의 머신 이름입니다(구현 방법에 따라 정의됨)."""
     release: str
-    """운영 체제 릴리스입니다. (release)"""
+    """운영 체제 릴리스입니다."""
     version: str
-    """운영 체제 버전입니다. (version)"""
+    """운영 체제 버전입니다."""
     machine: str
-    """하드웨어 식별자입니다. (machine)"""
+    """하드웨어 식별자입니다."""
 
 def uname() -> uname_result:
-    """현재 운영 시스템을 식별하는 정보를 반환합니다. (uname)
+    """현재 운영 시스템을 식별하는 정보를 반환합니다.
 
 Example: ``os.uname()``
 

--- a/lang/ko/typeshed/stdlib/radio.pyi
+++ b/lang/ko/typeshed/stdlib/radio.pyi
@@ -1,13 +1,13 @@
-"""내장 라디오를 사용해 micro:bit끼리 통신합니다. (radio)"""
+"""내장 라디오를 사용해 micro:bit끼리 통신합니다."""
 from _typeshed import WriteableBuffer
 from typing import Optional, Tuple
 RATE_1MBIT: int
-"""초당 1 MBit의 처리율을 지정하는 데 사용하는 상수 (rate 1mbit)"""
+"""초당 1 MBit의 처리율을 지정하는 데 사용하는 상수"""
 RATE_2MBIT: int
-"""초당 2 MBit의 처리율을 지정하는 데 사용하는 상수. (rate 2mbit)"""
+"""초당 2 MBit의 처리율을 지정하는 데 사용하는 상수."""
 
 def on() -> None:
-    """라디오를 켭니다. (on)
+    """라디오를 켭니다.
 
 Example: ``radio.on()``
 
@@ -16,33 +16,33 @@ up memory that you may otherwise need."""
     ...
 
 def off() -> None:
-    """라디오를 꺼 전력과 메모리를 절약합니다. (off)
+    """라디오를 꺼 전력과 메모리를 절약합니다.
 
 Example: ``radio.off()``"""
     ...
 
 def config(length: int=32, queue: int=3, channel: int=7, power: int=6, address: int=1969383796, group: int=0, data_rate: int=RATE_1MBIT) -> None:
-    """라디오를 설정합니다. (config)
+    """라디오를 설정합니다.
 
 Example: ``radio.config(group=42)``
 
 The default configuration is suitable for most use.
 
-:param length: (length) (기본값=32) 라디오를 통해 전송되는 메시지의 최대 길이를 바이트로 정의합니다.
+:param length: (기본값=32) 라디오를 통해 전송되는 메시지의 최대 길이를 바이트로 정의합니다.
 최대 251바이트까지 정의할 수 있습니다(S0, LENGTH 및 S1 프리앰블의 경우 254 - 3바이트).
-:param queue: (queue) (기본값=3) 수신 메시지 대기열에 보관할 수 있는 메시지의 수를 특정합니다. 만약 수신 메시지의 대기열 공간이 부족하다면 수신 메시지는 드롭됩니다.
-:param channel: (channel) (기본값=7) 임의의 "채널"을 라디오 채널로 설정하는 0부터 83까지의 정수(경계값 포함)입니다. 메시지는 이 채널로 전송되며 이 채널을 통해 받은 메시지만 수신 메시지 대기열에 등록됩니다. 2400MHz 기준으로 각 단계는 1MHz 대역입니다.
-:param power: (power) (기본값=6) 0부터 7의 정수값(경계값 포함)으로 메시지를 송출할 때의 신호 강도를 표현합니다.
+:param queue: (기본값=3) 수신 메시지 대기열에 보관할 수 있는 메시지의 수를 특정합니다. 만약 수신 메시지의 대기열 공간이 부족하다면 수신 메시지는 드롭됩니다.
+:param channel: (기본값=7) 임의의 "채널"을 라디오 채널로 설정하는 0부터 83까지의 정수(경계값 포함)입니다. 메시지는 이 채널로 전송되며 이 채널을 통해 받은 메시지만 수신 메시지 대기열에 등록됩니다. 2400MHz 기준으로 각 단계는 1MHz 대역입니다.
+:param power: (기본값=6) 0부터 7의 정수값(경계값 포함)으로 메시지를 송출할 때의 신호 강도를 표현합니다.
 값이 높을 수록 신호는 강해지지만 장치의 전력을 더 소모합니다. 각 숫자는 다음 dBm(데시벨 밀리와트)값 목록의 위치로 변환됩니다: -30, -20, -16, -12, -8, -4, 0, 4.
-:param address: (address) (기본=0x75626974) 32비트로 표현되는 임의의 이름입니다. 하드웨어 레벨에서 수신 패킷을 필터링하는 데 사용되며 설정한 주소와 일치하는 패킷만 유지합니다. 다른 micro:bit 관련 플랫폼이 사용하는 기본값은 여기에서도 사용됩니다.
-:param group: (group) 메시지를 필터링할 때 ``address``와 함께 사용되는 8비트 값(0~255)입니다. 개념상 "address(주소)"는 집/사무실 주소, "group(그룹)"은 해당 주소에서 메시지를 보내고자 하는 인물입니다.
-:param data_rate: (data rate) (default=``radio.RATE_1MBIT``) 데이터 처리율의 속도를 지정합니다. ``radio`` 모듈의 다음 상수 중 하나가 될 수 있습니다: ``RATE_250KBIT``, ``RATE_1MBIT`` 또는 ``RATE_2MBIT``.
+:param address: (기본=0x75626974) 32비트로 표현되는 임의의 이름입니다. 하드웨어 레벨에서 수신 패킷을 필터링하는 데 사용되며 설정한 주소와 일치하는 패킷만 유지합니다. 다른 micro:bit 관련 플랫폼이 사용하는 기본값은 여기에서도 사용됩니다.
+:param group: 메시지를 필터링할 때 ``address``와 함께 사용되는 8비트 값(0~255)입니다. 개념상 "address(주소)"는 집/사무실 주소, "group(그룹)"은 해당 주소에서 메시지를 보내고자 하는 인물입니다.
+:param data_rate: (default=``radio.RATE_1MBIT``) 데이터 처리율의 속도를 지정합니다. ``radio`` 모듈의 다음 상수 중 하나가 될 수 있습니다: ``RATE_250KBIT``, ``RATE_1MBIT`` 또는 ``RATE_2MBIT``.
 
 If ``config`` is not called then the defaults described above are assumed."""
     ...
 
 def reset() -> None:
-    """설정을 기본값으로 초기화합니다. (reset)
+    """설정을 기본값으로 초기화합니다.
 
 Example: ``radio.reset()``
 
@@ -50,15 +50,15 @@ The defaults as as per the ``config`` function above."""
     ...
 
 def send_bytes(message: bytes) -> None:
-    """바이트가 포함된 메시지를 전송합니다. (send bytes)
+    """바이트가 포함된 메시지를 전송합니다.
 
 Example: ``radio.send_bytes(b'hello')``
 
-:param message: (message) 전송할 바이트입니다."""
+:param message: 전송할 바이트입니다."""
     ...
 
 def receive_bytes() -> Optional[bytes]:
-    """메시지 대기열에 있는 다음 수신 메시지를 받습니다. (receive bytes)
+    """메시지 대기열에 있는 다음 수신 메시지를 받습니다.
 
 Example: ``radio.receive_bytes()``
 
@@ -66,27 +66,27 @@ Example: ``radio.receive_bytes()``
     ...
 
 def receive_bytes_into(buffer: WriteableBuffer) -> Optional[int]:
-    """메시지 대기열에 있는 다음 수신 메시지를 버퍼에 복사합니다. (receive bytes into)
+    """메시지 대기열에 있는 다음 수신 메시지를 버퍼에 복사합니다.
 
 Example: ``radio.receive_bytes_info(buffer)``
 
-:param buffer: (buffer) 목표 버퍼입니다. 메시지가 버퍼보다 크면 메시지가 잘립니다.
+:param buffer: 목표 버퍼입니다. 메시지가 버퍼보다 크면 메시지가 잘립니다.
 :return: ``None`` if there are no pending messages, otherwise it returns the length of the message (which might be more than the length of the buffer)."""
     ...
 
 def send(message: str) -> None:
-    """메시지 문자열을 전송합니다. (send)
+    """메시지 문자열을 전송합니다.
 
 Example: ``radio.send('hello')``
 
 This is the equivalent of ``radio.send_bytes(bytes(message, 'utf8'))`` but with ``b'\x01\x00\x01'``
 prepended to the front (to make it compatible with other platforms that target the micro:bit).
 
-:param message: (message) 전송할 문자열입니다."""
+:param message: 전송할 문자열입니다."""
     ...
 
 def receive() -> Optional[str]:
-    """``receive_bytes``와 정확히 동일한 작업을 하지만 모든 전송 항목을 반환한다는 차이가 있습니다. (receive)
+    """``receive_bytes``와 정확히 동일한 작업을 하지만 모든 전송 항목을 반환한다는 차이가 있습니다.
 
 Example: ``radio.receive()``
 
@@ -100,7 +100,7 @@ A ``ValueError`` exception is raised if conversion to string fails."""
     ...
 
 def receive_full() -> Optional[Tuple[bytes, int, int]]:
-    """메시지 대기열에 있는 다음 수신 메시지의 정보를 세 종류의 값이 포함된 튜플로 반환합니다. (receive full)
+    """메시지 대기열에 있는 다음 수신 메시지의 정보를 세 종류의 값이 포함된 튜플로 반환합니다.
 
 Example: ``radio.receive_full()``
 

--- a/lang/ko/typeshed/stdlib/random.pyi
+++ b/lang/ko/typeshed/stdlib/random.pyi
@@ -1,69 +1,69 @@
-"""무작위 숫자를 생성합니다. (random)"""
+"""무작위 숫자를 생성합니다."""
 from typing import TypeVar, Sequence, Union, overload
 
 def getrandbits(n: int) -> int:
-    """무작위 비트가 ``n``개 있는 정수를 생성합니다. (getrandbits)
+    """무작위 비트가 ``n``개 있는 정수를 생성합니다.
 
 Example: ``random.getrandbits(1)``
 
-:param n: (n) 1~30 사이의 값입니다(경계값 포함)."""
+:param n: 1~30 사이의 값입니다(경계값 포함)."""
     ...
 
 def seed(n: int) -> None:
-    """무작위 숫자 생성기를 초기화합니다. (seed)
+    """무작위 숫자 생성기를 초기화합니다.
 
 Example: ``random.seed(0)``
 
-:param n: (n) 정수 시드
+:param n: 정수 시드
 
 This will give you reproducibly deterministic randomness from a given starting
 state (``n``)."""
     ...
 
 def randint(a: int, b: int) -> int:
-    """``a``부터 ``b``까지 중 무작위 정수를 선택합니다(경계값 포함). (randint)
+    """``a``부터 ``b``까지 중 무작위 정수를 선택합니다(경계값 포함).
 
 Example: ``random.randint(0, 9)``
 
-:param a: (a) 범위 시작 값(경계값 포함)
-:param b: (b) 범위 종료 값(경계값 포함)
+:param a: 범위 시작 값(경계값 포함)
+:param b: 범위 종료 값(경계값 포함)
 
 Alias for ``randrange(a, b + 1)``."""
     ...
 
 @overload
 def randrange(stop: int) -> int:
-    """0과``stop``사이의 무작위 정수를 선택합니다(경계값 제외). (randrange)
+    """0과``stop``사이의 무작위 정수를 선택합니다(경계값 제외).
 
 Example: ``random.randrange(10)``
 
-:param stop: (stop) 범위 종료 값(경계값 제외)"""
+:param stop: 범위 종료 값(경계값 제외)"""
     ...
 
 @overload
 def randrange(start: int, stop: int, step: int=1) -> int:
-    """``range(start, stop, step)``에서 무작위로 정해지는 요소를 선택합니다. (randrange)
+    """``range(start, stop, step)``에서 무작위로 정해지는 요소를 선택합니다.
 
 Example: ``random.randrange(0, 10)``
 
-:param start: (start) 범위 시작(경계값 포함)
-:param stop: (stop) 범위 끝(경계값 제외)
-:param step: (step) 단계입니다."""
+:param start: 범위 시작(경계값 포함)
+:param stop: 범위 끝(경계값 제외)
+:param step: 단계입니다."""
     ...
 _T = TypeVar('_T')
 
 def choice(seq: Sequence[_T]) -> _T:
-    """공백이 아닌 ``seq`` 시퀀스로부터 무작위 요소를 선택합니다. (choice)
+    """공백이 아닌 ``seq`` 시퀀스로부터 무작위 요소를 선택합니다.
 
 Example: ``random.choice([Image.HAPPY, Image.SAD])``
 
-:param seq: (seq) 시퀀스입니다.
+:param seq: 시퀀스입니다.
 
 If ``seq`` is  empty, raises ``IndexError``."""
     ...
 
 def random() -> float:
-    """[0.0, 1.0) 범위 내의 무작위 부동 소수점 수를 생성합니다. (random)
+    """[0.0, 1.0) 범위 내의 무작위 부동 소수점 수를 생성합니다.
 
 Example: ``random.random()``
 
@@ -71,10 +71,10 @@ Example: ``random.random()``
     ...
 
 def uniform(a: float, b: float) -> float:
-    """경계값을 포함한 ``a``와 ``b``사이의 무작위 부동 소수점 수를 반환합니다. (uniform)
+    """경계값을 포함한 ``a``와 ``b``사이의 무작위 부동 소수점 수를 반환합니다.
 
 Example: ``random.uniform(0, 9)``
 
-:param a: (a) 범위 시작 값(경계값 포함)
-:param b: (b) 범위 종료 값(경계값 포함)"""
+:param a: 범위 시작 값(경계값 포함)
+:param b: 범위 종료 값(경계값 포함)"""
     ...

--- a/lang/ko/typeshed/stdlib/speech.pyi
+++ b/lang/ko/typeshed/stdlib/speech.pyi
@@ -1,13 +1,13 @@
-""" micro:bit이 말하고 노래부르고 소리를 재생하게 합니다. (speech)"""
+"""micro:bit이 말하고 노래부르고 소리를 재생하게 합니다."""
 from typing import Optional
 from .microbit import MicroBitDigitalPin, pin0
 
 def translate(words: str) -> str:
-    """영단어를 음소로 변환합니다. (translate)
+    """영단어를 음소로 변환합니다.
 
 Example: ``speech.translate('hello world')``
 
-:param words: (words) 영단어 문자열입니다.
+:param words: 영단어 문자열입니다.
 :return: A string containing a best guess at the appropriate phonemes to pronounce.
 The output is generated from this `text to phoneme translation table <https://github.com/s-macke/SAM/wiki/Text-to-phoneme-translation-table>`_.
 
@@ -19,15 +19,15 @@ See `the online documentation <https://microbit-micropython.readthedocs.io/en/v2
     ...
 
 def pronounce(phonemes: str, pitch: int=64, speed: int=72, mouth: int=128, throat: int=128, pin: Optional[MicroBitDigitalPin]=pin0) -> None:
-    """음소를 발음합니다. (pronounce)
+    """음소를 발음합니다.
 
 Example: ``speech.pronounce(' /HEHLOW WERLD')``
 
-:param phonemes: (phonemes) 발음할 음소의 문자열
+:param phonemes: 발음할 음소의 문자열
 :param pitch: (앞-뒤 기울기) 목소리의 음높이를 표현하는 숫자
-:param speed: (speed) 목소리의 속도를 표현하는 숫자
-:param mouth: (mouth) 목소리의 입 모양을 표현하는 숫자
-:param throat: (throat) 목소리의 목 모양을 표현하는 숫자
+:param speed: 목소리의 속도를 표현하는 숫자
+:param mouth: 목소리의 입 모양을 표현하는 숫자
+:param throat: 목소리의 목 모양을 표현하는 숫자
 :param pin: (핀) ``pin0``의 기본값을 덮어쓰고 출력 핀을 특정하는 인자입니다(선택 사항).
 핀에서 사운드를 재생하기 싫다면 ``pin=None``을 사용할 수 있습니다. micro:bit V2 전용입니다.
 
@@ -38,15 +38,15 @@ See `the online documentation <https://microbit-micropython.readthedocs.io/en/v2
     ...
 
 def say(words: str, pitch: int=64, speed: int=72, mouth: int=128, throat: int=128, pin: MicroBitDigitalPin=pin0) -> None:
-    """영어 단어를 말합니다. (say)
+    """영어 단어를 말합니다.
 
 Example: ``speech.say('hello world')``
 
-:param words: (words) 말할 단어의 문자열입니다.
+:param words: 말할 단어의 문자열입니다.
 :param pitch: (앞-뒤 기울기) 목소리의 음높이를 표현하는 숫자
-:param speed: (speed) 목소리의 속도를 표현하는 숫자
-:param mouth: (mouth) 목소리의 입 모양을 표현하는 숫자
-:param throat: (throat) 목소리의 목 모양을 표현하는 숫자
+:param speed: 목소리의 속도를 표현하는 숫자
+:param mouth: 목소리의 입 모양을 표현하는 숫자
+:param throat: 목소리의 목 모양을 표현하는 숫자
 :param pin: (핀) ``pin0``의 기본값을 덮어쓰고 출력 핀을 특정하는 인자입니다(선택 사항).
 핀에서 사운드를 재생하기 싫다면 ``pin=None``을 사용할 수 있습니다. micro:bit V2 전용입니다.
 
@@ -60,15 +60,15 @@ See `the online documentation <https://microbit-micropython.readthedocs.io/en/v2
     ...
 
 def sing(phonemes: str, pitch: int=64, speed: int=72, mouth: int=128, throat: int=128, pin: MicroBitDigitalPin=pin0) -> None:
-    """음소를 노래합니다. (sing)
+    """음소를 노래합니다.
 
 Example: ``speech.sing(' /HEHLOW WERLD')``
 
-:param phonemes: (phonemes) 노래할 단어 문자열입니다.
+:param phonemes: 노래할 단어 문자열입니다.
 :param pitch: (앞-뒤 기울기) 목소리의 음높이를 표현하는 숫자
-:param speed: (speed) 목소리의 속도를 표현하는 숫자
-:param mouth: (mouth) 목소리의 입 모양을 표현하는 숫자
-:param throat: (throat) 목소리의 목 모양을 표현하는 숫자
+:param speed: 목소리의 속도를 표현하는 숫자
+:param mouth: 목소리의 입 모양을 표현하는 숫자
+:param throat: 목소리의 목 모양을 표현하는 숫자
 :param pin: (핀) ``pin0``의 기본값을 덮어쓰고 출력 핀을 특정하는 인자입니다(선택 사항).
 핀에서 사운드를 재생하기 싫다면 ``pin=None``을 사용할 수 있습니다. micro:bit V2 전용입니다.
 

--- a/lang/ko/typeshed/stdlib/struct.pyi
+++ b/lang/ko/typeshed/stdlib/struct.pyi
@@ -1,56 +1,56 @@
-"""원시 데이터 유형을 패킹하고 언패킹합니다. (struct)"""
+"""원시 데이터 유형을 패킹하고 언패킹합니다."""
 from _typeshed import ReadableBuffer, WriteableBuffer
 from typing import Any, Tuple, Union
 
 def calcsize(fmt: str) -> int:
-    """주어진 ``fmt``를 저장하는 데 필요한 바이트의 수를 불러옵니다. (calcsize)
+    """주어진 ``fmt``를 저장하는 데 필요한 바이트의 수를 불러옵니다.
 
 Example: ``struct.calcsize('hf')``
 
-:param fmt: (fmt) 형식 문자열입니다.
+:param fmt: 형식 문자열입니다.
 :return The number of bytes needed to store such a value."""
     ...
 
 def pack(fmt: str, v1: Any, *vn: Any) -> bytes:
-    """형식 문자열에 따라 값을 패킹합니다. (pack)
+    """형식 문자열에 따라 값을 패킹합니다.
 
 Example: ``struct.pack('hf', 1, 3.1415)``
 
-:param fmt: (fmt) 형식 문자열입니다.
-:param v1: (v1) 첫 값입니다.
-:param *vn: (*vn) 남은 값입니다.
+:param fmt: 형식 문자열입니다.
+:param v1: 첫 값입니다.
+:param *vn: 남은 값입니다.
 :return A bytes object encoding the values."""
     ...
 
 def pack_into(fmt: str, buffer: WriteableBuffer, offset: int, v1: Any, *vn: Any) -> None:
-    """형식 문자열에 따라 값을 패킹합니다. (pack into)
+    """형식 문자열에 따라 값을 패킹합니다.
 
 Example: ``struct.pack_info('hf', buffer, 1, 3.1415)``
 
-:param fmt: (fmt) 형식 문자열입니다.
-:param buffer: (buffer) 작성할 목표 버퍼입니다.
-:param offset: (offset) 버퍼에 적용할 오프셋입니다. 음수를 입력하면 버퍼 끝부터 셀 수 있습니다.
-:param v1: (v1) 첫 값입니다.
-:param *vn: (*vn) 남은 값입니다."""
+:param fmt: 형식 문자열입니다.
+:param buffer: 작성할 목표 버퍼입니다.
+:param offset: 버퍼에 적용할 오프셋입니다. 음수를 입력하면 버퍼 끝부터 셀 수 있습니다.
+:param v1: 첫 값입니다.
+:param *vn: 남은 값입니다."""
     ...
 
 def unpack(fmt: str, data: ReadableBuffer) -> Tuple[Any, ...]:
-    """형식 문자열에 따라 데이터를 언패킹합니다. (unpack)
+    """형식 문자열에 따라 데이터를 언패킹합니다.
 
 Example: ``v1, v2 = struct.unpack('hf', buffer)``
 
-:param fmt: (fmt) 형식 문자열입니다.
-:param data: (data) 데이터입니다.
+:param fmt: 형식 문자열입니다.
+:param data: 데이터입니다.
 :return: A tuple of the unpacked values."""
     ...
 
 def unpack_from(fmt: str, buffer: ReadableBuffer, offset: int=0) -> Tuple:
-    """형식 문자열에 따라 버퍼로부터 데이터를 언패킹합니다. (unpack from)
+    """형식 문자열에 따라 버퍼로부터 데이터를 언패킹합니다.
 
 Example: ``v1, v2 = struct.unpack_from('hf', buffer)``
 
-:param fmt: (fmt) 형식 문자열입니다.
-:param buffer: (buffer) 읽을 소스 버퍼입니다.
+:param fmt: 형식 문자열입니다.
+:param buffer: 읽을 소스 버퍼입니다.
 :param offset: (오프셋) 버퍼에 적용할 오프셋입니다. 음수를 입력하면 버퍼 끝부터 셀 수 있습니다.
 :return: A tuple of the unpacked values."""
     ...

--- a/lang/ko/typeshed/stdlib/sys.pyi
+++ b/lang/ko/typeshed/stdlib/sys.pyi
@@ -1,36 +1,36 @@
-"""시스템 특정 함수 (sys)"""
+"""시스템 특정 함수"""
 from typing import Any, Dict, List, NoReturn, TextIO, Tuple
 
 def exit(retval: object=...) -> NoReturn:
-    """주어진 종료 코드로 현재 프로그램을 종료합니다. (exit)
+    """주어진 종료 코드로 현재 프로그램을 종료합니다.
 
 Example: ``sys.exit(1)``
 
 This function raises a ``SystemExit`` exception. If an argument is given, its
 value given as an argument to ``SystemExit``.
 
-:param retval: (retval) 종료 코드 또는 메시지입니다."""
+:param retval: 종료 코드 또는 메시지입니다."""
     ...
 
 def print_exception(exc: Exception) -> None:
-    """트레이스백으로 예외를 프린트합니다. (print exception)
+    """트레이스백으로 예외를 프린트합니다.
 
 Example: ``sys.print_exception(e)``
 
-:param exc: (exc) 프린트할 예외
+:param exc: 프린트할 예외
 
 This is simplified version of a function which appears in the
 ``traceback`` module in CPython."""
 argv: List[str]
-"""현재 프로그램과 같이 시작된 인자의 가변 리스트입니다. (argv)"""
+"""현재 프로그램과 같이 시작된 인자의 가변 리스트입니다."""
 byteorder: str
-"""시스템의 바이트 순서를 (``"little"`` 또는 ``"big"``)으로 정렬합니다. (byteorder)"""
+"""시스템의 바이트 순서를 (``"little"`` 또는 ``"big"``)으로 정렬합니다."""
 
 class _implementation:
     name: str
     version: Tuple[int, int, int]
 implementation: _implementation
-"""현재 Python 구현에 관한 정보가 담긴 오브젝트 (implementation)
+"""현재 Python 구현에 관한 정보가 담긴 오브젝트
 
 For MicroPython, it has following attributes:
 
@@ -45,7 +45,8 @@ CPython mandates more attributes for this object, but the actual useful
 bare minimum is implemented in MicroPython.
 """
 maxsize: int
-"""현재 플랫폼에서 자연 정수 유형이 지원할 수 있는 최대 값, 또는 값이 플랫폼의 최대 값보다 작다면 MicroPython 정수 유형으로 표현할 수 있는 최대 값(long int를 지원하지 않는 MicroPython 포트의 경우)입니다. (maxsize)
+"""
+현재 플랫폼에서 자연 정수 유형이 지원할 수 있는 최대 값, 또는 값이 플랫폼의 최대 값보다 작다면 MicroPython 정수 유형으로 표현할 수 있는 최대 값(long int를 지원하지 않는 MicroPython 포트의 경우)입니다.
 
 This attribute is useful for detecting "bitness" of a platform (32-bit vs
 64-bit, etc.). It's recommended to not compare this attribute to some
@@ -66,13 +67,13 @@ value directly, but instead count number of bits in it::
         # "> 32", "> 64" style of comparisons.
 """
 modules: Dict[str, Any]
-"""로드된 모듈의 딕셔너리입니다. (modules)
+"""로드된 모듈의 딕셔너리입니다. 
 
 On some ports, it may not include builtin modules."""
 path: List[str]
-"""불러온 모듈을 검색하기 위한 딕셔너리 가변 리스트입니다. (path)"""
+"""불러온 모듈을 검색하기 위한 딕셔너리 가변 리스트입니다."""
 platform: str
-"""MicroPython이 구동되고 있는 플랫폼. (platform)
+"""MicroPython이 구동되고 있는 플랫폼. 
 
 For OS/RTOS ports, this is usually an identifier of the OS, e.g. ``"linux"``.
 For baremetal ports it is an identifier of a board, e.g. ``"pyboard"`` for 
@@ -83,9 +84,9 @@ If you need to check whether your program runs on MicroPython (vs other
 Python implementation), use ``sys.implementation`` instead.
 """
 version: str
-"""이 구현이 준수하는 Python 언어 버전을 문자열로 제공. (version)"""
+"""이 구현이 준수하는 Python 언어 버전을 문자열로 제공."""
 version_info: Tuple[int, int, int]
-"""이 구현이 준수하는 Python 언어 버전을 int 튜플로 제공. (version info)
+"""이 구현이 준수하는 Python 언어 버전을 int 튜플로 제공.
 
 Only the first three version numbers (major, minor, micro) are supported and
 they can be referenced only by index, not by name.

--- a/lang/ko/typeshed/stdlib/time.pyi
+++ b/lang/ko/typeshed/stdlib/time.pyi
@@ -1,33 +1,33 @@
-"""시간을 측정하고 프로그램에 지연을 추가합니다. (time)"""
+"""시간을 측정하고 프로그램에 지연을 추가합니다."""
 from typing import Union
 
 def sleep(seconds: Union[int, float]) -> None:
-    """초 단위로 지연을 추가합니다. (sleep)
+    """초 단위로 지연을 추가합니다.
 
 Example: ``time.sleep(1)``
 
-:param seconds: (seconds) 초 단위만큼 슬립에 들어갑니다.
+:param seconds: 초 단위만큼 슬립에 들어갑니다.
 부동 소수점 수를 사용해 초 단위 미만만큼 슬립에 들어갑니다."""
     ...
 
 def sleep_ms(ms: int) -> None:
-    """밀리초 단위로 딜레이를 부여합니다. (sleep ms)
+    """밀리초 단위로 딜레이를 부여합니다.
 
 Example: ``time.sleep_ms(1_000_000)``
 
-:param ms: (ms) 밀리초 단위의 지연(>= 0)."""
+:param ms: 밀리초 단위의 지연(>= 0)."""
     ...
 
 def sleep_us(us: int) -> None:
-    """마이크로초 단위로 지연을 추가합니다. (sleep us)
+    """마이크로초 단위로 지연을 추가합니다.
 
 Example: ``time.sleep_us(1000)``
 
-:param us: (us) 마이크로초 단위의 지연(>= 0)."""
+:param us: 마이크로초 단위의 지연(>= 0)."""
     ...
 
 def ticks_ms() -> int:
-    """임의의 레퍼런스 포인트가 있는 점진적으로 증가하는 밀리초 카운터로, 일부 값을 따라 래핑합니다. (ticks ms)
+    """임의의 레퍼런스 포인트가 있는 점진적으로 증가하는 밀리초 카운터로, 일부 값을 따라 래핑합니다.
 
 Example: ``time.ticks_ms()``
 
@@ -35,7 +35,7 @@ Example: ``time.ticks_ms()``
     ...
 
 def ticks_us() -> int:
-    """임의의 레퍼런스 포인트가 있는 점진적으로 증가하는 마이크로초 카운터로, 일부 값을 따라 래핑합니다. (ticks us)
+    """임의의 레퍼런스 포인트가 있는 점진적으로 증가하는 마이크로초 카운터로, 일부 값을 따라 래핑합니다.
 
 Example: ``time.ticks_us()``
 
@@ -43,7 +43,7 @@ Example: ``time.ticks_us()``
     ...
 
 def ticks_add(ticks: int, delta: int) -> int:
-    """주어진 숫자에 따라 틱 값을 오프셋으로 사용합니다. 양수나 음수일 수 있습니다. (ticks add)
+    """주어진 숫자에 따라 틱 값을 오프셋으로 사용합니다. 양수나 음수일 수 있습니다.
 
 Example: ``time.ticks_add(time.ticks_ms(), 200)``
 
@@ -51,8 +51,8 @@ Given a ticks value, this function allows to calculate ticks
 value delta ticks before or after it, following modular-arithmetic
 definition of tick values.
 
-:param ticks: (ticks) 틱 값
-:param delta: (delta) 정수 오프셋
+:param ticks: 틱 값
+:param delta: 정수 오프셋
 
 Example::
 
@@ -69,12 +69,12 @@ Example::
     ...
 
 def ticks_diff(ticks1: int, ticks2: int) -> int:
-    """``time.ticks_ms()`` 또는 ``ticks_us()``에서 반환된 값 사이의 틱 차이를 측정합니다. 서명된 값은 래핑될 수 있습니다. (ticks diff)
+    """``time.ticks_ms()`` 또는 ``ticks_us()``에서 반환된 값 사이의 틱 차이를 측정합니다. 서명된 값은 래핑될 수 있습니다.
 
 Example: ``time.ticks_diff(scheduled_time, now)``
 
-:param ticks1: (ticks1) 빼기 전의 값
-:param ticks2: (ticks2) 뺄 값
+:param ticks1: 빼기 전의 값
+:param ticks2: 뺄 값
 
 The argument order is the same as for subtraction operator,
 ``ticks_diff(ticks1, ticks2)`` has the same meaning as ``ticks1 - ticks2``.

--- a/lang/zh-cn/typeshed/stdlib/gc.pyi
+++ b/lang/zh-cn/typeshed/stdlib/gc.pyi
@@ -1,22 +1,22 @@
-"""控制垃圾回收器 (gc)"""
+"""控制垃圾回收器"""
 from typing import overload
 
 def enable() -> None:
-    """启用自动垃圾回收机制。 (enable)"""
+    """启用自动垃圾回收机制。"""
     ...
 
 def disable() -> None:
-    """禁用自动垃圾回收机制。 (disable)
+    """禁用自动垃圾回收机制。
 
 Heap memory can still be allocated,
 and garbage collection can still be initiated manually using ``gc.collect``."""
 
 def collect() -> None:
-    """执行一次垃圾回收。 (collect)"""
+    """执行一次垃圾回收。"""
     ...
 
 def mem_alloc() -> int:
-    """获取分配的堆内存的字节数。 (mem alloc)
+    """获取分配的堆内存的字节数。
 
 :return: The number of bytes allocated.
 
@@ -24,7 +24,7 @@ This function is MicroPython extension."""
     ...
 
 def mem_free() -> int:
-    """获取可用堆内存的字节数，如果此数量未知，则返回值为 -1。 (mem free)
+    """获取可用堆内存的字节数，如果此数量未知，则返回值为 -1。
 
 :return: The number of bytes free.
 
@@ -33,7 +33,7 @@ This function is MicroPython extension."""
 
 @overload
 def threshold() -> int:
-    """查询额外的垃圾回收分配阈值。 (threshold)
+    """查询额外的垃圾回收分配阈值。
 
 :return: The GC allocation threshold.
 
@@ -44,7 +44,7 @@ implementations, its signature and semantics are different."""
 
 @overload
 def threshold(amount: int) -> None:
-    """设置额外的垃圾回收分配阈值。 (threshold)
+    """设置额外的垃圾回收分配阈值。
 
 Normally, a collection is triggered only when a new allocation
 cannot be satisfied, i.e. on an  out-of-memory (OOM) condition.
@@ -64,5 +64,5 @@ This function is a MicroPython extension. CPython has a similar
 function - ``set_threshold()``, but due to different GC
 implementations, its signature and semantics are different.
 
-:param amount: (amount) 触发进行垃圾回收的字节数。"""
+:param amount: 触发进行垃圾回收的字节数。"""
     ...

--- a/lang/zh-cn/typeshed/stdlib/log.pyi
+++ b/lang/zh-cn/typeshed/stdlib/log.pyi
@@ -1,18 +1,18 @@
-"""将数据记录到您的 micro:bit V2。 (log)"""
+"""将数据记录到您的 micro:bit V2。"""
 from typing import Literal, Optional, Union, overload
 MILLISECONDS = 1
-"""毫秒时间戳格式。 (milliseconds)"""
+"""毫秒时间戳格式。"""
 SECONDS = 10
-"""秒时间戳格式。 (seconds)"""
+"""秒时间戳格式。"""
 MINUTES = 600
-"""分钟时间戳格式。 (minutes)"""
+"""分钟时间戳格式。"""
 HOURS = 36000
-"""小时时间戳格式。 (hours)"""
+"""小时时间戳格式。"""
 DAYS = 864000
-"""日期时间戳格式。 (days)"""
+"""日期时间戳格式。"""
 
 def set_labels(*args: str, timestamp: Optional[Literal[1, 10, 36000, 864000]]=SECONDS) -> None:
-    """设置日志文件头。 (set labels)
+    """设置日志文件头。
 
 Example: ``log.set_labels('x', 'y', 'z', timestamp=log.MINUTES)``
 
@@ -24,14 +24,14 @@ labels set up by this function call to the last headers declared in the
 file. If the headers are different it will add a new header entry at the
 end of the file.
 
-:param *args: (*args) 每个日志头的位置参数。
-:param timestamp: (timestamp) 将自动添加为每行第一列的时间戳单位。
+:param *args: 每个日志头的位置参数。
+:param timestamp: 将自动添加为每行第一列的时间戳单位。
 将此参数设置为 ``None`` 来禁用时间戳。传递此模块定义的 ``log.MILLISECONDS``、 ``log.SECONDS``、 ``log.MINUTES``、 ``log.HOURS`` 或 ``log.DAYS`` 值。 无效的值会抛出异常。"""
     ...
 
 @overload
 def add(log_data: Optional[dict[str, Union[str, int, float]]]) -> None:
-    """通过传递包含标题和值的字典将数据行添加到日志中。 (add)
+    """通过传递包含标题和值的字典将数据行添加到日志中。
 
 Example: ``log.add({ 'temp': temperature() })``
 
@@ -44,12 +44,12 @@ entry to be added to the log with the extra label.
 Labels previously specified and not present in this function call will be
 skipped with an empty value in the log row.
 
-:param log_data: (log data) 要记录为字典的数据，每个标题都有一个键。"""
+:param log_data: 要记录为字典的数据，每个标题都有一个键。"""
     ...
 
 @overload
 def add(**kwargs: Union[str, int, float]) -> None:
-    """使用关键字参数将数据行添加到日志中。 (add)
+    """使用关键字参数将数据行添加到日志中。
 
 Example: ``log.add(temp=temperature())``
 
@@ -64,23 +64,23 @@ skipped with an empty value in the log row."""
     ...
 
 def delete(full=False):
-    """删除日志的内容，包括标题。 (delete)
+    """删除日志的内容，包括标题。
 
 Example: ``log.delete()``
 
 To add the log headers the ``set_labels`` function has to be called again
 after this.
 
-:param full: (full) 选择“完全”擦除模式，将数据从闪存中删除。
+:param full: 选择“完全”擦除模式，将数据从闪存中删除。
 如果设置为 ``False`` ，它将使用“快速”方法，该方法会使得数据无效，而不是执行较慢的完全擦除。"""
     ...
 
 def set_mirroring(serial: bool):
-    """把数据记录活动镜像到串行输出。 (set mirroring)
+    """把数据记录活动镜像到串行输出。
 
 Example: ``log.set_mirroring(True)``
 
 Mirroring is disabled by default.
 
-:param serial: (serial) ``True`` 则把数据记录活动镜像到串行输出，``False`` 则禁用镜像。"""
+:param serial: ``True`` 则把数据记录活动镜像到串行输出，``False`` 则禁用镜像。"""
     ...

--- a/lang/zh-cn/typeshed/stdlib/machine.pyi
+++ b/lang/zh-cn/typeshed/stdlib/machine.pyi
@@ -1,9 +1,9 @@
-"""低级实用程序。 (machine)"""
+"""低级实用程序。"""
 from typing import Any
 from .microbit import MicroBitDigitalPin
 
 def unique_id() -> bytes:
-    """获取具有板的唯一标识符的字节字符串。 (unique id)
+    """获取具有板的唯一标识符的字节字符串。
 
 Example: ``machine.unique_id()``
 
@@ -11,13 +11,13 @@ Example: ``machine.unique_id()``
     ...
 
 def reset() -> None:
-    """以类似于按下外部 RESET （重置）按钮的方式重置设备。 (reset)
+    """以类似于按下外部 RESET （重置）按钮的方式重置设备。
 
 Example: ``machine.reset()``"""
     ...
 
 def freq() -> int:
-    """以赫兹为单位获取 CPU 频率。 (freq)
+    """以赫兹为单位获取 CPU 频率。
 
 Example: ``machine.freq()``
 
@@ -25,7 +25,7 @@ Example: ``machine.freq()``
     ...
 
 def disable_irq() -> Any:
-    """禁止中断请求。 (disable irq)
+    """禁止中断请求。
 
 Example: ``interrupt_state = machine.disable_irq()``
 
@@ -36,15 +36,15 @@ interrupts to their original state."""
     ...
 
 def enable_irq(state: Any) -> None:
-    """重新启用中断请求。 (enable irq)
+    """重新启用中断请求。
 
 Example: ``machine.enable_irq(interrupt_state)``
 
-:param state: (state) 最近一次调用 ``disable_irq`` 函数得到的返回值。"""
+:param state: 最近一次调用 ``disable_irq`` 函数得到的返回值。"""
     ...
 
 def time_pulse_us(pin: MicroBitDigitalPin, pulse_level: int, timeout_us: int=1000000) -> int:
-    """对引脚上的脉冲计时。 (time pulse us)
+    """对引脚上的脉冲计时。
 
 Example: ``time_pulse_us(pin0, 1)``
 
@@ -55,30 +55,30 @@ function first waits until the pin input becomes equal to
 starts straight away.
 
 :param pin: (引脚) 要使用的引脚
-:param pulse_level: (pulse level) 0 来计时低脉冲或 1 来计时高脉冲。
-:param timeout_us: (timeout us) 微秒超时
+:param pulse_level: 0 来计时低脉冲或 1 来计时高脉冲。
+:param timeout_us: 微秒超时
 :return: The duration of the pulse in microseconds, or -1 for a timeout waiting for the level to match ``pulse_level``, or -2 on timeout waiting for the pulse to end"""
     ...
 
 class mem:
-    """``mem8``、 ``mem16`` 和 ``mem32`` 内存视图的类。 (mem)"""
+    """``mem8``、 ``mem16`` 和 ``mem32`` 内存视图的类。"""
 
     def __getitem__(self, address: int) -> int:
-        """从内存中获取一个值。 (getitem)
+        """从内存中获取一个值。
 
 :param address: (地址) 内存地址。
 :return: The value at that address as an integer."""
         ...
 
     def __setitem__(self, address: int, value: int) -> None:
-        """在给定地址处设置一个值。 (setitem)
+        """在给定地址处设置一个值。
 
 :param address: (地址) 内存地址。
-:param value: (value) 要设置的整数值。"""
+:param value: 要设置的整数值。"""
         ...
 mem8: mem
-"""8 位(字节) 内存视图。 (mem8)"""
+"""8 位(字节) 内存视图。"""
 mem16: mem
-"""16 位内存视图。 (mem16)"""
+"""16 位内存视图。"""
 mem32: mem
-"""32 位内存视图。 (mem32)"""
+"""32 位内存视图。"""

--- a/lang/zh-cn/typeshed/stdlib/math.pyi
+++ b/lang/zh-cn/typeshed/stdlib/math.pyi
@@ -1,105 +1,104 @@
-"""数学函数。 (math)"""
+"""数学函数。"""
 from typing import Tuple
 
 def acos(x: float) -> float:
-    """计算反余弦。 (acos)
+    """计算反余弦。
 
 Example: ``math.acos(1)``
 
-:param x: (x) 一个数字
+:param x: 一个数字
 :return: The inverse cosine of ``x``"""
     ...
 
 def asin(x: float) -> float:
-    """计算反正弦值。 (asin)
+    """计算反正弦值。
 
 Example: ``math.asin(0)``
 
-:param x: (x) 一个数字
+:param x: 一个数字
 :return: The inverse sine of ``x``"""
     ...
 
 def atan(x: float) -> float:
-    """计算反正切。 (atan)
+    """计算反正切。
 
 Example: ``math.atan(0)``
 
-:param x: (x) 一个数字
+:param x: 一个数字
 :return: The inverse tangent of ``x``"""
     ...
 
 def atan2(y: float, x: float) -> float:
-    """计算 ``y/x`` 的反正切的主值。 (atan2)
+    """计算 ``y/x`` 的反正切的主值。
 
 Example: ``math.atan2(0, -1)``
 
-:param y: (x) 一个数字
-:param x: (x) 一个数字
+:param y: 一个数字
+:param x: 一个数字
 :return: The principal value of the inverse tangent of ``y/x``"""
     ...
 
 def ceil(x: float) -> float:
-    """
-将数字向正无穷大取整(向上取整) (ceil)
+    """将数字向正无穷大取整(向上取整)
 
 Example: ``math.ceil(0.1)``
 
-:param x: (x) 一个数字
+:param x: 一个数字
 :return: ``x`` rounded towards positive infinity."""
     ...
 
 def copysign(x: float, y: float) -> float:
-    """获取 ``y`` 的符号和 ``x`` 的绝对值。 (copysign)
+    """获取 ``y`` 的符号和 ``x`` 的绝对值。
 
 Example: ``math.copysign(1, -1)``
 
-:param x: (x) 一个数字
-:param y: (y) 返回值的符号来源
+:param x: 一个数字
+:param y: 返回值的符号来源
 :return: ``x`` with the sign of ``y``"""
     ...
 
 def cos(x: float) -> float:
-    """计算 ``x`` 的余弦。 (cos)
+    """计算 ``x`` 的余弦。
 
 Example: ``math.cos(0)``
 
-:param x: (x) 一个数字
+:param x: 一个数字
 :return: The cosine of ``x``"""
     ...
 
 def degrees(x: float) -> float:
-    """将弧度转换为度。 (degrees)
+    """将弧度转换为度。
 
 Example: ``math.degrees(2 * math.pi)``
 
-:param x: (x) 一个以弧度为单位的值
+:param x: 一个以弧度为单位的值
 :return: The value converted to degrees"""
     ...
 
 def exp(x: float) -> float:
-    """计算 E 的 ``x`` 指数。 (exp)
+    """计算 E 的 ``x`` 指数。
 
 Example: ``math.exp(1)``
 
-:param x: (x) 一个数字
+:param x: 一个数字
 :return: The exponential of ``x``."""
     ...
 
 def fabs(x: float) -> float:
-    """返回 ``x`` 的绝对值。 (fabs)
+    """返回 ``x`` 的绝对值。
 
 Example: ``math.fabs(-0.1)``
 
-:param x: (x) 一个数字
+:param x: 一个数字
 :return: The absolute value of ``x``"""
     ...
 
 def floor(x: float) -> int:
-    """将数字向负无穷大取整(向下取整)。 (floor)
+    """将数字向负无穷大取整(向下取整)。
 
 Example: ``math.floor(0.9)``
 
-:param x: (x) 一个数字
+:param x: 一个数字
 :return: ``x`` rounded towards negative infinity."""
     ...
 
@@ -108,8 +107,8 @@ def fmod(x: float, y: float) -> float:
 
 Example: ``math.fmod(10, 3)``
 
-:param x: (x) 分子
-:param y: (y) 分母"""
+:param x: 分子
+:param y: 分母"""
     ...
 
 def frexp(x: float) -> Tuple[float, int]:
@@ -121,7 +120,7 @@ The returned value is the tuple ``(m, e)`` such that ``x == m * 2**e``
 exactly.  If ``x == 0`` then the function returns ``(0.0, 0)``, otherwise
 the relation ``0.5 <= abs(m) < 1`` holds.
 
-:param x: (x) 一个浮点数
+:param x: 一个浮点数
 :return: A tuple of length two containing its mantissa then exponent"""
     ...
 
@@ -130,7 +129,7 @@ def isfinite(x: float) -> bool:
 
 Example: ``math.isfinite(float('inf'))``
 
-:param x: (x) 一个数字。
+:param x: 一个数字。
 :return: ``True`` if ``x`` is finite, ``False`` otherwise."""
     ...
 
@@ -139,7 +138,7 @@ def isinf(x: float) -> bool:
 
 Example: ``math.isinf(float('-inf'))``
 
-:param x: (x) 一个数字。
+:param x: 一个数字。
 :return: ``True`` if ``x`` is infinite, ``False`` otherwise."""
     ...
 
@@ -148,7 +147,7 @@ def isnan(x: float) -> bool:
 
 Example: ``math.isnan(float('nan'))``
 
-:param x: (x) 一个数字
+:param x: 一个数字
 :return: ``True`` if ``x`` is not-a-number (NaN), ``False`` otherwise."""
     ...
 
@@ -157,13 +156,13 @@ def ldexp(x: float, exp: int) -> float:
 
 Example: ``math.ldexp(0.5, 2)``
 
-:param x: (x) 一个数字
-:param exp: (exp) 整数指数
+:param x: 一个数字
+:param exp: 整数指数
 :return: ``x * (2**exp)``"""
     ...
 
 def log(x: float, base: float=e) -> float:
-    """计算给定底数 ``x`` 的对数（默认为自然对数）。 (log)
+    """计算给定底数 ``x`` 的对数（默认为自然对数）。
 
 Example: ``math.log(math.e)``
 
@@ -171,8 +170,8 @@ With one argument, return the natural logarithm of x (to base e).
 
 With two arguments, return the logarithm of x to the given base, calculated as ``log(x)/log(base)``.
 
-:param x: (x) 一个数字
-:param base: (base) 要使用的底数
+:param x: 一个数字
+:param base: 要使用的底数
 :return: The natural logarithm of ``x``"""
     ...
 
@@ -181,7 +180,7 @@ def modf(x: float) -> Tuple[float, float]:
 
 Example: ``fractional, integral = math.modf(1.5)``
 
-:param x: (x) 一个数字
+:param x: 一个数字
 :return: A tuple of two floats representing the fractional then integral parts of ``x``.
 
 Both the fractional and integral values have the same sign as ``x``."""
@@ -192,27 +191,26 @@ def pow(x: float, y: float) -> float:
 
 Example: ``math.pow(4, 0.5)``
 
-:param x: (x) 一个数字
-:param y: (y) 指数值
+:param x: 一个数字
+:param y: 指数值
 :return: ``x`` to the power of ``y``"""
     ...
 
 def radians(x: float) -> float:
-    """将度数转换为弧度。 (radians)
+    """将度数转换为弧度。
 
 Example: ``math.radians(360)``
 
-:param x: (x) 以度为单位的值
+:param x: 以度为单位的值
 :return: The value converted to radians"""
     ...
 
 def sin(x: float) -> float:
-    """
-计算 ``x`` 的正弦值。 (正弦)
+    """计算 ``x`` 的正弦值。 (正弦)
 
 Example: ``math.sin(math.pi/2)``
 
-:param x: (x) 一个数字
+:param x: 一个数字
 :return: The sine of ``x``"""
     ...
 
@@ -221,7 +219,7 @@ def sqrt(x: float) -> float:
 
 Example: ``math.sqrt(4)``
 
-:param x: (x) 一个数字
+:param x: 一个数字
 :return: The square root of ``x``"""
     ...
 
@@ -230,7 +228,7 @@ def tan(x: float) -> float:
 
 Example: ``math.tan(0)``
 
-:param x: (x) 一个数字
+:param x: 一个数字
 :return: The tangent of ``x``."""
     ...
 
@@ -239,10 +237,10 @@ def trunc(x: float) -> int:
 
 Example: ``math.trunc(-0.9)``
 
-:param x: (x) 一个数字
+:param x: 一个数字
 :return: ``x`` rounded towards zero."""
     ...
 e: float
-"""自然对数的底数 (e)"""
+"""自然对数的底数"""
 pi: float
-"""圆的周长与其直径的比值 (pi)"""
+"""圆的周长与其直径的比值"""

--- a/lang/zh-cn/typeshed/stdlib/microbit/__init__.pyi
+++ b/lang/zh-cn/typeshed/stdlib/microbit/__init__.pyi
@@ -28,9 +28,9 @@ or used as a decorator::
 
 Arguments with different time units are additive.
 
-:param callback: (callback) 要调用的回调。当用作装饰器时省略。
-:param days: (days) 以天为单位的间隔。
-:param h: (h) 以小时为单位的间隔。
+:param callback: 要调用的回调。当用作装饰器时省略。
+:param days: 以天为单位的间隔。
+:param h: 以小时为单位的间隔。
 :param min: (分钟) 以分钟为单位的间隔。
 :param s: (秒) 以秒为单位的间隔。
 :param ms: (毫秒) 以毫秒为单位的间隔。"""
@@ -40,19 +40,19 @@ def panic(n: int) -> None:
 
 Example: ``panic(127)``
 
-:param n: (n) 一个 <= 255 的任意整数，以表示一个状态。
+:param n: 一个 <= 255 的任意整数，以表示一个状态。
 
 Requires restart."""
 
 def reset() -> None:
-    """重启主板。 (reset)"""
+    """重启主板。"""
 
 def sleep(n: float) -> None:
     """等待 ``n`` 毫秒。 (休眠)
 
 Example: ``sleep(1000)``
 
-:param n: (n) 要等待的毫秒数
+:param n: 要等待的毫秒数
 
 One second is 1000 milliseconds, so::
 
@@ -61,19 +61,19 @@ One second is 1000 milliseconds, so::
 will pause the execution for one second."""
 
 def running_time() -> int:
-    """获取主板的运行时间。 (running time)
+    """获取主板的运行时间。
 
 :return: The number of milliseconds since the board was switched on or restarted."""
 
 def temperature() -> int:
-    """以摄氏度为单位获取 micro:bit 的温度。 (temperature)"""
+    """以摄氏度为单位获取 micro:bit 的温度。"""
 
 def set_volume(v: int) -> None:
-    """设置音量。 (set volume)
+    """设置音量。
 
 Example: ``set_volume(127)``
 
-:param v: (v) 一个介于 0 (低) 和 255 (高) 之间的值。
+:param v: 一个介于 0 (低) 和 255 (高) 之间的值。
 
 Out of range values will be clamped to 0 or 255.
 
@@ -81,16 +81,16 @@ Out of range values will be clamped to 0 or 255.
     ...
 
 class Button:
-    """按钮 ``button_a`` 和 ``button_b`` 的类。 (button)"""
+    """按钮 ``button_a`` 和 ``button_b`` 的类。"""
 
     def is_pressed(self) -> bool:
-        """检查按钮是否被按下。 (is pressed)
+        """检查按钮是否被按下。
 
 :return: ``True`` if the specified button ``button`` is pressed, and ``False`` otherwise."""
         ...
 
     def was_pressed(self) -> bool:
-        """检查按钮自设备启动以来或者上次调用此方法之后是否被按下。 (was pressed)
+        """检查按钮自设备启动以来或者上次调用此方法之后是否被按下。
 
 Calling this method will clear the press state so
 that the button must be pressed again before this method will return
@@ -100,14 +100,14 @@ that the button must be pressed again before this method will return
         ...
 
     def get_presses(self) -> int:
-        """获得按钮被按下的总计次数，并在返回之前将该总计次数重置为 0。 (get presses)
+        """获得按钮被按下的总计次数，并在返回之前将该总计次数重置为 0。
 
 :return: The number of presses since the device started or the last time this method was called"""
         ...
 button_a: Button
-"""左键 ``Button`` 对象。 (button a)"""
+"""左键 ``Button`` 对象。"""
 button_b: Button
-"""右键 ``Button`` 对象。 (button b)"""
+"""右键 ``Button`` 对象。"""
 
 class MicroBitDigitalPin:
     """数字引脚。 (Microbit 数字引脚)
@@ -118,7 +118,7 @@ Some pins support analog and touch features using the ``MicroBitAnalogDigitalPin
     PULL_DOWN: int
 
     def read_digital(self) -> int:
-        """获取引脚的数字值。 (read digital)
+        """获取引脚的数字值。
 
 Example: ``value = pin0.read_digital()``
 
@@ -126,23 +126,23 @@ Example: ``value = pin0.read_digital()``
         ...
 
     def write_digital(self, value: int) -> None:
-        """设置引脚的数字值。 (write digital)
+        """设置引脚的数字值。
 
 Example: ``pin0.write_digital(1)``
 
-:param value: (value) 1 将引脚设置为高电平，或 0 将引脚设置为低电平"""
+:param value: 1 将引脚设置为高电平，或 0 将引脚设置为低电平"""
         ...
 
     def set_pull(self, value: int) -> None:
-        """将拉取状态设置为以下三个可能的值之一：``PULL_UP``、``PULL_DOWN`` 或 N``NO_PULL``。 (set pull)
+        """将拉取状态设置为以下三个可能的值之一：``PULL_UP``、``PULL_DOWN`` 或 N``NO_PULL``。
 
 Example: ``pin0.set_pull(pin0.PULL_UP)``
 
-:param value: (value) 相关引脚的拉取状态，例如： ``pin0.PULL_UP``。"""
+:param value: 相关引脚的拉取状态，例如： ``pin0.PULL_UP``。"""
         ...
 
     def get_pull(self) -> int:
-        """获取引脚上的拉取状态。 (get pull)
+        """获取引脚上的拉取状态。
 
 Example: ``pin0.get_pull()``
 
@@ -153,7 +153,7 @@ when a pin mode requires it."""
         ...
 
     def get_mode(self) -> str:
-        """返回引脚模式。 (get mode)
+        """返回引脚模式。
 
 Example: ``pin0.get_mode()``
 
@@ -165,43 +165,43 @@ changes.
         ...
 
     def write_analog(self, value: int) -> None:
-        """在引脚上输出 PWM 信号，占空比为 ``value``。 (write analog)
+        """在引脚上输出 PWM 信号，占空比为 ``value``。
 
 Example: ``pin0.write_analog(254)``
 
-:param value: (value) 介于 0（0% 占空比）和 1023（100% 占空比）之间的整数或浮点数。"""
+:param value: 介于 0（0% 占空比）和 1023（100% 占空比）之间的整数或浮点数。"""
 
     def set_analog_period(self, period: int) -> None:
-        """将输出的 PWM 信号的周期设置为 ``period``（单位：毫秒）。 (set analog period)
+        """将输出的 PWM 信号的周期设置为 ``period``（单位：毫秒）。
 
 Example: ``pin0.set_analog_period(10)``
 
-:param period: (period) 以毫秒为单位的周期，最小有效值为 1 毫秒。"""
+:param period: 以毫秒为单位的周期，最小有效值为 1 毫秒。"""
 
     def set_analog_period_microseconds(self, period: int) -> None:
-        """将输出的 PWM 信号的周期设置为 ``period``（单位：微秒）。 (set analog period microseconds)
+        """将输出的 PWM 信号的周期设置为 ``period``（单位：微秒）。
 
 Example: ``pin0.set_analog_period_microseconds(512)``
 
-:param period: (period) 以微秒为单位的周期，最小有效值为 256 毫秒。"""
+:param period: 以微秒为单位的周期，最小有效值为 256 毫秒。"""
 
 class MicroBitAnalogDigitalPin(MicroBitDigitalPin):
-    """带有模拟和数字功能的引脚。 (microbitanalogdigitalpin)"""
+    """带有模拟和数字功能的引脚。"""
 
     def read_analog(self) -> int:
-        """读取应用于引脚的电压。 (read analog)
+        """读取应用于引脚的电压。
 
 Example: ``pin0.read_analog()``
 
 :return: An integer between 0 (meaning 0V) and 1023 (meaning 3.3V)."""
 
 class MicroBitTouchPin(MicroBitAnalogDigitalPin):
-    """带有模拟、数字和触摸功能的引脚。 (microbittouchpin)"""
+    """带有模拟、数字和触摸功能的引脚。"""
     CAPACITIVE: int
     RESISTIVE: int
 
     def is_touched(self) -> bool:
-        """检查引脚是否被触摸。 (is touched)
+        """检查引脚是否被触摸。
 
 Example: ``pin0.is_touched()``
 
@@ -224,14 +224,14 @@ does not require you to make a ground connection as part of a circuit.
         ...
 
     def set_touch_mode(self, value: int) -> None:
-        """设置引脚的触摸模式。 (set touch mode)
+        """设置引脚的触摸模式。
 
 Example: ``pin0.set_touch_mode(pin0.CAPACITIVE)``
 
 The default touch mode for the pins on the edge connector is
 ``resistive``. The default for the logo pin **V2** is ``capacitive``.
 
-:param value: (value)  来自相关引脚的 ``CAPACITIVE`` 或 ``RESISTIVE``。"""
+:param value: 来自相关引脚的 ``CAPACITIVE`` 或 ``RESISTIVE``。"""
         ...
 pin0: MicroBitTouchPin
 """具有数字、模拟和触摸功能的引脚。 (引脚0)"""
@@ -272,8 +272,7 @@ pin19: MicroBitDigitalPin
 pin20: MicroBitDigitalPin
 """具有数字功能的引脚。 (引脚20)"""
 pin_logo: MicroBitTouchPin
-"""micro:bit 正面的触摸感应标志引脚，默认设置为电容式触摸模式。 (引脚标志
-)"""
+"""micro:bit 正面的触摸感应标志引脚，默认设置为电容式触摸模式。 (引脚标志)"""
 pin_speaker: MicroBitAnalogDigitalPin
 """用于对 micro:bit 扬声器寻址的引脚。 (扬声器引脚)
 
@@ -291,19 +290,19 @@ Given an image object it's possible to display it via the ``display`` API::
     HEART_SMALL: Image
     """小的心形图像。 (小的心形)"""
     HAPPY: Image
-    """快乐的脸部图像。 (happy)"""
+    """快乐的脸部图像。"""
     SMILE: Image
-    """微笑的脸部图像。 (smile)"""
+    """微笑的脸部图像。"""
     SAD: Image
-    """难过的脸部图像。 (sad)"""
+    """难过的脸部图像。"""
     CONFUSED: Image
-    """困惑的面部图像。 (confused)"""
+    """困惑的面部图像。"""
     ANGRY: Image
-    """愤怒的脸部图像。 (angry)"""
+    """愤怒的脸部图像。"""
     ASLEEP: Image
-    """睡着的脸部图像。 (asleep)"""
+    """睡着的脸部图像。"""
     SURPRISED: Image
-    """惊讶的脸部图像。 (surprised)"""
+    """惊讶的脸部图像。"""
     SILLY: Image
     """傻傻的脸部图像。 (傻的)"""
     FABULOUS: Image
@@ -357,8 +356,7 @@ Given an image object it's possible to display it via the ``display`` API::
     TRIANGLE: Image
     """向上的三角形图像。 (三角)"""
     TRIANGLE_LEFT: Image
-    """左角的三角形图像。 (
-triangle left)"""
+    """左角的三角形图像。"""
     CHESSBOARD: Image
     """按棋盘式交替点亮 LED。 (国际象棋棋盘)"""
     DIAMOND: Image
@@ -368,29 +366,29 @@ triangle left)"""
     SQUARE: Image
     """方形图像。 (正方形)"""
     SQUARE_SMALL: Image
-    """小的方形图像。 (square small)"""
+    """小的方形图像。"""
     RABBIT: Image
     """兔子图像。 (兔子)"""
     COW: Image
     """奶牛图像。 (牛)"""
     MUSIC_CROTCHET: Image
-    """音乐音符图像 (music crotchet)"""
+    """音乐音符图像"""
     MUSIC_QUAVER: Image
-    """八分音符图像。 (music quaver)"""
+    """八分音符图像。"""
     MUSIC_QUAVERS: Image
-    """一对八分音符图像。 (music quavers)"""
+    """一对八分音符图像。"""
     PITCHFORK: Image
     """干草叉图像。 (干草叉)"""
     XMAS: Image
-    """圣诞树图像。 (xmas)"""
+    """圣诞树图像。"""
     PACMAN: Image
-    """吃豆人游戏角色图像。 (pacman)"""
+    """吃豆人游戏角色图像。"""
     TARGET: Image
-    """目标图像 (target)"""
+    """目标图像"""
     TSHIRT: Image
     """T 恤图像。 (T恤)"""
     ROLLERSKATE: Image
-    """轮滑图像。 (rollerskate)"""
+    """轮滑图像。"""
     DUCK: Image
     """鸭子图像。 (鸭子)"""
     HOUSE: Image
@@ -400,8 +398,7 @@ triangle left)"""
     BUTTERFLY: Image
     """蝴蝶图像 (蝴蝶)"""
     STICKFIGURE: Image
-    """
-火柴人图像。 (简笔人物画)"""
+    """火柴人图像。 (简笔人物画)"""
     GHOST: Image
     """幽灵图像。 (幽灵)"""
     SWORD: Image
@@ -415,13 +412,13 @@ triangle left)"""
     SNAKE: Image
     """蛇图像。 (蛇)"""
     ALL_CLOCKS: List[Image]
-    """按顺序包含所有 CLOCK_ 图像的列表（时钟）。 (all clocks)"""
+    """按顺序包含所有 CLOCK_ 图像的列表（时钟）。"""
     ALL_ARROWS: List[Image]
-    """按顺序包含所有 ARROW_ 图像的列表（箭头）。 (all arrows)"""
+    """按顺序包含所有 ARROW_ 图像的列表（箭头）。"""
 
     @overload
     def __init__(self, string: str) -> None:
-        """根据描述点亮 LED 的字符串来创建一幅图像。 (init)
+        """根据描述点亮 LED 的字符串来创建一幅图像。
 
 ``string`` has to consist of digits 0-9 arranged into lines,
 describing the image, for example::
@@ -435,12 +432,12 @@ describing the image, for example::
 will create a 5×5 image of an X. The end of a line is indicated by a
 colon. It's also possible to use newlines (\\n) insead of the colons.
 
-:param string: (string) 描述图像的字符串。"""
+:param string: 描述图像的字符串。"""
         ...
 
     @overload
     def __init__(self, width: int=5, height: int=5, buffer: ReadableBuffer=None) -> None:
-        """创建一幅具有 ``width`` 列和 ``height`` 行的空白图像。 (init)
+        """创建一幅具有 ``width`` 列和 ``height`` 行的空白图像。
 
 :param width: (宽度) 可选的图像宽度
 :param height: (高度) 可选的图像高度
@@ -467,61 +464,61 @@ These create 2 x 2 pixel images at full brightness."""
         ...
 
     def set_pixel(self, x: int, y: int, value: int) -> None:
-        """设置像素亮度。 (set pixel)
+        """设置像素亮度。
 
 Example: ``my_image.set_pixel(0, 0, 9)``
 
-:param x: (x) 列号
-:param y: (y) 行号
-:param value: (value) 用 0（暗）和 9（亮）之间的整数来代表亮度
+:param x: 列号
+:param y: 行号
+:param value: 用 0（暗）和 9（亮）之间的整数来代表亮度
 
 This method will raise an exception when called on any of the built-in
 read-only images, like ``Image.HEART``."""
         ...
 
     def get_pixel(self, x: int, y: int) -> int:
-        """获取一个像素的亮度。 (get pixel)
+        """获取一个像素的亮度。
 
 Example: ``my_image.get_pixel(0, 0)``
 
-:param x: (x) 列号
-:param y: (y) 行号
+:param x: 列号
+:param y: 行号
 :return: The brightness as an integer between 0 and 9."""
         ...
 
     def shift_left(self, n: int) -> Image:
-        """通过向左移动图片来创建新图像。 (shift left)
+        """通过向左移动图片来创建新图像。
 
 Example: ``Image.HEART_SMALL.shift_left(1)``
 
-:param n: (n) 要移动的列数
+:param n: 要移动的列数
 :return: The shifted image"""
         ...
 
     def shift_right(self, n: int) -> Image:
-        """通过向右移动图片来创建新图像。 (shift right)
+        """通过向右移动图片来创建新图像。
 
 Example: ``Image.HEART_SMALL.shift_right(1)``
 
-:param n: (n) 要移动的列数
+:param n: 要移动的列数
 :return: The shifted image"""
         ...
 
     def shift_up(self, n: int) -> Image:
-        """通过向上移动图片来创建新图像。 (shift up)
+        """通过向上移动图片来创建新图像。
 
 Example: ``Image.HEART_SMALL.shift_up(1)``
 
-:param n: (n) 要移动的行数
+:param n: 要移动的行数
 :return: The shifted image"""
         ...
 
     def shift_down(self, n: int) -> Image:
-        """通过向下移动图片来创建新图像。 (shift down)
+        """通过向下移动图片来创建新图像。
 
 Example: ``Image.HEART_SMALL.shift_down(1)``
 
-:param n: (n) 要移动的行数
+:param n: 要移动的行数
 :return: The shifted image"""
         ...
 
@@ -530,10 +527,10 @@ Example: ``Image.HEART_SMALL.shift_down(1)``
 
 Example: ``Image.HEART.crop(1, 1, 3, 3)``
 
-:param x: (x) 裁剪偏移列
-:param y: (y) 裁剪偏移行
-:param w: (w) 裁剪宽度
-:param h: (h) 裁剪高度
+:param x: 裁剪偏移列
+:param y: 裁剪偏移行
+:param w: 裁剪宽度
+:param h: 裁剪高度
 :return: The new image"""
         ...
 
@@ -558,22 +555,22 @@ Example: ``Image.SMALL_HEART.invert()``
 
 Example: ``my_image.fill(5)``
 
-:param value: (value) 新亮度为 0 (暗) 和 9 (明) 之间的数字。
+:param value: 新亮度为 0 (暗) 和 9 (明) 之间的数字。
 
 This method will raise an exception when called on any of the built-in
 read-only images, like ``Image.HEART``."""
         ...
 
     def blit(self, src: Image, x: int, y: int, w: int, h: int, xdest: int=0, ydest: int=0) -> None:
-        """复制另一幅图像的一部分区域到这幅图像。 (blit)
+        """复制另一幅图像的一部分区域到这幅图像。
 
 Example: ``my_image.blit(Image.HEART, 1, 1, 3, 3, 1, 1)``
 
 :param src: (来源) 源图像
-:param x: (x) 源图像的起始列偏移量
-:param y: (y) 源图像的起始行偏移量
-:param w: (w) 要复制的列数
-:param h: (h) 要复制的行数
+:param x: 源图像的起始列偏移量
+:param y: 源图像的起始行偏移量
+:param w: 要复制的列数
+:param h: 要复制的行数
 :param xdest: (x偏离量) 此图像中要修改的列偏移量
 :param ydest: (y偏离量) 此图像中要修改的行偏移量
 
@@ -599,7 +596,7 @@ For example, img.crop(x, y, w, h) can be implemented as::
         ...
 
     def __add__(self, other: Image) -> Image:
-        """通过将两幅图像每个像素的亮度值相加来创建一幅新图像。 (add)
+        """通过将两幅图像每个像素的亮度值相加来创建一幅新图像。
 
 Example: ``Image.HEART + Image.HAPPY``
 
@@ -619,7 +616,7 @@ Example: ``Image.HEART - Image.HEART_SMALL``
 
 Example: ``Image.HEART * 0.5``
 
-:param n: (n) 要相乘的数值。"""
+:param n: 要相乘的数值。"""
         ...
 
     def __truediv__(self, n: float) -> Image:
@@ -627,7 +624,7 @@ Example: ``Image.HEART * 0.5``
 
 Example: ``Image.HEART / 2``
 
-:param n: (n) 要除以的数值。"""
+:param n: 要除以的数值。"""
         ...
 
 class SoundEvent:
@@ -641,14 +638,13 @@ class Sound:
     GIGGLE: Sound
     """咯咯的声音。 (咯咯笑)"""
     HAPPY: Sound
-    """快乐的声音。 (happy)"""
+    """快乐的声音。"""
     HELLO: Sound
     """问候声。 (你好)"""
     MYSTERIOUS: Sound
     """神秘的声音 (神秘的)"""
     SAD: Sound
-    """
-悲伤的声音。 (sad)"""
+    """悲伤的声音。"""
     SLIDE: Sound
     """滑动声。 (滑动)"""
     SOARING: Sound

--- a/lang/zh-cn/typeshed/stdlib/microbit/accelerometer.pyi
+++ b/lang/zh-cn/typeshed/stdlib/microbit/accelerometer.pyi
@@ -2,7 +2,7 @@
 from typing import Tuple
 
 def get_x() -> int:
-    """获取 ``x`` 轴上的加速度测量值（以 milli-g 为单位）。 (get x)
+    """获取 ``x`` 轴上的加速度测量值（以 milli-g 为单位）。
 
 Example: ``accelerometer.get_x()``
 
@@ -10,7 +10,7 @@ Example: ``accelerometer.get_x()``
     ...
 
 def get_y() -> int:
-    """获取 ``y`` 轴上的加速度测量值（以 milli-g 为单位）。 (get y)
+    """获取 ``y`` 轴上的加速度测量值（以 milli-g 为单位）。
 
 Example: ``accelerometer.get_y()``
 
@@ -18,7 +18,7 @@ Example: ``accelerometer.get_y()``
     ...
 
 def get_z() -> int:
-    """获取 ``z`` 轴上的加速度测量值（以 milli-g 为单位）。 (get z)
+    """获取 ``z`` 轴上的加速度测量值（以 milli-g 为单位）。
 
 Example: ``accelerometer.get_z()``
 
@@ -26,7 +26,7 @@ Example: ``accelerometer.get_z()``
     ...
 
 def get_values() -> Tuple[int, int, int]:
-    """一次获取所有轴上的加速度测量值作为元组。 (get values)
+    """一次获取所有轴上的加速度测量值作为元组。
 
 Example: ``x, y, z = accelerometer.get_values()``
 
@@ -34,7 +34,7 @@ Example: ``x, y, z = accelerometer.get_values()``
     ...
 
 def current_gesture() -> str:
-    """获取当前手势的名称。 (current gesture)
+    """获取当前手势的名称。
 
 Example: ``accelerometer.current_gesture()``
 
@@ -47,7 +47,7 @@ represented as strings.
     ...
 
 def is_gesture(name: str) -> bool:
-    """检查命名手势当前是否处于活动状态。 (is gesture)
+    """检查命名手势当前是否处于活动状态。
 
 Example: ``accelerometer.is_gesture('shake')``
 
@@ -56,12 +56,12 @@ MicroPython understands the following gesture names: ``"up"``, ``"down"``,
 ``"3g"``, ``"6g"``, ``"8g"``, ``"shake"``. Gestures are always
 represented as strings.
 
-:param name: (name) 手势名称。
+:param name: 手势名称。
 :return: ``True`` if the gesture is active, ``False`` otherwise."""
     ...
 
 def was_gesture(name: str) -> bool:
-    """检查命名手势自上次调用后是否处于活动状态。 (was gesture)
+    """检查命名手势自上次调用后是否处于活动状态。
 
 Example: ``accelerometer.was_gesture('shake')``
 
@@ -70,11 +70,11 @@ MicroPython understands the following gesture names: ``"up"``, ``"down"``,
 ``"3g"``, ``"6g"``, ``"8g"``, ``"shake"``. Gestures are always
 represented as strings.
 
-:param name: (name) 手势名称。
+:param name: 手势名称。
 :return: ``True`` if the gesture was active since the last call, ``False`` otherwise."""
 
 def get_gestures() -> Tuple[str, ...]:
-    """返回手势历史的元组。 (get gestures)
+    """返回手势历史的元组。
 
 Example: ``accelerometer.get_gestures()``
 

--- a/lang/zh-cn/typeshed/stdlib/microbit/audio.pyi
+++ b/lang/zh-cn/typeshed/stdlib/microbit/audio.pyi
@@ -1,4 +1,4 @@
-"""使用 micro:bit 播放声音（导入 ``audio`` 以兼容 V1）。 (audio)"""
+"""使用 micro:bit 播放声音（导入 ``audio`` 以兼容 V1）。"""
 from ..microbit import MicroBitDigitalPin, Sound, pin0
 from typing import Iterable, Union
 
@@ -10,10 +10,10 @@ Example: ``audio.play(Sound.GIGGLE)``
 :param source: (来源) 内置的音频 ``Sound``， 例如 ``Sound.GIGGLE``，  或作为可迭代的 ``AudioFrame`` 对象的样本数据。
 :param wait: (等待) 如果 ``wait`` 为 ``True``, 此函数将会阻塞直到声音完成。
 :param pin: (引脚) 可选参数， 用于指定可覆盖默认 ``pin0`` 的输出引脚。 如果不想播放任何声音，可以使用 ``pin=None``。
-:param return_pin: (return pin) 指定一个差分边缘连接器引脚以连接到外部扬声器而不是接地。对于 **V2** 修订版，这将被忽略。"""
+:param return_pin: 指定一个差分边缘连接器引脚以连接到外部扬声器而不是接地。对于 **V2** 修订版，这将被忽略。"""
 
 def is_playing() -> bool:
-    """检查是否在播放声音。 (is playing)
+    """检查是否在播放声音。
 
 Example: ``audio.is_playing()``
 

--- a/lang/zh-cn/typeshed/stdlib/microbit/compass.pyi
+++ b/lang/zh-cn/typeshed/stdlib/microbit/compass.pyi
@@ -1,4 +1,4 @@
-"""使用内置罗盘。 (compass)"""
+"""使用内置罗盘。"""
 
 def calibrate() -> None:
     """开始校准过程。 (校准)
@@ -10,7 +10,7 @@ to rotate the device in order to draw a circle on the LED display."""
     ...
 
 def is_calibrated() -> bool:
-    """检查罗盘是否已校准。 (is calibrated)
+    """检查罗盘是否已校准。
 
 Example: ``compass.is_calibrated()``
 
@@ -18,13 +18,13 @@ Example: ``compass.is_calibrated()``
     ...
 
 def clear_calibration() -> None:
-    """取消校准，将罗盘恢复到未校准状态。 (clear calibration)
+    """取消校准，将罗盘恢复到未校准状态。
 
 Example: ``compass.clear_calibration()``"""
     ...
 
 def get_x() -> int:
-    """获取 ``x`` 轴上的磁场强度。 (get x)
+    """获取 ``x`` 轴上的磁场强度。
 
 Example: ``compass.get_x()``
 
@@ -34,7 +34,7 @@ Call ``calibrate`` first or the results will be inaccurate.
     ...
 
 def get_y() -> int:
-    """获取 ``y`` 轴上的磁场强度。 (get y)
+    """获取 ``y`` 轴上的磁场强度。
 
 Example: ``compass.get_y()``
 
@@ -44,7 +44,7 @@ Call ``calibrate`` first or the results will be inaccurate.
     ...
 
 def get_z() -> int:
-    """获取 ``z`` 轴上的磁场强度。 (get z)
+    """获取 ``z`` 轴上的磁场强度。
 
 Example: ``compass.get_z()``
 
@@ -54,7 +54,7 @@ Call ``calibrate`` first or the results will be inaccurate.
     ...
 
 def heading() -> int:
-    """获取罗盘指向。 (heading)
+    """获取罗盘指向。
 
 Example: ``compass.heading()``
 

--- a/lang/zh-cn/typeshed/stdlib/microbit/display.pyi
+++ b/lang/zh-cn/typeshed/stdlib/microbit/display.pyi
@@ -3,23 +3,23 @@ from ..microbit import Image
 from typing import Union, overload, Iterable
 
 def get_pixel(x: int, y: int) -> int:
-    """获取第``y``行第``x``列的 LED 亮度。 (get pixel)
+    """获取第``y``行第``x``列的 LED 亮度。
 
 Example: ``display.get_pixel(0, 0)``
 
-:param x: (x) 显示屏的列(0..4)
-:param y: (y) 显示行 (0..4)
+:param x: 显示屏的列(0..4)
+:param y: 显示行 (0..4)
 :return: A number between 0 (off) and 9 (bright)"""
     ...
 
 def set_pixel(x: int, y: int, value: int) -> None:
-    """设置在 ``x`` 列和 ``y`` 行的 LED 的亮度。 (set pixel)
+    """设置在 ``x`` 列和 ``y`` 行的 LED 的亮度。
 
 Example: ``display.set_pixel(0, 0, 9)``
 
-:param x: (x) 显示屏的列(0..4)
-:param y: (y) 显示行 (0..4)
-:param value: (value) 在 0 (关闭) 和 9 (亮) 之间的亮度"""
+:param x: 显示屏的列(0..4)
+:param y: 显示行 (0..4)
+:param value: 在 0 (关闭) 和 9 (亮) 之间的亮度"""
     ...
 
 def clear() -> None:
@@ -39,7 +39,7 @@ If ``image`` is a string or number, each letter or digit is displayed in turn.
 :param image: (图像) 要显示的一个字符串、数字、图像或图像列表。
 :param delay: (延迟) 每个字母、数字或图像之间显示的间隔时间为 ``delay`` 毫秒。
 :param wait: (等待) 如果 ``wait`` 为 ``True``，此函数将阻塞直到动画完成，否则动画将在后台发生。
-:param loop: (loop) 如果 ``loop`` 为 ``True``, 动画将永远重复。
+:param loop: 如果 ``loop`` 为 ``True``, 动画将永远重复。
 :param clear: (清除) 如果 ``clear`` 是 ``True``, 则显示将在序列完成后被清除。
 
 The ``wait``, ``loop`` and ``clear`` arguments must be specified using their keyword."""
@@ -53,7 +53,7 @@ Example: ``display.scroll('micro:bit')``
 :param text: (文本) 要滚动的字符串。如果 ``text`` 是整数或浮点数，则首先使用 ``str()`` 将其转换为字符串。
 :param delay: (延迟) ``delay`` 参数控制文本滚动的速度。
 :param wait: (等待) 如果 ``wait`` 为 ``True``，此函数将阻塞直到动画完成，否则动画将发生在后台。
-:param loop: (loop) 如果 ``loop`` 为 ``True``, 动画将永远重复。
+:param loop: 如果 ``loop`` 为 ``True``, 动画将永远重复。
 :param monospace: (等宽) 如果 ``monospace`` 为 ``True``，则字符的宽度都将占用 5 个像素列，否则在滚动时每个字符之间将恰好有 1 个空白像素列。
 
 The ``wait``, ``loop`` and ``monospace`` arguments must be specified
@@ -73,7 +73,7 @@ Example: ``display.off()``"""
     ...
 
 def is_on() -> bool:
-    """检查 LED 显示屏是否启用。 (is on)
+    """检查 LED 显示屏是否启用。
 
 Example: ``display.is_on()``
 
@@ -81,8 +81,7 @@ Example: ``display.is_on()``
     ...
 
 def read_light_level() -> int:
-    """读取亮度。 (
-read light level)
+    """读取亮度。
 
 Example: ``display.read_light_level()``
 

--- a/lang/zh-cn/typeshed/stdlib/microbit/i2c.pyi
+++ b/lang/zh-cn/typeshed/stdlib/microbit/i2c.pyi
@@ -4,11 +4,11 @@ from ..microbit import MicroBitDigitalPin, pin19, pin20
 from typing import List
 
 def init(freq: int=100000, sda: MicroBitDigitalPin=pin20, scl: MicroBitDigitalPin=pin19) -> None:
-    """重新初始化外设。 (init)
+    """重新初始化外设。
 
 Example: ``i2c.init()``
 
-:param freq: (freq) 时钟频率
+:param freq: 时钟频率
 :param sda: (SDA引脚) ``sda`` 引脚(默认 20)
 :param scl: (SCL引脚) ``scl`` 引脚(默认 19)
 
@@ -33,8 +33,8 @@ def read(addr: int, n: int, repeat: bool=False) -> bytes:
 Example: ``i2c.read(0x50, 64)``
 
 :param addr: (地址) 设备的 7 位地址
-:param n: (n) 要读取的字节数
-:param repeat: (repeat) 如果为 ``True``，则不发送停止位
+:param n: 要读取的字节数
+:param repeat: 如果为 ``True``，则不发送停止位
 :return: The bytes read"""
     ...
 
@@ -45,5 +45,5 @@ Example: ``i2c.write(0x50, bytes([1, 2, 3]))``
 
 :param addr: (地址) 设备的 7 位地址
 :param buf: (缓冲区) 包含要写入的字节的缓冲区
-:param repeat: (repeat) 如果为 ``True``，则不发送停止位"""
+:param repeat: 如果为 ``True``，则不发送停止位"""
     ...

--- a/lang/zh-cn/typeshed/stdlib/microbit/microphone.pyi
+++ b/lang/zh-cn/typeshed/stdlib/microbit/microphone.pyi
@@ -1,9 +1,9 @@
-"""使用内置麦克风响应声音（仅限 V2）。 (microphone)"""
+"""使用内置麦克风响应声音（仅限 V2）。"""
 from typing import Optional, Tuple
 from ..microbit import SoundEvent
 
 def current_event() -> Optional[SoundEvent]:
-    """获取最后录制的声音事件 (current event)
+    """获取最后录制的声音事件
 
 Example: ``microphone.current_event()``
 
@@ -33,7 +33,7 @@ This call does not clear the sound event history.
     ...
 
 def get_events() -> Tuple[SoundEvent, ...]:
-    """以元组的形式获取声音事件历史。 (get events)
+    """以元组的形式获取声音事件历史。
 
 Example: ``microphone.get_events()``
 
@@ -43,18 +43,18 @@ This call clears the sound history before returning.
     ...
 
 def set_threshold(event: SoundEvent, value: int) -> None:
-    """设置声音事件的阈值。 (set threshold)
+    """设置声音事件的阈值。
 
 Example: ``microphone.set_threshold(SoundEvent.LOUD, 250)``
 
 A high threshold means the event will only trigger if the sound is very loud (>= 250 in the example).
 
 :param event: (事件) 声音事件，如``SoundEvent.LOUD``或``SoundEvent.QUIET``。
-:param value: (value) 范围为0到255的阈值水平。"""
+:param value: 范围为0到255的阈值水平。"""
     ...
 
 def sound_level() -> int:
-    """获取声压级。 (音量 )
+    """获取声压级。 (音量)
 
 Example: ``microphone.sound_level()``
 

--- a/lang/zh-cn/typeshed/stdlib/microbit/spi.pyi
+++ b/lang/zh-cn/typeshed/stdlib/microbit/spi.pyi
@@ -3,7 +3,7 @@ from _typeshed import ReadableBuffer, WriteableBuffer
 from ..microbit import pin13, pin14, pin15, MicroBitDigitalPin
 
 def init(baudrate: int=1000000, bits: int=8, mode: int=0, sclk: MicroBitDigitalPin=pin13, mosi: MicroBitDigitalPin=pin15, miso: MicroBitDigitalPin=pin14) -> None:
-    """初始化串行外设接口（SPI ）通信。 (init)
+    """初始化串行外设接口（SPI ）通信。
 
 Example: ``spi.init()``
 

--- a/lang/zh-cn/typeshed/stdlib/microbit/uart.pyi
+++ b/lang/zh-cn/typeshed/stdlib/microbit/uart.pyi
@@ -5,11 +5,10 @@ from typing import Optional, Union
 ODD: int
 """奇校验 (奇数)"""
 EVEN: int
-"""
-偶校验 (偶数)"""
+"""偶校验 (偶数)"""
 
 def init(baudrate: int=9600, bits: int=8, parity: Optional[int]=None, stop: int=1, tx: Optional[MicroBitDigitalPin]=None, rx: Optional[MicroBitDigitalPin]=None) -> None:
-    """初始化串行通信。 (init)
+    """初始化串行通信。
 
 Example: ``uart.init(115200, tx=pin0, rx=pin1)``
 

--- a/lang/zh-cn/typeshed/stdlib/micropython.pyi
+++ b/lang/zh-cn/typeshed/stdlib/micropython.pyi
@@ -66,7 +66,7 @@ The default optimisation level is usually level 0.
     ...
 
 def mem_info(verbose: Any=None) -> None:
-    """打印与当前使用内存相关的信息。 (mem info)
+    """打印与当前使用内存相关的信息。
 
 Example: ``micropython.mem_info()``
 

--- a/lang/zh-cn/typeshed/stdlib/music.pyi
+++ b/lang/zh-cn/typeshed/stdlib/music.pyi
@@ -2,7 +2,7 @@
 from typing import Tuple, Union, List
 from .microbit import MicroBitDigitalPin, pin0
 DADADADUM: Tuple[str, ...]
-"""旋律：《贝多芬 C 小调第五交响曲》开场曲。 (dadadadum)"""
+"""旋律：《贝多芬 C 小调第五交响曲》开场曲。"""
 ENTERTAINER: Tuple[str, ...]
 """旋律：斯科特·乔普林的拉格泰姆经典“演艺人”的开场片段。 (演艺人)"""
 PRELUDE: Tuple[str, ...]
@@ -40,21 +40,20 @@ BADDY: Tuple[str, ...]
 CHASE: Tuple[str, ...]
 """旋律：无声电影时代的追逐场景。 (追逐)"""
 BA_DING: Tuple[str, ...]
-"""旋律：表示某事发生的简短信号。 (ba ding )"""
+"""旋律：表示某事发生的简短信号。"""
 WAWAWAWAA: Tuple[str, ...]
-"""旋律：非常悲伤的长号。 (wawawawaa)"""
+"""旋律：非常悲伤的长号。"""
 JUMP_UP: Tuple[str, ...]
-"""旋律：用于游戏中，表示向上运动。 (jump up)"""
+"""旋律：用于游戏中，表示向上运动。"""
 JUMP_DOWN: Tuple[str, ...]
-"""旋律：用于游戏中，表示向下运动。 (jump down)"""
+"""旋律：用于游戏中，表示向下运动。"""
 POWER_UP: Tuple[str, ...]
 """旋律：表示解锁成就的号角。 (能力增强)"""
 POWER_DOWN: Tuple[str, ...]
 """旋律：表示失去成就的悲伤号角。 (能力减弱)"""
 
 def set_tempo(ticks: int=4, bpm: int=120) -> None:
-    """
-设置播放的大致节奏。 (设置节奏)
+    """设置播放的大致节奏。 (设置节奏)
 
 Example: ``music.set_tempo(bpm=120)``
 
@@ -88,7 +87,7 @@ Example: ``music.play(music.NYAN)``
 :param music: (音乐) `a special notation <https://microbit-micropython.readthedocs.io/en/v2-docs/music.html#musical-notation>`_中指定的音乐
 :param pin: (引脚) 用于外接扬声器的输出引脚（默认为 ``pin0``），``None`` 表示无声音。
 :param wait: (等待) 如果 ``wait`` 设置为 ``True``，则此函数阻塞。
-:param loop: (loop) 如果 ``loop`` 设置为 ``True``，曲调会重复直到调用 ``stop`` 或阻塞调用被中断。
+:param loop: 如果 ``loop`` 设置为 ``True``，曲调会重复直到调用 ``stop`` 或阻塞调用被中断。
 
 Many built-in melodies are defined in this module."""
     ...
@@ -117,7 +116,7 @@ Example: ``music.stop()``
 :param pin: (引脚) 可以提供可选参数来指定一个引脚，如``music.stop(pin1)``。"""
 
 def reset() -> None:
-    """将 ticks、bpm、duration 和 octave重置为默认值。 (reset)
+    """将 ticks、bpm、duration 和 octave重置为默认值。
 
 Example: ``music.reset()``
 

--- a/lang/zh-cn/typeshed/stdlib/neopixel.pyi
+++ b/lang/zh-cn/typeshed/stdlib/neopixel.pyi
@@ -5,7 +5,7 @@ from typing import Tuple
 class NeoPixel:
 
     def __init__(self, pin: MicroBitDigitalPin, n: int, bpp: int=3) -> None:
-        """初始化一条通过一个引脚控制的新 neopixel LED 灯带。 (init)
+        """初始化一条通过一个引脚控制的新 neopixel LED 灯带。
 
 Example: ``np = neopixel.NeoPixel(pin0, 8)``
 
@@ -14,7 +14,7 @@ RGBW neopixels are only supported by micro:bit V2.
 See `the online docs <https://microbit-micropython.readthedocs.io/en/v2-docs/neopixel.html>`_ for warnings and other advice.
 
 :param pin: (引脚) 控制 neopixel 灯带的引脚。
-:param n: (n) 灯带中 neopixel 灯珠的数量。
+:param n: 灯带中 neopixel 灯珠的数量。
 :param bpp: (每像素字节数) 每个像素的字节数。对于 RGB 和 GRB 而言，只有将该值设置为 4 而不是默认值 3，micro:bit V2 RGBW neopixel 才能支持。"""
         ...
 
@@ -43,8 +43,7 @@ Equivalent to ``show``."""
         ...
 
     def fill(self, colour: Tuple[int, ...]) -> None:
-        """
-用给定的 RGB/RGBW 值为所有像素着色。 (填充)
+        """用给定的 RGB/RGBW 值为所有像素着色。 (填充)
 
 Example: ``np.fill((0, 0, 255))``
 
@@ -54,15 +53,15 @@ Use in conjunction with ``show()`` to update the neopixels."""
         ...
 
     def __setitem__(self, key: int, value: Tuple[int, ...]) -> None:
-        """设置像素颜色 (setitem)
+        """设置像素颜色
 
 Example: ``np[0] = (255, 0, 0)``
 
 :param key: (键) 像素数。
-:param value: (value) 颜色。"""
+:param value: 颜色。"""
 
     def __getitem__(self, key: int) -> Tuple[int, ...]:
-        """获取像素颜色。 (getitem)
+        """获取像素颜色。
 
 Example: ``r, g, b = np[0]``
 

--- a/lang/zh-cn/typeshed/stdlib/os.pyi
+++ b/lang/zh-cn/typeshed/stdlib/os.pyi
@@ -42,7 +42,7 @@ class uname_result(Tuple[str, str, str, str, str]):
     version: str
     """操作系统版本。 (版本)"""
     machine: str
-    """硬件标识符。 (machine)"""
+    """硬件标识符。"""
 
 def uname() -> uname_result:
     """返回标识当前操作系统的信息。 (当前系统名称)

--- a/lang/zh-cn/typeshed/stdlib/radio.pyi
+++ b/lang/zh-cn/typeshed/stdlib/radio.pyi
@@ -46,7 +46,7 @@ If ``config`` is not called then the defaults described above are assumed."""
     ...
 
 def reset() -> None:
-    """将设置重设为默认值。 (reset)
+    """将设置重设为默认值。
 
 Example: ``radio.reset()``
 

--- a/lang/zh-cn/typeshed/stdlib/random.pyi
+++ b/lang/zh-cn/typeshed/stdlib/random.pyi
@@ -6,7 +6,7 @@ def getrandbits(n: int) -> int:
 
 Example: ``random.getrandbits(1)``
 
-:param n: (n) 一个在1到30之间（包含30）的数值。"""
+:param n: 一个在1到30之间（包含30）的数值。"""
     ...
 
 def seed(n: int) -> None:
@@ -14,7 +14,7 @@ def seed(n: int) -> None:
 
 Example: ``random.seed(0)``
 
-:param n: (n) 整数种子
+:param n: 整数种子
 
 This will give you reproducibly deterministic randomness from a given starting
 state (``n``)."""
@@ -25,8 +25,8 @@ def randint(a: int, b: int) -> int:
 
 Example: ``random.randint(0, 9)``
 
-:param a: (a) 区间起始值（包含）
-:param b: (b) 区间结束值（包含）
+:param a: 区间起始值（包含）
+:param b: 区间结束值（包含）
 
 Alias for ``randrange(a, b + 1)``."""
     ...
@@ -75,6 +75,6 @@ def uniform(a: float, b: float) -> float:
 
 Example: ``random.uniform(0, 9)``
 
-:param a: (a) 区间起始值（包含）
-:param b: (b) 区间结束值（包含）"""
+:param a: 区间起始值（包含）
+:param b: 区间结束值（包含）"""
     ...

--- a/lang/zh-cn/typeshed/stdlib/speech.pyi
+++ b/lang/zh-cn/typeshed/stdlib/speech.pyi
@@ -44,8 +44,7 @@ Example: ``speech.say('hello world')``
 
 :param words: (单词) 要说的词串。
 :param pitch: (音高) 代表声音音高的数字
-:param speed: (速度) 
-代表声音速度的数字
+:param speed: (速度) 代表声音速度的数字
 :param mouth: (嘴部) 表示声音口型的数字
 :param throat: (喉部) 表示声音喉型的数字
 :param pin: (引脚) 可选参数，可用于指定输出引脚来覆盖 ``pin0`` 默认值。
@@ -66,8 +65,7 @@ def sing(phonemes: str, pitch: int=64, speed: int=72, mouth: int=128, throat: in
 Example: ``speech.sing(' /HEHLOW WERLD')``
 
 :param phonemes: (音素) 要唱的词串。
-:param pitch: (音高) 
-代表声音音高的数字
+:param pitch: (音高) 代表声音音高的数字
 :param speed: (速度) 代表声音速度的数字
 :param mouth: (嘴部) 表示声音口型的数字
 :param throat: (喉部) 表示声音喉型的数字

--- a/lang/zh-cn/typeshed/stdlib/struct.pyi
+++ b/lang/zh-cn/typeshed/stdlib/struct.pyi
@@ -17,21 +17,21 @@ def pack(fmt: str, v1: Any, *vn: Any) -> bytes:
 Example: ``struct.pack('hf', 1, 3.1415)``
 
 :param fmt: (格式字符串) 格式字符串。
-:param v1: (v1) 第一个值。
-:param *vn: (*vn) 剩余值。
+:param v1: 第一个值。
+:param *vn: 剩余值。
 :return A bytes object encoding the values."""
     ...
 
 def pack_into(fmt: str, buffer: WriteableBuffer, offset: int, v1: Any, *vn: Any) -> None:
-    """根据格式字符串打包值。 (pack into)
+    """根据格式字符串打包值。
 
 Example: ``struct.pack_info('hf', buffer, 1, 3.1415)``
 
 :param fmt: (格式字符串) 格式字符串。
 :param buffer: (缓冲区) 待写入的目标缓冲区。
 :param offset: (偏移量) 缓冲区内的偏移量。如果从缓冲区末端开始算起，该偏移量可能是负数。
-:param v1: (v1) 第一个值。
-:param *vn: (*vn) 剩余值。"""
+:param v1: 第一个值。
+:param *vn: 剩余值。"""
     ...
 
 def unpack(fmt: str, data: ReadableBuffer) -> Tuple[Any, ...]:
@@ -45,12 +45,12 @@ Example: ``v1, v2 = struct.unpack('hf', buffer)``
     ...
 
 def unpack_from(fmt: str, buffer: ReadableBuffer, offset: int=0) -> Tuple:
-    """根据格式字符串从缓冲区解压数据。 (unpack from)
+    """根据格式字符串从缓冲区解压数据。
 
 Example: ``v1, v2 = struct.unpack_from('hf', buffer)``
 
 :param fmt: (格式字符串) 格式字符串。
-:param buffer: (buffer) 待读取的源缓冲区。
+:param buffer: 待读取的源缓冲区。
 :param offset: (偏移量) 缓冲区内的偏移量。如果从缓冲区末端开始算起，该偏移量可能是负数。
 :return: A tuple of the unpacked values."""
     ...

--- a/lang/zh-cn/typeshed/stdlib/sys.pyi
+++ b/lang/zh-cn/typeshed/stdlib/sys.pyi
@@ -13,8 +13,7 @@ value given as an argument to ``SystemExit``.
     ...
 
 def print_exception(exc: Exception) -> None:
-    """
-打印带有回溯的异常。 (打印异常)
+    """打印带有回溯的异常。 (打印异常)
 
 Example: ``sys.print_exception(e)``
 
@@ -31,7 +30,7 @@ class _implementation:
     name: str
     version: Tuple[int, int, int]
 implementation: _implementation
-"""包含有关当前 Python 实现的信息的对象。 (implementation)
+"""包含有关当前 Python 实现的信息的对象。
 
 For MicroPython, it has following attributes:
 
@@ -46,7 +45,8 @@ CPython mandates more attributes for this object, but the actual useful
 bare minimum is implemented in MicroPython.
 """
 maxsize: int
-"""在当前平台上可以容纳的整数类型的最大值，
+"""
+在当前平台上可以容纳的整数类型的最大值，
 或 MicroPython 整数类型可表示的最大值，如果它小于
 平台的最大值（这见于 MicroPython 端口不支持长整数的情况）。 (最大值)
 
@@ -69,13 +69,13 @@ value directly, but instead count number of bits in it::
         # "> 32", "> 64" style of comparisons.
 """
 modules: Dict[str, Any]
-"""已加载模块的字典。  (模块)
+"""已加载模块的字典。 (模块) 
 
 On some ports, it may not include builtin modules."""
 path: List[str]
 """用于搜索导入模块的目录的可变列表。 (路径)"""
 platform: str
-"""正在运行 MicroPython 的平台。 (平台)
+"""正在运行 MicroPython 的平台。 (平台) 
 
 For OS/RTOS ports, this is usually an identifier of the OS, e.g. ``"linux"``.
 For baremetal ports it is an identifier of a board, e.g. ``"pyboard"`` for 

--- a/lang/zh-cn/typeshed/stdlib/time.pyi
+++ b/lang/zh-cn/typeshed/stdlib/time.pyi
@@ -6,7 +6,7 @@ def sleep(seconds: Union[int, float]) -> None:
 
 Example: ``time.sleep(1)``
 
-:param seconds: (seconds) 休眠的秒数。
+:param seconds: 休眠的秒数。
 使用浮点数休眠小数秒数。"""
     ...
 
@@ -52,7 +52,7 @@ value delta ticks before or after it, following modular-arithmetic
 definition of tick values.
 
 :param ticks: (刻度) 一个刻度值
-:param delta: (delta) 整数偏移量
+:param delta: 整数偏移量
 
 Example::
 

--- a/lang/zh-tw/typeshed/stdlib/gc.pyi
+++ b/lang/zh-tw/typeshed/stdlib/gc.pyi
@@ -1,18 +1,18 @@
-"""Control the garbage collector (gc)"""
+"""Control the garbage collector"""
 from typing import overload
 
 def enable() -> None:
-    """啟用自動記憶體管理。 (enable)"""
+    """啟用自動記憶體管理。"""
     ...
 
 def disable() -> None:
-    """停用自動記憶體管理。 (disable)
+    """停用自動記憶體管理。
 
 Heap memory can still be allocated,
 and garbage collection can still be initiated manually using ``gc.collect``."""
 
 def collect() -> None:
-    """執行自動記憶體管理 (collect)"""
+    """執行自動記憶體管理"""
     ...
 
 def mem_alloc() -> int:
@@ -24,7 +24,7 @@ This function is MicroPython extension."""
     ...
 
 def mem_free() -> int:
-    """獲取可用堆積 RAM 的位元組，如果此數量未知，則為 -1。 (mem free)
+    """獲取可用堆積 RAM 的位元組，如果此數量未知，則為 -1。
 
 :return: The number of bytes free.
 
@@ -33,7 +33,7 @@ This function is MicroPython extension."""
 
 @overload
 def threshold() -> int:
-    """查詢額外的GC分配閾值。 (threshold)
+    """查詢額外的GC分配閾值。
 
 :return: The GC allocation threshold.
 
@@ -44,7 +44,7 @@ implementations, its signature and semantics are different."""
 
 @overload
 def threshold(amount: int) -> None:
-    """設定其他 GC 分配閾值。 (threshold)
+    """設定其他 GC 分配閾值。
 
 Normally, a collection is triggered only when a new allocation
 cannot be satisfied, i.e. on an  out-of-memory (OOM) condition.
@@ -64,5 +64,5 @@ This function is a MicroPython extension. CPython has a similar
 function - ``set_threshold()``, but due to different GC
 implementations, its signature and semantics are different.
 
-:param amount: (amount) 應該觸發自動記憶體管理之後的位元組。"""
+:param amount: 應該觸發自動記憶體管理之後的位元組。"""
     ...

--- a/lang/zh-tw/typeshed/stdlib/log.pyi
+++ b/lang/zh-tw/typeshed/stdlib/log.pyi
@@ -1,18 +1,18 @@
-"""將資料記錄到您的 micro:bit V2。 (log)"""
+"""將資料記錄到您的 micro:bit V2。"""
 from typing import Literal, Optional, Union, overload
 MILLISECONDS = 1
-"""毫秒時間郵戳格式。 (milliseconds)"""
+"""毫秒時間郵戳格式。"""
 SECONDS = 10
-"""秒時間郵戳格式。 (seconds)"""
+"""秒時間郵戳格式。"""
 MINUTES = 600
-"""分鐘時間郵戳格式 (minutes)"""
+"""分鐘時間郵戳格式"""
 HOURS = 36000
-"""小時時間郵戳格式。 (hours)"""
+"""小時時間郵戳格式。"""
 DAYS = 864000
-"""天時間郵戳格式。 (days)"""
+"""天時間郵戳格式。"""
 
 def set_labels(*args: str, timestamp: Optional[Literal[1, 10, 36000, 864000]]=SECONDS) -> None:
-    """設定記錄檔案標頭。 (set labels)
+    """設定記錄檔案標頭。
 
 Example: ``log.set_labels('x', 'y', 'z', timestamp=log.MINUTES)``
 
@@ -24,14 +24,14 @@ labels set up by this function call to the last headers declared in the
 file. If the headers are different it will add a new header entry at the
 end of the file.
 
-:param *args: (*args) 各記錄標頭的位置引數。
+:param *args: 各記錄標頭的位置引數。
 :param timestamp: (時間戳記) 將自動新增為每列第一行的時間郵戳單元。
 將此引數設定為 ``None``，則會停用時間郵戳。傳遞此模組定義的 ``log.MILLISECONDS``、``log.SECONDS``、``log.MINUTES``、``log.HOURS`` 或 ``log.DAYS`` 值。無效值將擲回例外狀況。"""
     ...
 
 @overload
 def add(log_data: Optional[dict[str, Union[str, int, float]]]) -> None:
-    """透過傳遞包含標頭和數值的字典，將資料列新增至紀錄中。 (add)
+    """透過傳遞包含標頭和數值的字典，將資料列新增至紀錄中。
 
 Example: ``log.add({ 'temp': temperature() })``
 
@@ -44,12 +44,12 @@ entry to be added to the log with the extra label.
 Labels previously specified and not present in this function call will be
 skipped with an empty value in the log row.
 
-:param log_data: (log data) 若要記錄為字典的資料，每個標頭都有一個金鑰。"""
+:param log_data: 若要記錄為字典的資料，每個標頭都有一個金鑰。"""
     ...
 
 @overload
 def add(**kwargs: Union[str, int, float]) -> None:
-    """使用關鍵字引數將資料行新增至紀錄中。 (add)
+    """使用關鍵字引數將資料行新增至紀錄中。
 
 Example: ``log.add(temp=temperature())``
 
@@ -64,23 +64,23 @@ skipped with an empty value in the log row."""
     ...
 
 def delete(full=False):
-    """刪除紀錄的內容，包括標題。 (delete)
+    """刪除紀錄的內容，包括標題。
 
 Example: ``log.delete()``
 
 To add the log headers the ``set_labels`` function has to be called again
 after this.
 
-:param full: (full) 選擇從快取記憶體中刪除資料的「完整」抹除格式。
+:param full: 選擇從快取記憶體中刪除資料的「完整」抹除格式。
 如果設定為 ``False`` 則會使用「快速」方法，該方法會使資料無效，而不是執行較慢的完全抹除。"""
     ...
 
 def set_mirroring(serial: bool):
-    """將資料記錄活動鏡像到序列輸出。 (set mirroring)
+    """將資料記錄活動鏡像到序列輸出。
 
 Example: ``log.set_mirroring(True)``
 
 Mirroring is disabled by default.
 
-:param serial: (serial) 傳遞 ``True`` 將資料記錄活動鏡像到序列輸出，``False`` 則停用鏡像。"""
+:param serial: 傳遞 ``True`` 將資料記錄活動鏡像到序列輸出，``False`` 則停用鏡像。"""
     ...

--- a/lang/zh-tw/typeshed/stdlib/machine.pyi
+++ b/lang/zh-tw/typeshed/stdlib/machine.pyi
@@ -1,9 +1,9 @@
-"""低等實用工具程序。 (machine)"""
+"""低等實用工具程序。"""
 from typing import Any
 from .microbit import MicroBitDigitalPin
 
 def unique_id() -> bytes:
-    """取得具有板的唯一識別碼之位元組字串。 (unique id)
+    """取得具有板的唯一識別碼之位元組字串。
 
 Example: ``machine.unique_id()``
 
@@ -11,7 +11,7 @@ Example: ``machine.unique_id()``
     ...
 
 def reset() -> None:
-    """以類似於按下外部 RESET 按鍵的方式重置裝置。 (reset)
+    """以類似於按下外部 RESET 按鍵的方式重置裝置。
 
 Example: ``machine.reset()``"""
     ...
@@ -40,11 +40,11 @@ def enable_irq(state: Any) -> None:
 
 Example: ``machine.enable_irq(interrupt_state)``
 
-:param state: (state) 從最近一次叫用 ``disable_irq`` 函式傳回的值。"""
+:param state: 從最近一次叫用 ``disable_irq`` 函式傳回的值。"""
     ...
 
 def time_pulse_us(pin: MicroBitDigitalPin, pulse_level: int, timeout_us: int=1000000) -> int:
-    """計時引腳上的脈衝。 (time pulse us)
+    """計時引腳上的脈衝。
 
 Example: ``time_pulse_us(pin0, 1)``
 
@@ -54,32 +54,31 @@ function first waits until the pin input becomes equal to
 ``pulse_level``. If the pin is already equal to ``pulse_level`` then timing
 starts straight away.
 
-:param pin: (引腳
-) 要使用的引腳
-:param pulse_level: (pulse level) 0 到計時低脈衝或 1 到計時高脈衝
-:param timeout_us: (timeout us) 微秒超時
+:param pin: (引腳) 要使用的引腳
+:param pulse_level: 0 到計時低脈衝或 1 到計時高脈衝
+:param timeout_us: 微秒超時
 :return: The duration of the pulse in microseconds, or -1 for a timeout waiting for the level to match ``pulse_level``, or -2 on timeout waiting for the pulse to end"""
     ...
 
 class mem:
-    """``mem8``、``mem16`` 和 ``mem32`` 記憶體檢視的類別。 (mem)"""
+    """``mem8``、``mem16`` 和 ``mem32`` 記憶體檢視的類別。"""
 
     def __getitem__(self, address: int) -> int:
-        """從記憶體中存取一個值。 (getitem)
+        """從記憶體中存取一個值。
 
-:param address: (address) 記憶體位址。
+:param address: 記憶體位址。
 :return: The value at that address as an integer."""
         ...
 
     def __setitem__(self, address: int, value: int) -> None:
-        """在指定位址設定一個值。 (setitem)
+        """在指定位址設定一個值。
 
-:param address: (address) 記憶體位址。
-:param value: (value) 要設定的整數值。"""
+:param address: 記憶體位址。
+:param value: 要設定的整數值。"""
         ...
 mem8: mem
-"""8 位元 (位元組) 的記憶體檢視。 (mem8)"""
+"""8 位元 (位元組) 的記憶體檢視。"""
 mem16: mem
-"""16 位元的記憶體檢視。 (mem16)"""
+"""16 位元的記憶體檢視。"""
 mem32: mem
-"""32 位元的記憶體檢視。 (mem32)"""
+"""32 位元的記憶體檢視。"""

--- a/lang/zh-tw/typeshed/stdlib/math.pyi
+++ b/lang/zh-tw/typeshed/stdlib/math.pyi
@@ -1,68 +1,68 @@
-"""數學函式。 (math)"""
+"""數學函式。"""
 from typing import Tuple
 
 def acos(x: float) -> float:
-    """計算反餘弦。 (acos)
+    """計算反餘弦。
 
 Example: ``math.acos(1)``
 
-:param x: (x) 一個數字
+:param x: 一個數字
 :return: The inverse cosine of ``x``"""
     ...
 
 def asin(x: float) -> float:
-    """計算反正弦值。 (asin)
+    """計算反正弦值。
 
 Example: ``math.asin(0)``
 
-:param x: (x) 一個數字
+:param x: 一個數字
 :return: The inverse sine of ``x``"""
     ...
 
 def atan(x: float) -> float:
-    """計算反正切。 (atan)
+    """計算反正切。
 
 Example: ``math.atan(0)``
 
-:param x: (x) 一個數字
+:param x: 一個數字
 :return: The inverse tangent of ``x``"""
     ...
 
 def atan2(y: float, x: float) -> float:
-    """計算 ``y/x`` 的反正切主值。 (atan2)
+    """計算 ``y/x`` 的反正切主值。
 
 Example: ``math.atan2(0, -1)``
 
-:param y: (x) 一個數字
-:param x: (x) 一個數字
+:param y: 一個數字
+:param x: 一個數字
 :return: The principal value of the inverse tangent of ``y/x``"""
     ...
 
 def ceil(x: float) -> float:
-    """將數字向正無限大捨入。 (ceil)
+    """將數字向正無限大捨入。
 
 Example: ``math.ceil(0.1)``
 
-:param x: (x) 一個數字
+:param x: 一個數字
 :return: ``x`` rounded towards positive infinity."""
     ...
 
 def copysign(x: float, y: float) -> float:
-    """用 ``y`` 的符號計算 ``x``。 (copysign)
+    """用 ``y`` 的符號計算 ``x``。
 
 Example: ``math.copysign(1, -1)``
 
-:param x: (x) 一個數字
-:param y: (y) 傳回值的符號來源
+:param x: 一個數字
+:param y: 傳回值的符號來源
 :return: ``x`` with the sign of ``y``"""
     ...
 
 def cos(x: float) -> float:
-    """計算 ``x`` 的餘弦。 (cos)
+    """計算 ``x`` 的餘弦。
 
 Example: ``math.cos(0)``
 
-:param x: (x) 一個數字
+:param x: 一個數字
 :return: The cosine of ``x``"""
     ...
 
@@ -71,7 +71,7 @@ def degrees(x: float) -> float:
 
 Example: ``math.degrees(2 * math.pi)``
 
-:param x: (x) 單位為弧度的數值
+:param x: 單位為弧度的數值
 :return: The value converted to degrees"""
     ...
 
@@ -80,39 +80,39 @@ def exp(x: float) -> float:
 
 Example: ``math.exp(1)``
 
-:param x: (x) 一個數字
+:param x: 一個數字
 :return: The exponential of ``x``."""
     ...
 
 def fabs(x: float) -> float:
-    """傳回 ``x`` 的絕對值。 (fabs)
+    """傳回 ``x`` 的絕對值。
 
 Example: ``math.fabs(-0.1)``
 
-:param x: (x) 一個數字
+:param x: 一個數字
 :return: The absolute value of ``x``"""
     ...
 
 def floor(x: float) -> int:
-    """將數字向負無限大捨入。 (floor)
+    """將數字向負無限大捨入。
 
 Example: ``math.floor(0.9)``
 
-:param x: (x) 一個數字
+:param x: 一個數字
 :return: ``x`` rounded towards negative infinity."""
     ...
 
 def fmod(x: float, y: float) -> float:
-    """計算 ``x/y`` 的餘數。 (fmod)
+    """計算 ``x/y`` 的餘數。
 
 Example: ``math.fmod(10, 3)``
 
-:param x: (x) 分子
-:param y: (y) 分母"""
+:param x: 分子
+:param y: 分母"""
     ...
 
 def frexp(x: float) -> Tuple[float, int]:
-    """將一個浮點數分解為其尾數和指數。 (frexp)
+    """將一個浮點數分解為其尾數和指數。
 
 Example: ``mantissa, exponent = math.frexp(2)``
 
@@ -120,49 +120,49 @@ The returned value is the tuple ``(m, e)`` such that ``x == m * 2**e``
 exactly.  If ``x == 0`` then the function returns ``(0.0, 0)``, otherwise
 the relation ``0.5 <= abs(m) < 1`` holds.
 
-:param x: (x) 一個浮點數
+:param x: 一個浮點數
 :return: A tuple of length two containing its mantissa then exponent"""
     ...
 
 def isfinite(x: float) -> bool:
-    """檢查值是否是有限的。 (isfinite)
+    """檢查值是否是有限的。
 
 Example: ``math.isfinite(float('inf'))``
 
-:param x: (x) 一個數字。
+:param x: 一個數字。
 :return: ``True`` if ``x`` is finite, ``False`` otherwise."""
     ...
 
 def isinf(x: float) -> bool:
-    """檢查值是否是無限的。 (isinf)
+    """檢查值是否是無限的。
 
 Example: ``math.isinf(float('-inf'))``
 
-:param x: (x) 一個數字。
+:param x: 一個數字。
 :return: ``True`` if ``x`` is infinite, ``False`` otherwise."""
     ...
 
 def isnan(x: float) -> bool:
-    """檢查值是否不是數字 (NaN)。 (isnan)
+    """檢查值是否不是數字 (NaN)。
 
 Example: ``math.isnan(float('nan'))``
 
-:param x: (x) 一個數字
+:param x: 一個數字
 :return: ``True`` if ``x`` is not-a-number (NaN), ``False`` otherwise."""
     ...
 
 def ldexp(x: float, exp: int) -> float:
-    """計算 ``x * (2**exp)``。 (ldexp)
+    """計算 ``x * (2**exp)``。
 
 Example: ``math.ldexp(0.5, 2)``
 
-:param x: (x) 一個數字
+:param x: 一個數字
 :param exp: (指數) 整數指數
 :return: ``x * (2**exp)``"""
     ...
 
 def log(x: float, base: float=e) -> float:
-    """計算指定底數 ``x`` 的對數 (預設為自然對數)。 (log)
+    """計算指定底數 ``x`` 的對數 (預設為自然對數)。
 
 Example: ``math.log(math.e)``
 
@@ -170,77 +170,77 @@ With one argument, return the natural logarithm of x (to base e).
 
 With two arguments, return the logarithm of x to the given base, calculated as ``log(x)/log(base)``.
 
-:param x: (x) 一個數字
-:param base: (base) 要使用的底數
+:param x: 一個數字
+:param base: 要使用的底數
 :return: The natural logarithm of ``x``"""
     ...
 
 def modf(x: float) -> Tuple[float, float]:
-    """計算 ``x`` 的小數部分和整數部分。 (modf)
+    """計算 ``x`` 的小數部分和整數部分。
 
 Example: ``fractional, integral = math.modf(1.5)``
 
-:param x: (x) 一個數字
+:param x: 一個數字
 :return: A tuple of two floats representing the fractional then integral parts of ``x``.
 
 Both the fractional and integral values have the same sign as ``x``."""
     ...
 
 def pow(x: float, y: float) -> float:
-    """傳回 ``x`` 的 ``y`` 次方。 (pow)
+    """傳回 ``x`` 的 ``y`` 次方。
 
 Example: ``math.pow(4, 0.5)``
 
-:param x: (x) 一個數字
-:param y: (y) 指數
+:param x: 一個數字
+:param y: 指數
 :return: ``x`` to the power of ``y``"""
     ...
 
 def radians(x: float) -> float:
-    """將角度轉換為弧度。 (radians)
+    """將角度轉換為弧度。
 
 Example: ``math.radians(360)``
 
-:param x: (x) 以角度為單位的值
+:param x: 以角度為單位的值
 :return: The value converted to radians"""
     ...
 
 def sin(x: float) -> float:
-    """計算 ``x`` 的正弦。 (sin)
+    """計算 ``x`` 的正弦。
 
 Example: ``math.sin(math.pi/2)``
 
-:param x: (x) 一個數字
+:param x: 一個數字
 :return: The sine of ``x``"""
     ...
 
 def sqrt(x: float) -> float:
-    """計算 ``x`` 的平方根。 (sqrt)
+    """計算 ``x`` 的平方根。
 
 Example: ``math.sqrt(4)``
 
-:param x: (x) 一個數字
+:param x: 一個數字
 :return: The square root of ``x``"""
     ...
 
 def tan(x: float) -> float:
-    """計算 ``x`` 的正切。 (tan)
+    """計算 ``x`` 的正切。
 
 Example: ``math.tan(0)``
 
-:param x: (x) 一個數字
+:param x: 一個數字
 :return: The tangent of ``x``."""
     ...
 
 def trunc(x: float) -> int:
-    """將數字向 0 舍入。 (trunc)
+    """將數字向 0 舍入。
 
 Example: ``math.trunc(-0.9)``
 
-:param x: (x) 一個數字
+:param x: 一個數字
 :return: ``x`` rounded towards zero."""
     ...
 e: float
-"""自然對數的底數 (e)"""
+"""自然對數的底數"""
 pi: float
-"""圓的周長與其直徑的比率 (pi)"""
+"""圓的周長與其直徑的比率"""

--- a/lang/zh-tw/typeshed/stdlib/microbit/__init__.pyi
+++ b/lang/zh-tw/typeshed/stdlib/microbit/__init__.pyi
@@ -1,4 +1,4 @@
-"""引腳、影像、聲音、溫度和音量。 (microbit)"""
+"""引腳、影像、聲音、溫度和音量。"""
 from _typeshed import ReadableBuffer
 from typing import Any, Callable, List, Optional, overload
 from . import accelerometer as accelerometer
@@ -12,7 +12,7 @@ from . import uart as uart
 from . import audio as audio
 
 def run_every(callback: Optional[Callable[[], None]]=None, days: int=0, h: int=0, min: int=0, s: int=0, ms: int=0) -> Callable[[Callable[[], None]], Callable[[], None]]:
-    """安排一個函式以指定的時間間隔叫用 **僅限 V2**。 (run every)
+    """安排一個函式以指定的時間間隔叫用 **僅限 V2**。
 
 Example: ``run_every(my_logging, min=5)``
 
@@ -28,31 +28,31 @@ or used as a decorator::
 
 Arguments with different time units are additive.
 
-:param callback: (callback) 要叫用的回呼。 做為裝飾項目時省略。
-:param days: (days) 以天數為單位的間隔。
-:param h: (h) 以小時為單位的間隔。
-:param min: (min) 以分鐘為單位的間隔。
-:param s: (s) 以秒為單位的間隔。
-:param ms: (ms) 以毫秒為單位的間隔。"""
+:param callback: 要叫用的回呼。 做為裝飾項目時省略。
+:param days: 以天數為單位的間隔。
+:param h: 以小時為單位的間隔。
+:param min: 以分鐘為單位的間隔。
+:param s: 以秒為單位的間隔。
+:param ms: 以毫秒為單位的間隔。"""
 
 def panic(n: int) -> None:
-    """進入緊急模式。 (panic)
+    """進入緊急模式。
 
 Example: ``panic(127)``
 
-:param n: (n) 任意整數 <= 255 表示狀態。
+:param n: 任意整數 <= 255 表示狀態。
 
 Requires restart."""
 
 def reset() -> None:
-    """重啟板子。 (reset)"""
+    """重啟板子。"""
 
 def sleep(n: float) -> None:
-    """等待 ``n`` 毫秒。 (sleep)
+    """等待 ``n`` 毫秒。
 
 Example: ``sleep(1000)``
 
-:param n: (n) 要等待的毫秒數。
+:param n: 要等待的毫秒數。
 
 One second is 1000 milliseconds, so::
 
@@ -61,7 +61,7 @@ One second is 1000 milliseconds, so::
 will pause the execution for one second."""
 
 def running_time() -> int:
-    """取得板子的執行時間。 (running time)
+    """取得板子的執行時間。
 
 :return: The number of milliseconds since the board was switched on or restarted."""
 
@@ -69,11 +69,11 @@ def temperature() -> int:
     """取得 micro:bit 的溫度 (以攝氏為單位)。 (溫度)"""
 
 def set_volume(v: int) -> None:
-    """設定音量。 (set volume)
+    """設定音量。
 
 Example: ``set_volume(127)``
 
-:param v: (v) 介於 0 (低) 和 255 (高) 之間的值。
+:param v: 介於 0 (低) 和 255 (高) 之間的值。
 
 Out of range values will be clamped to 0 or 255.
 
@@ -81,16 +81,16 @@ Out of range values will be clamped to 0 or 255.
     ...
 
 class Button:
-    """按鈕 ``button_a`` 和 ``button_b`` 的類別。 (button)"""
+    """按鈕 ``button_a`` 和 ``button_b`` 的類別。"""
 
     def is_pressed(self) -> bool:
-        """檢查按鈕是否按下。 (is pressed)
+        """檢查按鈕是否按下。
 
 :return: ``True`` if the specified button ``button`` is pressed, and ``False`` otherwise."""
         ...
 
     def was_pressed(self) -> bool:
-        """檢查自裝置啟動或上次呼叫此方法以來是否按下該按鈕。 (was pressed)
+        """檢查自裝置啟動或上次呼叫此方法以來是否按下該按鈕。
 
 Calling this method will clear the press state so
 that the button must be pressed again before this method will return
@@ -100,17 +100,17 @@ that the button must be pressed again before this method will return
         ...
 
     def get_presses(self) -> int:
-        """取得按下按鈕的執行總數，並在傳回前，將此總數重設為零。 (get presses)
+        """取得按下按鈕的執行總數，並在傳回前，將此總數重設為零。
 
 :return: The number of presses since the device started or the last time this method was called"""
         ...
 button_a: Button
-"""左鍵 ``Button`` 物件。 (button a)"""
+"""左鍵 ``Button`` 物件。"""
 button_b: Button
-"""右鍵 ``Button`` 物件。 (button b)"""
+"""右鍵 ``Button`` 物件。"""
 
 class MicroBitDigitalPin:
-    """數位引腳。 (microbitdigitalpin)
+    """數位引腳。
 
 Some pins support analog and touch features using the ``MicroBitAnalogDigitalPin`` and ``MicroBitTouchPin`` subclasses."""
     NO_PULL: int
@@ -118,7 +118,7 @@ Some pins support analog and touch features using the ``MicroBitAnalogDigitalPin
     PULL_DOWN: int
 
     def read_digital(self) -> int:
-        """取得引腳的數位值。 (read digital)
+        """取得引腳的數位值。
 
 Example: ``value = pin0.read_digital()``
 
@@ -126,23 +126,23 @@ Example: ``value = pin0.read_digital()``
         ...
 
     def write_digital(self, value: int) -> None:
-        """設定引腳的數位值。 (write digital)
+        """設定引腳的數位值。
 
 Example: ``pin0.write_digital(1)``
 
-:param value: (value) 1 將引腳設為高電平，或 0 將引腳設為低電平"""
+:param value: 1 將引腳設為高電平，或 0 將引腳設為低電平"""
         ...
 
     def set_pull(self, value: int) -> None:
-        """將提取狀態設為三個可能值之一：``PULL_UP``、``PULL_DOWN`` 或 ``NO_PULL``。 (set pull)
+        """將提取狀態設為三個可能值之一：``PULL_UP``、``PULL_DOWN`` 或 ``NO_PULL``。
 
 Example: ``pin0.set_pull(pin0.PULL_UP)``
 
-:param value: (value) 相關引腳的提取狀態，例如 ``pin0.PULL_UP``。"""
+:param value: 相關引腳的提取狀態，例如 ``pin0.PULL_UP``。"""
         ...
 
     def get_pull(self) -> int:
-        """取得引腳上的提取狀態。 (get pull)
+        """取得引腳上的提取狀態。
 
 Example: ``pin0.get_pull()``
 
@@ -153,7 +153,7 @@ when a pin mode requires it."""
         ...
 
     def get_mode(self) -> str:
-        """傳回引腳模式。 (get mode)
+        """傳回引腳模式。
 
 Example: ``pin0.get_mode()``
 
@@ -165,43 +165,43 @@ changes.
         ...
 
     def write_analog(self, value: int) -> None:
-        """在引腳上輸出 PWM 訊號，工作週期與 ``value`` 成正比。 (write analog)
+        """在引腳上輸出 PWM 訊號，工作週期與 ``value`` 成正比。
 
 Example: ``pin0.write_analog(254)``
 
-:param value: (value) 介於 0 (0% 工作週期) 和 1023 (100% 工作週期) 之間的整數或浮點數。"""
+:param value: 介於 0 (0% 工作週期) 和 1023 (100% 工作週期) 之間的整數或浮點數。"""
 
     def set_analog_period(self, period: int) -> None:
-        """將輸出的 PWM 訊號週期設為 ``period`` (以毫秒為單位)。 (set analog period)
+        """將輸出的 PWM 訊號週期設為 ``period`` (以毫秒為單位)。
 
 Example: ``pin0.set_analog_period(10)``
 
-:param period: (period) 以毫秒為單位的週期，最小有效值為 1ms。"""
+:param period: 以毫秒為單位的週期，最小有效值為 1ms。"""
 
     def set_analog_period_microseconds(self, period: int) -> None:
-        """將輸出的 PWM 訊號週期設為 ``period`` (以微秒為單位)。 (set analog period microseconds)
+        """將輸出的 PWM 訊號週期設為 ``period`` (以微秒為單位)。
 
 Example: ``pin0.set_analog_period_microseconds(512)``
 
-:param period: (period) 以微秒為單位的週期，最小有效值為 256µs。"""
+:param period: 以微秒為單位的週期，最小有效值為 256µs。"""
 
 class MicroBitAnalogDigitalPin(MicroBitDigitalPin):
-    """具有類比和數位功能的引腳。 (microbitanalogdigitalpin)"""
+    """具有類比和數位功能的引腳。"""
 
     def read_analog(self) -> int:
-        """讀取施加到引腳的電壓。 (read analog)
+        """讀取施加到引腳的電壓。
 
 Example: ``pin0.read_analog()``
 
 :return: An integer between 0 (meaning 0V) and 1023 (meaning 3.3V)."""
 
 class MicroBitTouchPin(MicroBitAnalogDigitalPin):
-    """具有類比、數位和觸控功能的引腳。 (microbittouchpin)"""
+    """具有類比、數位和觸控功能的引腳。"""
     CAPACITIVE: int
     RESISTIVE: int
 
     def is_touched(self) -> bool:
-        """檢查引腳是否受觸控。 (is touched)
+        """檢查引腳是否受觸控。
 
 Example: ``pin0.is_touched()``
 
@@ -224,201 +224,201 @@ does not require you to make a ground connection as part of a circuit.
         ...
 
     def set_touch_mode(self, value: int) -> None:
-        """設定引腳的觸控模式。 (set touch mode)
+        """設定引腳的觸控模式。
 
 Example: ``pin0.set_touch_mode(pin0.CAPACITIVE)``
 
 The default touch mode for the pins on the edge connector is
 ``resistive``. The default for the logo pin **V2** is ``capacitive``.
 
-:param value: (value) 相關引腳的 ``CAPACITIVE`` 或 ``RESISTIVE``。"""
+:param value: 相關引腳的 ``CAPACITIVE`` 或 ``RESISTIVE``。"""
         ...
 pin0: MicroBitTouchPin
-"""具有數位、類比和觸控功能的引腳。 (pin0)"""
+"""具有數位、類比和觸控功能的引腳。"""
 pin1: MicroBitTouchPin
-"""具有數位、類比和觸控功能的引腳。 (pin1)"""
+"""具有數位、類比和觸控功能的引腳。"""
 pin2: MicroBitTouchPin
-"""具有數位、類比和觸控功能的引腳。 (pin2)"""
+"""具有數位、類比和觸控功能的引腳。"""
 pin3: MicroBitAnalogDigitalPin
-"""具有數位和類比功能的引腳。 (pin3)"""
+"""具有數位和類比功能的引腳。"""
 pin4: MicroBitAnalogDigitalPin
-"""具有數位和類比功能的引腳。 (pin4)"""
+"""具有數位和類比功能的引腳。"""
 pin5: MicroBitDigitalPin
-"""具有數位功能的引腳。 (pin5)"""
+"""具有數位功能的引腳。"""
 pin6: MicroBitDigitalPin
-"""具有數位功能的引腳。 (pin6)"""
+"""具有數位功能的引腳。"""
 pin7: MicroBitDigitalPin
-"""具有數位功能的引腳。 (pin7)"""
+"""具有數位功能的引腳。"""
 pin8: MicroBitDigitalPin
-"""具有數位功能的引腳。 (pin8)"""
+"""具有數位功能的引腳。"""
 pin9: MicroBitDigitalPin
-"""具有數位功能的引腳。 (pin9)"""
+"""具有數位功能的引腳。"""
 pin10: MicroBitAnalogDigitalPin
-"""具有數位和類比功能的引腳。 (pin10)"""
+"""具有數位和類比功能的引腳。"""
 pin11: MicroBitDigitalPin
-"""具有數位功能的引腳。 (pin11)"""
+"""具有數位功能的引腳。"""
 pin12: MicroBitDigitalPin
-"""具有數位功能的引腳。 (pin12)"""
+"""具有數位功能的引腳。"""
 pin13: MicroBitDigitalPin
-"""具有數位功能的引腳。 (pin13)"""
+"""具有數位功能的引腳。"""
 pin14: MicroBitDigitalPin
-"""具有數位功能的引腳。 (pin14)"""
+"""具有數位功能的引腳。"""
 pin15: MicroBitDigitalPin
-"""具有數位功能的引腳。 (pin15)"""
+"""具有數位功能的引腳。"""
 pin16: MicroBitDigitalPin
-"""具有數位功能的引腳。 (pin16)"""
+"""具有數位功能的引腳。"""
 pin19: MicroBitDigitalPin
-"""具有數位功能的引腳。 (pin19)"""
+"""具有數位功能的引腳。"""
 pin20: MicroBitDigitalPin
-"""具有數位功能的引腳。 (pin20)"""
+"""具有數位功能的引腳。"""
 pin_logo: MicroBitTouchPin
-"""micro:bit 正面的觸控感應標誌引腳，預設為電容觸控模式。 (pin logo)"""
+"""micro:bit 正面的觸控感應標誌引腳，預設為電容觸控模式。"""
 pin_speaker: MicroBitAnalogDigitalPin
-"""用於定址 micro:bit 揚聲器的引腳。 (pin speaker)
+"""用於定址 micro:bit 揚聲器的引腳。
 
 This API is intended only for use in Pulse-Width Modulation pin operations e.g. pin_speaker.write_analog(128).
 """
 
 class Image:
-    """要在 micro:bit LED 顯示器上顯示的圖片。 (image)
+    """要在 micro:bit LED 顯示器上顯示的圖片。
 
 Given an image object it's possible to display it via the ``display`` API::
 
     display.show(Image.HAPPY)"""
     HEART: Image
-    """愛心圖片。 (heart)"""
+    """愛心圖片。"""
     HEART_SMALL: Image
-    """小愛心影像。 (heart small)"""
+    """小愛心影像。"""
     HAPPY: Image
-    """開心的臉圖片。 (happy)"""
+    """開心的臉圖片。"""
     SMILE: Image
-    """微笑的臉圖片。 (smile)"""
+    """微笑的臉圖片。"""
     SAD: Image
-    """傷心的臉圖片。 (sad)"""
+    """傷心的臉圖片。"""
     CONFUSED: Image
-    """困惑的臉圖片。 (confused)"""
+    """困惑的臉圖片。"""
     ANGRY: Image
-    """生氣的臉圖片。 (angry)"""
+    """生氣的臉圖片。"""
     ASLEEP: Image
-    """瞌睡的臉圖片。 (asleep)"""
+    """瞌睡的臉圖片。"""
     SURPRISED: Image
-    """驚訝的臉圖片。 (surprised)"""
+    """驚訝的臉圖片。"""
     SILLY: Image
-    """鬼臉圖片。 (silly)"""
+    """鬼臉圖片。"""
     FABULOUS: Image
-    """戴太陽眼鏡的臉圖片。 (fabulous)"""
+    """戴太陽眼鏡的臉圖片。"""
     MEH: Image
-    """冷漠的臉圖片。 (meh)"""
+    """冷漠的臉圖片。"""
     YES: Image
-    """勾號圖片。 (yes)"""
+    """勾號圖片。"""
     NO: Image
-    """叉號圖片。 (no)"""
+    """叉號圖片。"""
     CLOCK12: Image
-    """指針指向 12 點鐘的圖片。 (clock12)"""
+    """指針指向 12 點鐘的圖片。"""
     CLOCK11: Image
-    """指針指向 11 點鐘的圖片。 (clock11)"""
+    """指針指向 11 點鐘的圖片。"""
     CLOCK10: Image
-    """指針指向 10 點鐘的圖片。 (clock10)"""
+    """指針指向 10 點鐘的圖片。"""
     CLOCK9: Image
-    """指針指向 9 點鐘的圖片。 (clock9)"""
+    """指針指向 9 點鐘的圖片。"""
     CLOCK8: Image
-    """指針指向 8 點鐘的圖片。 (clock8)"""
+    """指針指向 8 點鐘的圖片。"""
     CLOCK7: Image
-    """指針指向 7 點鐘的圖片。 (clock7)"""
+    """指針指向 7 點鐘的圖片。"""
     CLOCK6: Image
-    """指針指向 6 點鐘的圖片。 (clock6)"""
+    """指針指向 6 點鐘的圖片。"""
     CLOCK5: Image
-    """指針指向 5 點鐘的圖片。 (clock5)"""
+    """指針指向 5 點鐘的圖片。"""
     CLOCK4: Image
-    """指針指向 4 點鐘的圖片。 (clock4)"""
+    """指針指向 4 點鐘的圖片。"""
     CLOCK3: Image
-    """指針指向 3 點鐘的圖片。 (clock3)"""
+    """指針指向 3 點鐘的圖片。"""
     CLOCK2: Image
-    """指針指向 2 點鐘的圖片。 (clock2)"""
+    """指針指向 2 點鐘的圖片。"""
     CLOCK1: Image
-    """指針指向 1 點鐘的圖片。 (clock1)"""
+    """指針指向 1 點鐘的圖片。"""
     ARROW_N: Image
-    """指向北方箭頭的圖片。 (arrow n)"""
+    """指向北方箭頭的圖片。"""
     ARROW_NE: Image
-    """指向東北箭頭的圖片。 (arrow ne)"""
+    """指向東北箭頭的圖片。"""
     ARROW_E: Image
-    """指向東方箭頭的圖片。 (arrow e)"""
+    """指向東方箭頭的圖片。"""
     ARROW_SE: Image
-    """指向東南箭頭的圖片。 (arrow se)"""
+    """指向東南箭頭的圖片。"""
     ARROW_S: Image
-    """指向南方箭頭的圖片。 (arrow s)"""
+    """指向南方箭頭的圖片。"""
     ARROW_SW: Image
-    """指向西南箭頭的圖片。 (arrow sw)"""
+    """指向西南箭頭的圖片。"""
     ARROW_W: Image
-    """指向西方箭頭的圖片。 (arrow w)"""
+    """指向西方箭頭的圖片。"""
     ARROW_NW: Image
-    """指向西北箭頭的圖片。 (arrow nw)"""
+    """指向西北箭頭的圖片。"""
     TRIANGLE: Image
-    """朝上三角形的圖片。 (triangle)"""
+    """朝上三角形的圖片。"""
     TRIANGLE_LEFT: Image
-    """左角三角形的圖片。 (triangle left)"""
+    """左角三角形的圖片。"""
     CHESSBOARD: Image
-    """以棋盤圖案交錯發亮的 LED 燈。 (chessboard)"""
+    """以棋盤圖案交錯發亮的 LED 燈。"""
     DIAMOND: Image
-    """鑽石圖片。 (diamond)"""
+    """鑽石圖片。"""
     DIAMOND_SMALL: Image
-    """小鑽石圖片。 (diamond small)"""
+    """小鑽石圖片。"""
     SQUARE: Image
-    """正方形圖片。 (square)"""
+    """正方形圖片。"""
     SQUARE_SMALL: Image
-    """小正方形圖片。 (square small)"""
+    """小正方形圖片。"""
     RABBIT: Image
-    """兔子圖片。 (rabbit)"""
+    """兔子圖片。"""
     COW: Image
-    """乳牛圖片。 (cow)"""
+    """乳牛圖片。"""
     MUSIC_CROTCHET: Image
-    """四分音符圖片。 (music crotchet)"""
+    """四分音符圖片。"""
     MUSIC_QUAVER: Image
-    """八分音符圖片。 (music quaver)"""
+    """八分音符圖片。"""
     MUSIC_QUAVERS: Image
-    """一組八分音符圖片。 (music quavers)"""
+    """一組八分音符圖片。"""
     PITCHFORK: Image
-    """乾草叉圖片。 (pitchfork)"""
+    """乾草叉圖片。"""
     XMAS: Image
-    """聖誕樹圖片。 (xmas)"""
+    """聖誕樹圖片。"""
     PACMAN: Image
-    """吃豆人街機角色圖片。 (pacman)"""
+    """吃豆人街機角色圖片。"""
     TARGET: Image
-    """靶子圖片。 (target)"""
+    """靶子圖片。"""
     TSHIRT: Image
-    """T 恤圖片。 (tshirt)"""
+    """T 恤圖片。"""
     ROLLERSKATE: Image
-    """輪式溜冰鞋圖片。 (rollerskate)"""
+    """輪式溜冰鞋圖片。"""
     DUCK: Image
-    """鴨子圖片。 (duck)"""
+    """鴨子圖片。"""
     HOUSE: Image
-    """房子圖片。 (house)"""
+    """房子圖片。"""
     TORTOISE: Image
-    """陸龜圖片。 (tortoise)"""
+    """陸龜圖片。"""
     BUTTERFLY: Image
-    """蝴蝶圖片。 (butterfly)"""
+    """蝴蝶圖片。"""
     STICKFIGURE: Image
-    """簡筆人物畫圖片。 (stickfigure)"""
+    """簡筆人物畫圖片。"""
     GHOST: Image
-    """幽靈圖片。 (ghost)"""
+    """幽靈圖片。"""
     SWORD: Image
-    """劍圖片。 (sword)"""
+    """劍圖片。"""
     GIRAFFE: Image
-    """長頸鹿圖片。 (giraffe)"""
+    """長頸鹿圖片。"""
     SKULL: Image
-    """骷髏頭圖片。 (skull)"""
+    """骷髏頭圖片。"""
     UMBRELLA: Image
-    """雨傘圖片。 (umbrella)"""
+    """雨傘圖片。"""
     SNAKE: Image
-    """蛇圖片。 (snake)"""
+    """蛇圖片。"""
     ALL_CLOCKS: List[Image]
-    """按順序包含所有時鐘圖片的清單。 (all clocks)"""
+    """按順序包含所有時鐘圖片的清單。"""
     ALL_ARROWS: List[Image]
-    """按順序包含所有箭頭圖片的清單。 (all arrows)"""
+    """按順序包含所有箭頭圖片的清單。"""
 
     @overload
     def __init__(self, string: str) -> None:
-        """從描述點亮哪些 LED 的字串建立圖片。 (init)
+        """從描述點亮哪些 LED 的字串建立圖片。
 
 ``string`` has to consist of digits 0-9 arranged into lines,
 describing the image, for example::
@@ -432,16 +432,16 @@ describing the image, for example::
 will create a 5×5 image of an X. The end of a line is indicated by a
 colon. It's also possible to use newlines (\\n) insead of the colons.
 
-:param string: (string) 描述圖片的字串。"""
+:param string: 描述圖片的字串。"""
         ...
 
     @overload
     def __init__(self, width: int=5, height: int=5, buffer: ReadableBuffer=None) -> None:
-        """建立一個 ``width`` 行 ``height`` 列的空白圖片。 (init)
+        """建立一個 ``width`` 行 ``height`` 列的空白圖片。
 
-:param width: (width) 可選的圖片寬度
-:param height: (height) 可選的圖片高度
-:param buffer: (buffer) 用可選陣列或在 0-9 範圍內的 ``width``×``height`` 整數位元組，來初始化圖片
+:param width: 可選的圖片寬度
+:param height: 可選的圖片高度
+:param buffer: 用可選陣列或在 0-9 範圍內的 ``width``×``height`` 整數位元組，來初始化圖片
 
 Examples::
 
@@ -452,90 +452,90 @@ These create 2 x 2 pixel images at full brightness."""
         ...
 
     def width(self) -> int:
-        """取得行數。 (width)
+        """取得行數。
 
 :return: The number of columns in the image"""
         ...
 
     def height(self) -> int:
-        """取得列數。 (height)
+        """取得列數。
 
 :return: The number of rows in the image"""
         ...
 
     def set_pixel(self, x: int, y: int, value: int) -> None:
-        """設定像素的亮度。 (set pixel)
+        """設定像素的亮度。
 
 Example: ``my_image.set_pixel(0, 0, 9)``
 
-:param x: (x) 行號
-:param y: (y) 列號
-:param value: (value) 亮度為介於 0 (暗) 和 9 (亮) 之間的整數
+:param x: 行號
+:param y: 列號
+:param value: 亮度為介於 0 (暗) 和 9 (亮) 之間的整數
 
 This method will raise an exception when called on any of the built-in
 read-only images, like ``Image.HEART``."""
         ...
 
     def get_pixel(self, x: int, y: int) -> int:
-        """取得像素的亮度。 (get pixel)
+        """取得像素的亮度。
 
 Example: ``my_image.get_pixel(0, 0)``
 
-:param x: (x) 行號
-:param y: (y) 列號
+:param x: 行號
+:param y: 列號
 :return: The brightness as an integer between 0 and 9."""
         ...
 
     def shift_left(self, n: int) -> Image:
-        """透過向左移動圖片，以建立一個新影像。 (shift left)
+        """透過向左移動圖片，以建立一個新影像。
 
 Example: ``Image.HEART_SMALL.shift_left(1)``
 
-:param n: (n) 要移動的行數
+:param n: 要移動的行數
 :return: The shifted image"""
         ...
 
     def shift_right(self, n: int) -> Image:
-        """透過向右移動圖片，以建立一個新影像。 (shift right)
+        """透過向右移動圖片，以建立一個新影像。
 
 Example: ``Image.HEART_SMALL.shift_right(1)``
 
-:param n: (n) 要移動的行數
+:param n: 要移動的行數
 :return: The shifted image"""
         ...
 
     def shift_up(self, n: int) -> Image:
-        """向上移動圖片來建立新影像。 (shift up)
+        """向上移動圖片來建立新影像。
 
 Example: ``Image.HEART_SMALL.shift_up(1)``
 
-:param n: (n) 要移動的列數
+:param n: 要移動的列數
 :return: The shifted image"""
         ...
 
     def shift_down(self, n: int) -> Image:
-        """向下移動圖片來建立新影像。 (shift down)
+        """向下移動圖片來建立新影像。
 
 Example: ``Image.HEART_SMALL.shift_down(1)``
 
-:param n: (n) 要移動的列數
+:param n: 要移動的列數
 :return: The shifted image"""
         ...
 
     def crop(self, x: int, y: int, w: int, h: int) -> Image:
-        """裁剪圖片來建立新影像。 (crop)
+        """裁剪圖片來建立新影像。
 
 Example: ``Image.HEART.crop(1, 1, 3, 3)``
 
-:param x: (x) 裁剪位移行
-:param y: (y) 裁剪位移列
-:param w: (w) 剪裁寬度
-:param h: (h) 剪裁高度
+:param x: 裁剪位移行
+:param y: 裁剪位移列
+:param w: 剪裁寬度
+:param h: 剪裁高度
 :return: The new image"""
         ...
 
     def copy(self) -> Image:
-        """建立影像的精確副本。 (copy)
+        """建立影像的精確副本。
 
 Example: ``Image.HEART.copy()``
 
@@ -543,7 +543,7 @@ Example: ``Image.HEART.copy()``
         ...
 
     def invert(self) -> Image:
-        """透過反轉來源影像中像素亮度，以建立一個新影像。 (invert)
+        """透過反轉來源影像中像素亮度，以建立一個新影像。
 
 Example: ``Image.SMALL_HEART.invert()``
 
@@ -551,28 +551,28 @@ Example: ``Image.SMALL_HEART.invert()``
         ...
 
     def fill(self, value: int) -> None:
-        """設定影像中所有像素的亮度。 (fill)
+        """設定影像中所有像素的亮度。
 
 Example: ``my_image.fill(5)``
 
-:param value: (value) 新亮度為 0 (暗) 和 9 (亮) 之間的數字。
+:param value: 新亮度為 0 (暗) 和 9 (亮) 之間的數字。
 
 This method will raise an exception when called on any of the built-in
 read-only images, like ``Image.HEART``."""
         ...
 
     def blit(self, src: Image, x: int, y: int, w: int, h: int, xdest: int=0, ydest: int=0) -> None:
-        """將另一個影像中的一個區域複製到該影像中。 (blit)
+        """將另一個影像中的一個區域複製到該影像中。
 
 Example: ``my_image.blit(Image.HEART, 1, 1, 3, 3, 1, 1)``
 
-:param src: (src) 來源影像
-:param x: (x) 來源影像中的起始資料行偏移量
-:param y: (y) 來源影像中的起始資料列偏移量
-:param w: (w) 要複製的資料行
-:param h: (h) 要複製的資料列
-:param xdest: (xdest) 此影像中要修改的資料列偏移量
-:param ydest: (ydest) 此影像中要修改的資料列偏移量
+:param src: 來源影像
+:param x: 來源影像中的起始資料行偏移量
+:param y: 來源影像中的起始資料列偏移量
+:param w: 要複製的資料行
+:param h: 要複製的資料列
+:param xdest: 此影像中要修改的資料列偏移量
+:param ydest: 此影像中要修改的資料列偏移量
 
 Pixels outside the source image are treated as having a brightness of 0.
 
@@ -588,70 +588,70 @@ For example, img.crop(x, y, w, h) can be implemented as::
         ...
 
     def __repr__(self) -> str:
-        """取得影像的緊湊字串顯示。 (repr)"""
+        """取得影像的緊湊字串顯示。"""
         ...
 
     def __str__(self) -> str:
-        """取得影像的可讀字串顯示。 (str)"""
+        """取得影像的可讀字串顯示。"""
         ...
 
     def __add__(self, other: Image) -> Image:
-        """透過將兩個影像的像素亮度值相加，以建立一個新影像。 (add)
+        """透過將兩個影像的像素亮度值相加，以建立一個新影像。
 
 Example: ``Image.HEART + Image.HAPPY``
 
-:param other: (other) 要新增的影像。"""
+:param other: 要新增的影像。"""
         ...
 
     def __sub__(self, other: Image) -> Image:
-        """透過從該影像中減去另一個影像的亮度值，以建立一個新影像。 (sub)
+        """透過從該影像中減去另一個影像的亮度值，以建立一個新影像。
 
 Example: ``Image.HEART - Image.HEART_SMALL``
 
-:param other: (other) 要減去的影像。"""
+:param other: 要減去的影像。"""
         ...
 
     def __mul__(self, n: float) -> Image:
-        """將各像素的亮度乘以 ``n`` 建立一個新影像。 (mul)
+        """將各像素的亮度乘以 ``n`` 建立一個新影像。
 
 Example: ``Image.HEART * 0.5``
 
-:param n: (n) 要乘以的值。"""
+:param n: 要乘以的值。"""
         ...
 
     def __truediv__(self, n: float) -> Image:
-        """將各像素的亮度除以 ``n`` 來創建新影像。 (truediv)
+        """將各像素的亮度除以 ``n`` 來創建新影像。
 
 Example: ``Image.HEART / 2``
 
-:param n: (n) 要除以的值。"""
+:param n: 要除以的值。"""
         ...
 
 class SoundEvent:
     LOUD: SoundEvent
-    """表示聲音事件的轉換，從 ``quiet`` 到 ``loud``，如鼓掌或喊叫。 (loud)"""
+    """表示聲音事件的轉換，從 ``quiet`` 到 ``loud``，如鼓掌或喊叫。"""
     QUIET: SoundEvent
-    """表示聲音事件的轉換，從 ``loud`` 到 ``quiet``，例如說話或背景音樂。 (quiet)"""
+    """表示聲音事件的轉換，從 ``loud`` 到 ``quiet``，例如說話或背景音樂。"""
 
 class Sound:
-    """可以使用 ``audio.play(Sound.NAME)`` 調用內建聲音。 (sound)"""
+    """可以使用 ``audio.play(Sound.NAME)`` 調用內建聲音。"""
     GIGGLE: Sound
-    """咯咯笑的聲音。 (giggle)"""
+    """咯咯笑的聲音。"""
     HAPPY: Sound
-    """開心的聲音。 (happy)"""
+    """開心的聲音。"""
     HELLO: Sound
-    """歡迎的聲音。 (hello)"""
+    """歡迎的聲音。"""
     MYSTERIOUS: Sound
-    """神祕的聲音。 (mysterious)"""
+    """神祕的聲音。"""
     SAD: Sound
-    """難過的聲音。 (sad)"""
+    """難過的聲音。"""
     SLIDE: Sound
-    """滑動的聲音。 (slide)"""
+    """滑動的聲音。"""
     SOARING: Sound
-    """高昂的聲音。 (soaring)"""
+    """高昂的聲音。"""
     SPRING: Sound
-    """彈跳的聲音。 (spring)"""
+    """彈跳的聲音。"""
     TWINKLE: Sound
-    """閃亮的聲音。 (twinkle)"""
+    """閃亮的聲音。"""
     YAWN: Sound
-    """呵欠的聲音。 (yawn)"""
+    """呵欠的聲音。"""

--- a/lang/zh-tw/typeshed/stdlib/microbit/accelerometer.pyi
+++ b/lang/zh-tw/typeshed/stdlib/microbit/accelerometer.pyi
@@ -1,8 +1,8 @@
-"""測量 micro:bit 的加速度並識別手勢。 (accelerometer)"""
+"""測量 micro:bit 的加速度並識別手勢。"""
 from typing import Tuple
 
 def get_x() -> int:
-    """取得 ``x`` 軸上的加速度測量值 (以毫克為單位)。 (get x)
+    """取得 ``x`` 軸上的加速度測量值 (以毫克為單位)。
 
 Example: ``accelerometer.get_x()``
 
@@ -10,7 +10,7 @@ Example: ``accelerometer.get_x()``
     ...
 
 def get_y() -> int:
-    """取得 ``y`` 軸上的加速度測量值 (以毫克為單位)。 (get y)
+    """取得 ``y`` 軸上的加速度測量值 (以毫克為單位)。
 
 Example: ``accelerometer.get_y()``
 
@@ -18,7 +18,7 @@ Example: ``accelerometer.get_y()``
     ...
 
 def get_z() -> int:
-    """取得 ``z`` 軸上的加速度測量值 (以毫克為單位)。 (get z)
+    """取得 ``z`` 軸上的加速度測量值 (以毫克為單位)。
 
 Example: ``accelerometer.get_z()``
 
@@ -26,7 +26,7 @@ Example: ``accelerometer.get_z()``
     ...
 
 def get_values() -> Tuple[int, int, int]:
-    """一次取得所有軸上的加速度測量值作為元組。 (get values)
+    """一次取得所有軸上的加速度測量值作為元組。
 
 Example: ``x, y, z = accelerometer.get_values()``
 
@@ -34,7 +34,7 @@ Example: ``x, y, z = accelerometer.get_values()``
     ...
 
 def current_gesture() -> str:
-    """取得目前手勢的名稱。 (current gesture)
+    """取得目前手勢的名稱。
 
 Example: ``accelerometer.current_gesture()``
 
@@ -47,7 +47,7 @@ represented as strings.
     ...
 
 def is_gesture(name: str) -> bool:
-    """檢查命名的手勢目前是否處於活動狀態。 (is gesture)
+    """檢查命名的手勢目前是否處於活動狀態。
 
 Example: ``accelerometer.is_gesture('shake')``
 
@@ -56,12 +56,12 @@ MicroPython understands the following gesture names: ``"up"``, ``"down"``,
 ``"3g"``, ``"6g"``, ``"8g"``, ``"shake"``. Gestures are always
 represented as strings.
 
-:param name: (name) 手勢名稱
+:param name: 手勢名稱
 :return: ``True`` if the gesture is active, ``False`` otherwise."""
     ...
 
 def was_gesture(name: str) -> bool:
-    """檢查命名手勢自上次通話後是否處於活動狀態。 (was gesture)
+    """檢查命名手勢自上次通話後是否處於活動狀態。
 
 Example: ``accelerometer.was_gesture('shake')``
 
@@ -70,11 +70,11 @@ MicroPython understands the following gesture names: ``"up"``, ``"down"``,
 ``"3g"``, ``"6g"``, ``"8g"``, ``"shake"``. Gestures are always
 represented as strings.
 
-:param name: (name) 手勢名稱
+:param name: 手勢名稱
 :return: ``True`` if the gesture was active since the last call, ``False`` otherwise."""
 
 def get_gestures() -> Tuple[str, ...]:
-    """傳回手勢歷史紀錄的元組。 (get gestures)
+    """傳回手勢歷史紀錄的元組。
 
 Example: ``accelerometer.get_gestures()``
 

--- a/lang/zh-tw/typeshed/stdlib/microbit/audio.pyi
+++ b/lang/zh-tw/typeshed/stdlib/microbit/audio.pyi
@@ -1,20 +1,19 @@
-"""使用 micro:bit 播放聲音 (匯入 ``audio`` 與 V1 相容)。 (audio)"""
+"""使用 micro:bit 播放聲音 (匯入 ``audio`` 與 V1 相容)。"""
 from ..microbit import MicroBitDigitalPin, Sound, pin0
 from typing import Iterable, Union
 
 def play(source: Union[Iterable[AudioFrame], Sound], wait: bool=True, pin: MicroBitDigitalPin=pin0, return_pin: Union[MicroBitDigitalPin, None]=None) -> None:
-    """播放內建聲音或自訂音訊幀。 (play)
+    """播放內建聲音或自訂音訊幀。
 
 Example: ``audio.play(Sound.GIGGLE)``
 
-:param source: (source) 內建 ``Sound`` 例如 ``Sound.GIGGLE`` 或作為 ``AudioFrame`` 對象的可迭代樣本資料。
-:param wait: (wait) 如果 ``wait`` 為 ``True``，此函式將會封鎖，直到聲音完成。
-:param pin: (引腳
-) 指定輸出引腳的可選引數可用於覆寫預設值 ``pin0``。如果我們不想播放任何聲音，我們可以使用 ``pin=None``。
-:param return_pin: (return pin) 指定差分邊緣連接器引腳，以連接到外部揚聲器而不是接地。在 **V2** 修訂版中，這將會被忽略。"""
+:param source: 內建 ``Sound`` 例如 ``Sound.GIGGLE`` 或作為 ``AudioFrame`` 對象的可迭代樣本資料。
+:param wait: 如果 ``wait`` 為 ``True``，此函式將會封鎖，直到聲音完成。
+:param pin: (引腳) 指定輸出引腳的可選引數可用於覆寫預設值 ``pin0``。如果我們不想播放任何聲音，我們可以使用 ``pin=None``。
+:param return_pin: 指定差分邊緣連接器引腳，以連接到外部揚聲器而不是接地。在 **V2** 修訂版中，這將會被忽略。"""
 
 def is_playing() -> bool:
-    """檢查是否正在播放聲音。 (is playing)
+    """檢查是否正在播放聲音。
 
 Example: ``audio.is_playing()``
 
@@ -22,13 +21,13 @@ Example: ``audio.is_playing()``
     ...
 
 def stop() -> None:
-    """停止所有音訊播放。 (stop)
+    """停止所有音訊播放。
 
 Example: ``audio.stop()``"""
     ...
 
 class AudioFrame:
-    """``AudioFrame`` 物件是 32 個樣本的列表，每個樣本都是一個無符號位元組 (0 到 255 之間的整數)。 (audioframe)
+    """``AudioFrame`` 物件是 32 個樣本的列表，每個樣本都是一個無符號位元組 (0 到 255 之間的整數)。
 
 It takes just over 4 ms to play a single frame.
 

--- a/lang/zh-tw/typeshed/stdlib/microbit/compass.pyi
+++ b/lang/zh-tw/typeshed/stdlib/microbit/compass.pyi
@@ -1,7 +1,7 @@
 """使用內建指南針。 (羅盤)"""
 
 def calibrate() -> None:
-    """開始校準程序。 (calibrate)
+    """開始校準程序。
 
 Example: ``compass.calibrate()``
 
@@ -10,7 +10,7 @@ to rotate the device in order to draw a circle on the LED display."""
     ...
 
 def is_calibrated() -> bool:
-    """檢查指南針是否已校準。 (is calibrated)
+    """檢查指南針是否已校準。
 
 Example: ``compass.is_calibrated()``
 
@@ -18,13 +18,13 @@ Example: ``compass.is_calibrated()``
     ...
 
 def clear_calibration() -> None:
-    """撤消校準，使指南針再次未校準。 (clear calibration)
+    """撤消校準，使指南針再次未校準。
 
 Example: ``compass.clear_calibration()``"""
     ...
 
 def get_x() -> int:
-    """取得 ``x`` 軸上的磁場強度。 (get x)
+    """取得 ``x`` 軸上的磁場強度。
 
 Example: ``compass.get_x()``
 
@@ -34,7 +34,7 @@ Call ``calibrate`` first or the results will be inaccurate.
     ...
 
 def get_y() -> int:
-    """取得 ``y`` 軸上的磁場強度。 (get y)
+    """取得 ``y`` 軸上的磁場強度。
 
 Example: ``compass.get_y()``
 
@@ -44,7 +44,7 @@ Call ``calibrate`` first or the results will be inaccurate.
     ...
 
 def get_z() -> int:
-    """取得 ``z`` 軸上的磁場強度。 (get z)
+    """取得 ``z`` 軸上的磁場強度。
 
 Example: ``compass.get_z()``
 
@@ -54,7 +54,7 @@ Call ``calibrate`` first or the results will be inaccurate.
     ...
 
 def heading() -> int:
-    """取得指南針方向。 (heading)
+    """取得指南針方向。
 
 Example: ``compass.heading()``
 
@@ -62,7 +62,7 @@ Example: ``compass.heading()``
     ...
 
 def get_field_strength() -> int:
-    """獲取裝置周圍磁場的大小。 (get field strength)
+    """獲取裝置周圍磁場的大小。
 
 Example: ``compass.get_field_strength()``
 

--- a/lang/zh-tw/typeshed/stdlib/microbit/display.pyi
+++ b/lang/zh-tw/typeshed/stdlib/microbit/display.pyi
@@ -1,79 +1,79 @@
-"""在 5×5 LED 顯示器上顯示文字、影像和動畫。 (display)"""
+"""在 5×5 LED 顯示器上顯示文字、影像和動畫。"""
 from ..microbit import Image
 from typing import Union, overload, Iterable
 
 def get_pixel(x: int, y: int) -> int:
-    """取得 ``x`` 列和 ``y`` 行的 LED 亮度。 (get pixel)
+    """取得 ``x`` 列和 ``y`` 行的 LED 亮度。
 
 Example: ``display.get_pixel(0, 0)``
 
-:param x: (x) 顯示資料行 (0..4)
-:param y: (y) 顯示資料列 (0..4)
+:param x: 顯示資料行 (0..4)
+:param y: 顯示資料列 (0..4)
 :return: A number between 0 (off) and 9 (bright)"""
     ...
 
 def set_pixel(x: int, y: int, value: int) -> None:
-    """在 ``x`` 資料行和 ``y`` 資料列設定 LED 的亮度。 (set pixel)
+    """在 ``x`` 資料行和 ``y`` 資料列設定 LED 的亮度。
 
 Example: ``display.set_pixel(0, 0, 9)``
 
-:param x: (x) 顯示資料行 (0..4)
-:param y: (y) 顯示資料列 (0..4)
-:param value: (value) 0 (關閉) 和 9 (最亮) 之間的亮度"""
+:param x: 顯示資料行 (0..4)
+:param y: 顯示資料列 (0..4)
+:param value: 0 (關閉) 和 9 (最亮) 之間的亮度"""
     ...
 
 def clear() -> None:
-    """將所有 LED 的亮度設定為 0 (關閉)。 (clear)
+    """將所有 LED 的亮度設定為 0 (關閉)。
 
 Example: ``display.clear()``"""
     ...
 
 def show(image: Union[str, float, int, Image, Iterable[Image]], delay: int=400, wait: bool=True, loop: bool=False, clear: bool=False) -> None:
-    """在 LED 顯示器上顯示影像、字母或數字。 (show)
+    """在 LED 顯示器上顯示影像、字母或數字。
 
 Example: ``display.show(Image.HEART)``
 
 When ``image`` is an image or a list of images then each image is displayed in turn.
 If ``image`` is a string or number, each letter or digit is displayed in turn.
 
-:param image: (image) 要顯示的字串、數字、影像或影像列表。
-:param delay: (delay) 每個字母、數字或影像之間的顯示時間為 ``delay`` 毫秒。
-:param wait: (wait) 如果 ``wait`` 為 ``True``，此函式將封鎖直到動畫完成，否則動畫將在背景發生。
-:param loop: (loop) 如果 ``loop`` 為 ``True``，動畫將永遠重複。
-:param clear: (clear) 如果 ``clear`` 為 ``True``，則顯示將在序列完成後清除。
+:param image: 要顯示的字串、數字、影像或影像列表。
+:param delay: 每個字母、數字或影像之間的顯示時間為 ``delay`` 毫秒。
+:param wait: 如果 ``wait`` 為 ``True``，此函式將封鎖直到動畫完成，否則動畫將在背景發生。
+:param loop: 如果 ``loop`` 為 ``True``，動畫將永遠重複。
+:param clear: 如果 ``clear`` 為 ``True``，則顯示將在序列完成後清除。
 
 The ``wait``, ``loop`` and ``clear`` arguments must be specified using their keyword."""
     ...
 
 def scroll(text: Union[str, float, int], delay: int=150, wait: bool=True, loop: bool=False, monospace: bool=False) -> None:
-    """捲動 LED 顯示器上的數字或文字。 (scroll)
+    """捲動 LED 顯示器上的數字或文字。
 
 Example: ``display.scroll('micro:bit')``
 
-:param text: (text) 要捲動的字串。如果 ``text`` 是整數或浮點數，則首先使用 ``str()`` 將其轉換為字串。
-:param delay: (delay) ``delay`` 參數能控制文字捲動的速度。
-:param wait: (wait) 如果 ``wait`` 為 ``True``，此函式將封鎖直到動畫完成，否則動畫將在背景發生。
-:param loop: (loop) 如果 ``loop`` 為 ``True``，動畫將永遠重複。
-:param monospace: (monospace) 如果 ``monospace`` 為 ``True``，則字元的寬度將全部佔用 5 個像素資料行，否則捲動時每個字元之間將恰好有 1 個空白像素資料行。
+:param text: 要捲動的字串。如果 ``text`` 是整數或浮點數，則首先使用 ``str()`` 將其轉換為字串。
+:param delay: ``delay`` 參數能控制文字捲動的速度。
+:param wait: 如果 ``wait`` 為 ``True``，此函式將封鎖直到動畫完成，否則動畫將在背景發生。
+:param loop: 如果 ``loop`` 為 ``True``，動畫將永遠重複。
+:param monospace: 如果 ``monospace`` 為 ``True``，則字元的寬度將全部佔用 5 個像素資料行，否則捲動時每個字元之間將恰好有 1 個空白像素資料行。
 
 The ``wait``, ``loop`` and ``monospace`` arguments must be specified
 using their keyword."""
     ...
 
 def on() -> None:
-    """打開 LED 顯示器。 (on)
+    """打開 LED 顯示器。
 
 Example: ``display.on()``"""
     ...
 
 def off() -> None:
-    """關閉 LED 顯示器 (停用顯示器，可讓您將 GPIO 引腳重新用於其他目的)。 (off)
+    """關閉 LED 顯示器 (停用顯示器，可讓您將 GPIO 引腳重新用於其他目的)。
 
 Example: ``display.off()``"""
     ...
 
 def is_on() -> bool:
-    """檢查 LED 顯示器是否啟用。 (is on)
+    """檢查 LED 顯示器是否啟用。
 
 Example: ``display.is_on()``
 
@@ -81,7 +81,7 @@ Example: ``display.is_on()``
     ...
 
 def read_light_level() -> int:
-    """讀取光照水平。 (read light level)
+    """讀取光照水平。
 
 Example: ``display.read_light_level()``
 

--- a/lang/zh-tw/typeshed/stdlib/microbit/i2c.pyi
+++ b/lang/zh-tw/typeshed/stdlib/microbit/i2c.pyi
@@ -1,16 +1,16 @@
-"""使用 I²C 匯流排協定與裝置通訊。 (i2c)"""
+"""使用 I²C 匯流排協定與裝置通訊。"""
 from _typeshed import ReadableBuffer
 from ..microbit import MicroBitDigitalPin, pin19, pin20
 from typing import List
 
 def init(freq: int=100000, sda: MicroBitDigitalPin=pin20, scl: MicroBitDigitalPin=pin19) -> None:
-    """重新初始化周邊設備。 (init)
+    """重新初始化周邊設備。
 
 Example: ``i2c.init()``
 
 :param freq: (頻率) 時脈頻率
-:param sda: (sda) ``sda`` 引腳 (預設 20)
-:param scl: (scl) ``scl`` 引腳 (預設 19)
+:param sda: ``sda`` 引腳 (預設 20)
+:param scl: ``scl`` 引腳 (預設 19)
 
 On a micro:bit V1 board, changing the I²C pins from defaults will make
 the accelerometer and compass stop working, as they are connected
@@ -20,7 +20,7 @@ for the motion sensors and the edge connector."""
     ...
 
 def scan() -> List[int]:
-    """掃描匯流排以尋找裝置。 (scan)
+    """掃描匯流排以尋找裝置。
 
 Example: ``i2c.scan()``
 
@@ -28,22 +28,22 @@ Example: ``i2c.scan()``
     ...
 
 def read(addr: int, n: int, repeat: bool=False) -> bytes:
-    """從裝置讀取位元組。 (read)
+    """從裝置讀取位元組。
 
 Example: ``i2c.read(0x50, 64)``
 
-:param addr: (addr) 裝置的 7 位元地址
-:param n: (n) 要讀取的位元組數
-:param repeat: (repeat) 如果 ``True``，則不會發送停止位元
+:param addr: 裝置的 7 位元地址
+:param n: 要讀取的位元組數
+:param repeat: 如果 ``True``，則不會發送停止位元
 :return: The bytes read"""
     ...
 
 def write(addr: int, buf: ReadableBuffer, repeat: bool=False) -> None:
-    """將位元組寫入裝置。 (write)
+    """將位元組寫入裝置。
 
 Example: ``i2c.write(0x50, bytes([1, 2, 3]))``
 
-:param addr: (addr) 裝置的 7 位元地址
-:param buf: (buf) 包含要寫入位元組的緩衝區
-:param repeat: (repeat) 如果 ``True``，則不會發送停止位元"""
+:param addr: 裝置的 7 位元地址
+:param buf: 包含要寫入位元組的緩衝區
+:param repeat: 如果 ``True``，則不會發送停止位元"""
     ...

--- a/lang/zh-tw/typeshed/stdlib/microbit/microphone.pyi
+++ b/lang/zh-tw/typeshed/stdlib/microbit/microphone.pyi
@@ -1,9 +1,9 @@
-"""使用內建麥克風回應聲音 (僅限 V2)。 (microphone)"""
+"""使用內建麥克風回應聲音 (僅限 V2)。"""
 from typing import Optional, Tuple
 from ..microbit import SoundEvent
 
 def current_event() -> Optional[SoundEvent]:
-    """獲取最後錄製的聲音事件 (current event)
+    """獲取最後錄製的聲音事件
 
 Example: ``microphone.current_event()``
 
@@ -11,29 +11,29 @@ Example: ``microphone.current_event()``
     ...
 
 def was_event(event: SoundEvent) -> bool:
-    """檢查自上次通話後是否至少聽到一次聲音。 (was event)
+    """檢查自上次通話後是否至少聽到一次聲音。
 
 Example: ``microphone.was_event(SoundEvent.LOUD)``
 
 This call clears the sound history before returning.
 
-:param event: (event) 要檢查的事件，例如 ``SoundEvent.LOUD`` 或 ``SoundEvent.QUIET``
+:param event: 要檢查的事件，例如 ``SoundEvent.LOUD`` 或 ``SoundEvent.QUIET``
 :return: ``True`` if sound was heard at least once since the last call, otherwise ``False``."""
     ...
 
 def is_event(event: SoundEvent) -> bool:
-    """檢查檢測到的最新聲音事件。 (is event)
+    """檢查檢測到的最新聲音事件。
 
 Example: ``microphone.is_event(SoundEvent.LOUD)``
 
 This call does not clear the sound event history.
 
-:param event: (event) 要檢查的事件，例如 ``SoundEvent.LOUD`` 或 ``SoundEvent.QUIET``
+:param event: 要檢查的事件，例如 ``SoundEvent.LOUD`` 或 ``SoundEvent.QUIET``
 :return: ``True`` if sound was the most recent heard, ``False`` otherwise."""
     ...
 
 def get_events() -> Tuple[SoundEvent, ...]:
-    """以元組的形式獲取聲音事件歷史。 (get events)
+    """以元組的形式獲取聲音事件歷史。
 
 Example: ``microphone.get_events()``
 
@@ -43,18 +43,18 @@ This call clears the sound history before returning.
     ...
 
 def set_threshold(event: SoundEvent, value: int) -> None:
-    """設定聲音事件的閾值。 (set threshold)
+    """設定聲音事件的閾值。
 
 Example: ``microphone.set_threshold(SoundEvent.LOUD, 250)``
 
 A high threshold means the event will only trigger if the sound is very loud (>= 250 in the example).
 
-:param event: (event) 聲音事件，例如 ``SoundEvent.LOUD`` 或 ``SoundEvent.QUIET``。
-:param value: (value) 0-255 範圍內的閾值級別。"""
+:param event: 聲音事件，例如 ``SoundEvent.LOUD`` 或 ``SoundEvent.QUIET``。
+:param value: 0-255 範圍內的閾值級別。"""
     ...
 
 def sound_level() -> int:
-    """獲取聲壓等級。 (sound level)
+    """獲取聲壓等級。
 
 Example: ``microphone.sound_level()``
 

--- a/lang/zh-tw/typeshed/stdlib/microbit/speaker.pyi
+++ b/lang/zh-tw/typeshed/stdlib/microbit/speaker.pyi
@@ -1,7 +1,7 @@
-"""控制內建揚聲器 (僅限 V2)。 (speaker)"""
+"""控制內建揚聲器 (僅限 V2)。"""
 
 def off() -> None:
-    """關閉揚聲器。 (off)
+    """關閉揚聲器。
 
 Example: ``speaker.off()``
 
@@ -9,7 +9,7 @@ This does not disable sound output to an edge connector pin."""
     ...
 
 def on() -> None:
-    """打開揚聲器。 (on)
+    """打開揚聲器。
 
 Example: ``speaker.on()``"""
     ...

--- a/lang/zh-tw/typeshed/stdlib/microbit/spi.pyi
+++ b/lang/zh-tw/typeshed/stdlib/microbit/spi.pyi
@@ -1,46 +1,46 @@
-"""使用周邊設備介面 (SPI) 匯流排與裝置進行通訊。 (spi)"""
+"""使用周邊設備介面 (SPI) 匯流排與裝置進行通訊。"""
 from _typeshed import ReadableBuffer, WriteableBuffer
 from ..microbit import pin13, pin14, pin15, MicroBitDigitalPin
 
 def init(baudrate: int=1000000, bits: int=8, mode: int=0, sclk: MicroBitDigitalPin=pin13, mosi: MicroBitDigitalPin=pin15, miso: MicroBitDigitalPin=pin14) -> None:
-    """初始化 SPI 通訊。 (init)
+    """初始化 SPI 通訊。
 
 Example: ``spi.init()``
 
 For correct communication, the parameters have to be the same on both communicating devices.
 
-:param baudrate: (baudrate) 通訊速度。
-:param bits: (bits) 每次傳輸的位元寬度。目前僅支持 ``bits=8``。 但是，這種情況在未來可能會改變。
-:param mode: (mode) 確定時脈極性和相位的組合 - 請見線上表格 <https://microbit-micropython.readthedocs.io/en/v2-docs/spi.html#microbit.spi.init>`_。
-:param sclk: (sclk) sclk pin (default 13)
-:param mosi: (mosi) mosi pin (default 15)
-:param miso: (miso) miso pin (default 14)"""
+:param baudrate: 通訊速度。
+:param bits: 每次傳輸的位元寬度。目前僅支持 ``bits=8``。 但是，這種情況在未來可能會改變。
+:param mode: 確定時脈極性和相位的組合 - 請見線上表格 <https://microbit-micropython.readthedocs.io/en/v2-docs/spi.html#microbit.spi.init>`_。
+:param sclk: sclk pin (default 13)
+:param mosi: mosi pin (default 15)
+:param miso: miso pin (default 14)"""
     ...
 
 def read(nbytes: int) -> bytes:
-    """讀取位元組。 (read)
+    """讀取位元組。
 
 Example: ``spi.read(64)``
 
-:param nbytes: (nbytes) 要讀取的最大位元組數。
+:param nbytes: 要讀取的最大位元組數。
 :return: The bytes read."""
     ...
 
 def write(buffer: ReadableBuffer) -> None:
-    """將位元組寫入匯流排。 (write)
+    """將位元組寫入匯流排。
 
 Example: ``spi.write(bytes([1, 2, 3]))``
 
-:param buffer: (buffer) 讀取資料的來源緩衝區。"""
+:param buffer: 讀取資料的來源緩衝區。"""
     ...
 
 def write_readinto(out: WriteableBuffer, in_: ReadableBuffer) -> None:
-    """將 ``out`` 緩衝區寫入匯流排，並將任何回應寫入 ``in_`` 緩衝區。 (write readinto)
+    """將 ``out`` 緩衝區寫入匯流排，並將任何回應寫入 ``in_`` 緩衝區。
 
 Example: ``spi.write_readinto(out_buffer, in_buffer)``
 
 The length of the buffers should be the same. The buffers can be the same object.
 
-:param out: (out) 要寫入任何回應的緩衝區。
-:param in_: (in) 要從中讀取資料的緩衝區。"""
+:param out: 要寫入任何回應的緩衝區。
+:param in_: 要從中讀取資料的緩衝區。"""
     ...

--- a/lang/zh-tw/typeshed/stdlib/microbit/uart.pyi
+++ b/lang/zh-tw/typeshed/stdlib/microbit/uart.pyi
@@ -1,23 +1,23 @@
-"""使用序列介面與裝置通訊。 (uart)"""
+"""使用序列介面與裝置通訊。"""
 from _typeshed import WriteableBuffer
 from ..microbit import MicroBitDigitalPin
 from typing import Optional, Union
 ODD: int
-"""奇數檢查 (odd)"""
+"""奇數檢查"""
 EVEN: int
-"""偶數檢查 (even)"""
+"""偶數檢查"""
 
 def init(baudrate: int=9600, bits: int=8, parity: Optional[int]=None, stop: int=1, tx: Optional[MicroBitDigitalPin]=None, rx: Optional[MicroBitDigitalPin]=None) -> None:
-    """初始化序列通訊。 (init)
+    """初始化序列通訊。
 
 Example: ``uart.init(115200, tx=pin0, rx=pin1)``
 
-:param baudrate: (baudrate) 通訊速度。
-:param bits: (bits) 正在傳輸的位元組大小，micro:bit 只支援 8。
-:param parity: (parity) 如何檢查奇數，``None``、``uart.ODD`` 或 ``uart.EVEN``。
-:param stop: (stop) 停止位元的數量，micro:bit 必須為 1。
-:param tx: (tx) 發射引腳。
-:param rx: (rx) 正在接收引腳。
+:param baudrate: 通訊速度。
+:param bits: 正在傳輸的位元組大小，micro:bit 只支援 8。
+:param parity: 如何檢查奇數，``None``、``uart.ODD`` 或 ``uart.EVEN``。
+:param stop: 停止位元的數量，micro:bit 必須為 1。
+:param tx: 發射引腳。
+:param rx: 正在接收引腳。
 
 Initializing the UART on external pins will cause the Python console on
 USB to become unaccessible, as it uses the same hardware. To bring the
@@ -29,7 +29,7 @@ For more details see `the online documentation <https://microbit-micropython.rea
     ...
 
 def any() -> bool:
-    """Check if any data is waiting. (any)
+    """Check if any data is waiting.
 
 Example: ``uart.any()``
 
@@ -37,26 +37,26 @@ Example: ``uart.any()``
     ...
 
 def read(nbytes: Optional[int]=None) -> Optional[bytes]:
-    """讀取位元組。 (read)
+    """讀取位元組。
 
 Example: ``uart.read()``
 
-:param nbytes: (nbytes) 如果指定了 ``nbytes``，則最多讀取那麼多位元組，否則讀取盡可能多的位元組
+:param nbytes: 如果指定了 ``nbytes``，則最多讀取那麼多位元組，否則讀取盡可能多的位元組
 :return: A bytes object or ``None`` on timeout"""
     ...
 
 def readinto(buf: WriteableBuffer, nbytes: Optional[int]=None) -> Optional[int]:
-    """將位元組讀入 ``buf``。 (readinto)
+    """將位元組讀入 ``buf``。
 
 Example: ``uart.readinto(input_buffer)``
 
-:param buf: (buf) 要寫入的緩衝區。
-:param nbytes: (nbytes) 如果指定了 ``nbytes``，則最多讀取那麼多位元組，否則讀取 ``len(buf)`` 個位元組。
+:param buf: 要寫入的緩衝區。
+:param nbytes: 如果指定了 ``nbytes``，則最多讀取那麼多位元組，否則讀取 ``len(buf)`` 個位元組。
 :return: number of bytes read and stored into ``buf`` or ``None`` on timeout."""
     ...
 
 def readline() -> Optional[bytes]:
-    """讀取一行，以換行符結尾。 (readline)
+    """讀取一行，以換行符結尾。
 
 Example: ``uart.readline()``
 
@@ -64,11 +64,11 @@ Example: ``uart.readline()``
     ...
 
 def write(buf: Union[bytes, str]) -> Optional[int]:
-    """將緩衝區寫入匯流排。 (write)
+    """將緩衝區寫入匯流排。
 
 Example: ``uart.write('hello world')``
 
-:param buf: (buf) 一個位元組物件或一個字串。
+:param buf: 一個位元組物件或一個字串。
 :return: The number of bytes written, or ``None`` on timeout.
 
 Examples::

--- a/lang/zh-tw/typeshed/stdlib/micropython.pyi
+++ b/lang/zh-tw/typeshed/stdlib/micropython.pyi
@@ -1,9 +1,9 @@
-"""MicroPython 內部。 (micropython)"""
+"""MicroPython 內部。"""
 from typing import Any, TypeVar, overload
 _T = TypeVar('_T')
 
 def const(expr: _T) -> _T:
-    """用於宣告運算式為常數，以便編譯器對其進行最佳化。 (const)
+    """用於宣告運算式為常數，以便編譯器對其進行最佳化。
 
 The use of this function should be as follows::
 
@@ -16,12 +16,12 @@ outside the module they are declared in. On the other hand, if a constant
 begins with an underscore then it is hidden, it is not available as a
 global variable, and does not take up any memory during execution.
 
-:param expr: (expr) 一個常數運算式。"""
+:param expr: 一個常數運算式。"""
     ...
 
 @overload
 def opt_level() -> int:
-    """取得指令碼編譯的目前最佳化等級。 (opt level)
+    """取得指令碼編譯的目前最佳化等級。
 
 Example: ``micropython.opt_level()``
 
@@ -43,7 +43,7 @@ The optimisation level controls the following compilation features:
 
 @overload
 def opt_level(level: int) -> None:
-    """設定指令碼後續編譯的最佳化級別。 (opt level)
+    """設定指令碼後續編譯的最佳化級別。
 
 Example: ``micropython.opt_level(1)``
 
@@ -62,23 +62,23 @@ The optimisation level controls the following compilation features:
 
 The default optimisation level is usually level 0.
 
-:param level: (level) 整數最佳化級別。"""
+:param level: 整數最佳化級別。"""
     ...
 
 def mem_info(verbose: Any=None) -> None:
-    """輸出關於目前使用的記憶體資訊。 (mem info)
+    """輸出關於目前使用的記憶體資訊。
 
 Example: ``micropython.mem_info()``
 
-:param verbose: (verbose) 如果給出 ``verbose`` 引數，則輸出額外資訊。"""
+:param verbose: 如果給出 ``verbose`` 引數，則輸出額外資訊。"""
     ...
 
 def qstr_info(verbose: Any=None) -> None:
-    """輸出關於目前駐留字串的資訊。 (qstr info)
+    """輸出關於目前駐留字串的資訊。
 
 Example: ``micropython.qstr_info()``
 
-:param verbose: (verbose) 如果指定 ``verbose`` 引數，則會輸出額外資訊。
+:param verbose: 如果指定 ``verbose`` 引數，則會輸出額外資訊。
 
 The information that is printed is implementation dependent, but currently
 includes the number of interned strings and the amount of RAM they use.  In
@@ -86,7 +86,7 @@ verbose mode it prints out the names of all RAM-interned strings."""
     ...
 
 def stack_use() -> int:
-    """傳回整數，表示目前正在使用的堆疊數量。 (stack use)
+    """傳回整數，表示目前正在使用的堆疊數量。
 
 Example: ``micropython.stack_use()``
 
@@ -97,7 +97,7 @@ should be used to compute differences in stack usage at different points.
     ...
 
 def heap_lock() -> None:
-    """鎖定堆積。 (heap lock)
+    """鎖定堆積。
 
 Example: ``micropython.heap_lock()``
 
@@ -106,7 +106,7 @@ raised if any heap allocation is attempted."""
     ...
 
 def heap_unlock() -> None:
-    """解鎖堆積。 (heap unlock)
+    """解鎖堆積。
 
 Example: ``micropython.heap_unlock()``
 
@@ -115,11 +115,11 @@ raised if any heap allocation is attempted."""
     ...
 
 def kbd_intr(chr: int) -> None:
-    """設定將觸發 ``KeyboardInterrupt`` 異常的字元。 (kbd intr)
+    """設定將觸發 ``KeyboardInterrupt`` 異常的字元。
 
 Example: ``micropython.kbd_intr(-1)``
 
-:param chr: (chr) 用於引發中斷的字元程式碼或 -1，以停用 Ctrl-C 的擷取。
+:param chr: 用於引發中斷的字元程式碼或 -1，以停用 Ctrl-C 的擷取。
 
 By default this is set to 3 during script execution, corresponding to Ctrl-C.
 Passing -1 to this function will disable capture of Ctrl-C, and passing 3

--- a/lang/zh-tw/typeshed/stdlib/music.pyi
+++ b/lang/zh-tw/typeshed/stdlib/music.pyi
@@ -1,64 +1,64 @@
-"""創作和播放旋律。 (music)"""
+"""創作和播放旋律。"""
 from typing import Tuple, Union, List
 from .microbit import MicroBitDigitalPin, pin0
 DADADADUM: Tuple[str, ...]
-"""旋律：貝多芬 C 小調第五交響曲的開場。 (dadadadum)"""
+"""旋律：貝多芬 C 小調第五交響曲的開場。"""
 ENTERTAINER: Tuple[str, ...]
-"""旋律：史考特喬普林的名曲《演藝人》開場。 (entertainer)"""
+"""旋律：史考特喬普林的名曲《演藝人》開場。"""
 PRELUDE: Tuple[str, ...]
-"""旋律：巴哈 48 首前奏曲與賦格曲 C 大調第一前奏曲的開場。 (prelude)"""
+"""旋律：巴哈 48 首前奏曲與賦格曲 C 大調第一前奏曲的開場。"""
 ODE: Tuple[str, ...]
-"""旋律：貝多芬 D 小調第九交響曲中的「歡樂頌」主題。 (ode)"""
+"""旋律：貝多芬 D 小調第九交響曲中的「歡樂頌」主題。"""
 NYAN: Tuple[str, ...]
-"""旋律：Nyan Cat 主題 (http://www.nyan.cat/)。 (nyan)
+"""旋律：Nyan Cat 主題 (http://www.nyan.cat/)。
 
 The composer is unknown. This is fair use for educational porpoises (as they say in New York)."""
 RINGTONE: Tuple[str, ...]
-"""旋律：聽起來像手機鈴聲的東西。 (ringtone)
+"""旋律：聽起來像手機鈴聲的東西。
 
 To be used to indicate an incoming message.
 """
 FUNK: Tuple[str, ...]
-"""旋律：為秘密特工和犯罪策劃者準備的放克低音。 (funk)"""
+"""旋律：為秘密特工和犯罪策劃者準備的放克低音。"""
 BLUES: Tuple[str, ...]
-"""旋律：布基烏基 12 小節藍調走路低音。 (blues)"""
+"""旋律：布基烏基 12 小節藍調走路低音。"""
 BIRTHDAY: Tuple[str, ...]
-"""旋律：「祝你生日快樂…」 (birthday)
+"""旋律：「祝你生日快樂…」
 
 For copyright status see: http://www.bbc.co.uk/news/world-us-canada-34332853
 """
 WEDDING: Tuple[str, ...]
-"""旋律：華格納歌劇《羅恩格林》中的新娘合唱。 (wedding)"""
+"""旋律：華格納歌劇《羅恩格林》中的新娘合唱。"""
 FUNERAL: Tuple[str, ...]
-"""旋律：《葬禮進行曲》，亦稱為蕭邦的「降 b 小調第二號鋼琴奏鳴曲」。 (funeral)"""
+"""旋律：《葬禮進行曲》，亦稱為蕭邦的「降 b 小調第二號鋼琴奏鳴曲」。"""
 PUNCHLINE: Tuple[str, ...]
-"""旋律：一段有趣的音樂，表示說了一個笑話。 (punchline)"""
+"""旋律：一段有趣的音樂，表示說了一個笑話。"""
 PYTHON: Tuple[str, ...]
-"""旋律：約翰菲利普蘇薩的進行曲《自由鐘》，又名《蒙提派森的飛行馬戲團》的主題曲 (Python 程式語言以此命名)。 (python)"""
+"""旋律：約翰菲利普蘇薩的進行曲《自由鐘》，又名《蒙提派森的飛行馬戲團》的主題曲 (Python 程式語言以此命名)。"""
 BADDY: Tuple[str, ...]
-"""旋律：無聲電影時代的壞人登場。 (baddy)"""
+"""旋律：無聲電影時代的壞人登場。"""
 CHASE: Tuple[str, ...]
-"""旋律：無聲電影時代的追逐場景。 (chase)"""
+"""旋律：無聲電影時代的追逐場景。"""
 BA_DING: Tuple[str, ...]
-"""旋律：表示某事發生的簡短訊號。 (ba ding)"""
+"""旋律：表示某事發生的簡短訊號。"""
 WAWAWAWAA: Tuple[str, ...]
-"""旋律：非常悲傷的長號。 (wawawawaa)"""
+"""旋律：非常悲傷的長號。"""
 JUMP_UP: Tuple[str, ...]
-"""旋律：用於遊戲中，代表向上移動。 (jump up)"""
+"""旋律：用於遊戲中，代表向上移動。"""
 JUMP_DOWN: Tuple[str, ...]
-"""旋律：用於遊戲中，表示向下移動。 (jump down)"""
+"""旋律：用於遊戲中，表示向下移動。"""
 POWER_UP: Tuple[str, ...]
-"""旋律：表示已解鎖成就的號角齊鳴。 (power up)"""
+"""旋律：表示已解鎖成就的號角齊鳴。"""
 POWER_DOWN: Tuple[str, ...]
-"""旋律：表示失去成就的悲傷號角聲。 (power down)"""
+"""旋律：表示失去成就的悲傷號角聲。"""
 
 def set_tempo(ticks: int=4, bpm: int=120) -> None:
-    """設定播放的大致速度。 (set tempo)
+    """設定播放的大致速度。
 
 Example: ``music.set_tempo(bpm=120)``
 
-:param ticks: (ticks) 構成節拍的 tick 數。
-:param bpm: (bpm) 一個整數，決定每分鐘有多少次節拍。
+:param ticks: 構成節拍的 tick 數。
+:param bpm: 一個整數，決定每分鐘有多少次節拍。
 
 Suggested default values allow the following useful behaviour:
 
@@ -72,7 +72,7 @@ To work out the length of a tick in milliseconds is very simple arithmetic:
     ...
 
 def get_tempo() -> Tuple[int, int]:
-    """以整數元組的形式獲取當前速度：``(ticks, bpm)``。 (get tempo)
+    """以整數元組的形式獲取當前速度：``(ticks, bpm)``。
 
 Example: ``ticks, beats = music.get_tempo()``
 
@@ -80,15 +80,14 @@ Example: ``ticks, beats = music.get_tempo()``
     ...
 
 def play(music: Union[str, List[str], Tuple[str, ...]], pin: Union[MicroBitDigitalPin, None]=pin0, wait: bool=True, loop: bool=False) -> None:
-    """播放音樂。 (play)
+    """播放音樂。
 
 Example: ``music.play(music.NYAN)``
 
-:param music: (music) 特殊音符中指定的音樂 <https://microbit-micropython.readthedocs.io/en/v2-docs/music.html#musical-notation>`_
-:param pin: (引腳
-) 用於外接揚聲器的輸出引腳 (預設為 ``pin0``)，``None`` 表示無聲音。
-:param wait: (wait) 如果 ``wait`` 設定為 ``True``，則此函式會封鎖。
-:param loop: (loop) 如果 ``loop`` 設定為 ``True``，曲調會重複直到呼叫 ``stop`` 或封鎖呼叫被中斷。
+:param music: 特殊音符中指定的音樂 <https://microbit-micropython.readthedocs.io/en/v2-docs/music.html#musical-notation>`_
+:param pin: (引腳) 用於外接揚聲器的輸出引腳 (預設為 ``pin0``)，``None`` 表示無聲音。
+:param wait: 如果 ``wait`` 設定為 ``True``，則此函式會封鎖。
+:param loop: 如果 ``loop`` 設定為 ``True``，曲調會重複直到呼叫 ``stop`` 或封鎖呼叫被中斷。
 
 Many built-in melodies are defined in this module."""
     ...
@@ -99,10 +98,9 @@ def pitch(frequency: int, duration: int=-1, pin: MicroBitDigitalPin=pin0, wait: 
 Example: ``music.pitch(185, 1000)``
 
 :param frequency: (頻率) 整數頻率
-:param duration: (duration) 毫秒的持續時間。如果是否定的，則聲音將持續到下一次呼叫或對 ``stop`` 的呼叫。
-:param pin: (引腳
-) 可選輸出引腳 (預設值 ``pin0``)。
-:param wait: (wait) 如果 ``wait`` 設定為 ``True``，則此函式為封鎖。
+:param duration: 毫秒的持續時間。如果是否定的，則聲音將持續到下一次呼叫或對 ``stop`` 的呼叫。
+:param pin: (引腳) 可選輸出引腳 (預設值 ``pin0``)。
+:param wait: 如果 ``wait`` 設定為 ``True``，則此函式為封鎖。
 
 For example, if the frequency is set to 440 and the length to
 1000 then we hear a standard concert A for one second.
@@ -111,15 +109,14 @@ You can only play one pitch on one pin at any one time."""
     ...
 
 def stop(pin: MicroBitDigitalPin=pin0) -> None:
-    """停止內建揚聲器上的所有音樂播放和任何引腳輸出聲音。 (stop)
+    """停止內建揚聲器上的所有音樂播放和任何引腳輸出聲音。
 
 Example: ``music.stop()``
 
-:param pin: (引腳
-) 可以提供一個可選引數來指定一個引腳，例如``music.stop(pin1)``。"""
+:param pin: (引腳) 可以提供一個可選引數來指定一個引腳，例如``music.stop(pin1)``。"""
 
 def reset() -> None:
-    """將 tick、bpm、持續時間和八度音程重置為其預設值。 (reset)
+    """將 tick、bpm、持續時間和八度音程重置為其預設值。
 
 Example: ``music.reset()``
 

--- a/lang/zh-tw/typeshed/stdlib/neopixel.pyi
+++ b/lang/zh-tw/typeshed/stdlib/neopixel.pyi
@@ -1,11 +1,11 @@
-"""可獨立尋址的 RGB 和 RGBW LED 燈條。 (neopixel)"""
+"""可獨立尋址的 RGB 和 RGBW LED 燈條。"""
 from .microbit import MicroBitDigitalPin
 from typing import Tuple
 
 class NeoPixel:
 
     def __init__(self, pin: MicroBitDigitalPin, n: int, bpp: int=3) -> None:
-        """初始化透過引腳控制的 NeoPixel LED 燈條。 (init)
+        """初始化透過引腳控制的 NeoPixel LED 燈條。
 
 Example: ``np = neopixel.NeoPixel(pin0, 8)``
 
@@ -14,18 +14,18 @@ RGBW neopixels are only supported by micro:bit V2.
 See `the online docs <https://microbit-micropython.readthedocs.io/en/v2-docs/neopixel.html>`_ for warnings and other advice.
 
 :param pin: (引腳) 控制 NeoPixel 燈條的引腳。
-:param n: (n) 燈條中的 NeoPixel 數。
-:param bpp: (bpp) 各像素位元組數。 對於 micro:bit V2 RGBW neopixel 支持，傳遞 4 而不是 RGB 和 GRB 的預設值 3。"""
+:param n: 燈條中的 NeoPixel 數。
+:param bpp: 各像素位元組數。 對於 micro:bit V2 RGBW neopixel 支持，傳遞 4 而不是 RGB 和 GRB 的預設值 3。"""
         ...
 
     def clear(self) -> None:
-        """清除所有像素。 (clear)
+        """清除所有像素。
 
 Example: ``np.clear()``"""
         ...
 
     def show(self) -> None:
-        """顯示像素。 (show)
+        """顯示像素。
 
 Example: ``np.show()``
 
@@ -33,7 +33,7 @@ Must be called for any updates to become visible."""
         ...
 
     def write(self) -> None:
-        """顯示像素 (僅限 micro:bit V2)。 (write)
+        """顯示像素 (僅限 micro:bit V2)。
 
 Example: ``np.write()``
 
@@ -43,32 +43,32 @@ Equivalent to ``show``."""
         ...
 
     def fill(self, colour: Tuple[int, ...]) -> None:
-        """用特定 RGB/RGBW 值為所有像素著色。 (fill)
+        """用特定 RGB/RGBW 值為所有像素著色。
 
 Example: ``np.fill((0, 0, 255))``
 
-:param colour: (colour) 長度與每像素位元組數 (bpp) 相同的元組。
+:param colour: 長度與每像素位元組數 (bpp) 相同的元組。
 
 Use in conjunction with ``show()`` to update the neopixels."""
         ...
 
     def __setitem__(self, key: int, value: Tuple[int, ...]) -> None:
-        """設定像素顏色。 (setitem)
+        """設定像素顏色。
 
 Example: ``np[0] = (255, 0, 0)``
 
-:param key: (key) 像素編號。
-:param value: (value) 顏色。"""
+:param key: 像素編號。
+:param value: 顏色。"""
 
     def __getitem__(self, key: int) -> Tuple[int, ...]:
-        """取得像素顏色。 (getitem)
+        """取得像素顏色。
 
 Example: ``r, g, b = np[0]``
 
-:param key: (key) 像素編號。
+:param key: 像素編號。
 :return: The colour tuple."""
 
     def __len__(self) -> int:
-        """取得此像素燈條的長度。 (len)
+        """取得此像素燈條的長度。
 
 Example: ``len(np)``"""

--- a/lang/zh-tw/typeshed/stdlib/os.pyi
+++ b/lang/zh-tw/typeshed/stdlib/os.pyi
@@ -1,9 +1,9 @@
-"""存取檔案系統。 (os)"""
+"""存取檔案系統。"""
 from typing import Tuple
 from typing import List
 
 def listdir() -> List[str]:
-    """列出檔案。 (listdir)
+    """列出檔案。
 
 Example: ``os.listdir()``
 
@@ -12,40 +12,40 @@ persistent on-device file system."""
     ...
 
 def remove(filename: str) -> None:
-    """移除 (刪除) 一個檔案。 (remove)
+    """移除 (刪除) 一個檔案。
 
 Example: ``os.remove('data.txt')``
 
-:param filename: (filename) 要刪除的文件。
+:param filename: 要刪除的文件。
 
 If the file does not exist an ``OSError`` exception will occur."""
     ...
 
 def size(filename: str) -> int:
-    """傳回檔案的大小。 (size)
+    """傳回檔案的大小。
 
 Example: ``os.size('data.txt')``
 
-:param filename: (filename) 檔案
+:param filename: 檔案
 :return: The size in bytes.
 
 If the file does not exist an ``OSError`` exception will occur."""
 
 class uname_result(Tuple[str, str, str, str, str]):
-    """``os.uname()`` 的結果 (uname result)"""
+    """``os.uname()`` 的結果"""
     sysname: str
-    """作業系統名稱。 (sysname)"""
+    """作業系統名稱。"""
     nodename: str
-    """網路上的機器名稱 (執行定義)。 (nodename)"""
+    """網路上的機器名稱 (執行定義)。"""
     release: str
-    """作業系統發佈。 (release)"""
+    """作業系統發佈。"""
     version: str
-    """作業系統版本。 (version)"""
+    """作業系統版本。"""
     machine: str
-    """硬體識別碼。 (machine)"""
+    """硬體識別碼。"""
 
 def uname() -> uname_result:
-    """傳回標識目前作業系統的資訊。 (uname)
+    """傳回標識目前作業系統的資訊。
 
 Example: ``os.uname()``
 

--- a/lang/zh-tw/typeshed/stdlib/radio.pyi
+++ b/lang/zh-tw/typeshed/stdlib/radio.pyi
@@ -1,13 +1,13 @@
-"""使用內建無線電在 micro:bits 之間進行通訊。 (radio)"""
+"""使用內建無線電在 micro:bits 之間進行通訊。"""
 from _typeshed import WriteableBuffer
 from typing import Optional, Tuple
 RATE_1MBIT: int
-"""常數用於指示每秒 1 MBit 的傳輸量。 (rate 1mbit)"""
+"""常數用於指示每秒 1 MBit 的傳輸量。"""
 RATE_2MBIT: int
-"""常數用於指示每秒 2 MBit 的傳輸量。 (rate 2mbit)"""
+"""常數用於指示每秒 2 MBit 的傳輸量。"""
 
 def on() -> None:
-    """開啟無線電。 (on)
+    """開啟無線電。
 
 Example: ``radio.on()``
 
@@ -16,38 +16,38 @@ up memory that you may otherwise need."""
     ...
 
 def off() -> None:
-    """關閉收音機，節省電量和記憶體。 (off)
+    """關閉收音機，節省電量和記憶體。
 
 Example: ``radio.off()``"""
     ...
 
 def config(length: int=32, queue: int=3, channel: int=7, power: int=6, address: int=1969383796, group: int=0, data_rate: int=RATE_1MBIT) -> None:
-    """設定無線電。 (config)
+    """設定無線電。
 
 Example: ``radio.config(group=42)``
 
 The default configuration is suitable for most use.
 
-:param length: (length) (default=32) 定義透過無線電傳送的訊息的最大長度 (以位元組為單位)。
+:param length: (default=32) 定義透過無線電傳送的訊息的最大長度 (以位元組為單位)。
 最長可達 251 個位元組 (S0、LENGTH 和 S1 前序編碼為 254 - 3 個位元組)。
-:param queue: (queue) (default=3) 指定可以存儲在傳入訊息佇列中的訊息數。
+:param queue: (default=3) 指定可以存儲在傳入訊息佇列中的訊息數。
 如果佇列中沒有空間可留給傳入訊息，則捨棄傳入訊息。
-:param channel: (channel) (default=7) 一個從 0 到 83 (包含) 的整數值，定義無線電調整到的任意 "channel"。
+:param channel: (default=7) 一個從 0 到 83 (包含) 的整數值，定義無線電調整到的任意 "channel"。
 訊息將透過此頻道傳送。只有透過此頻道接收的訊息，才會放入傳入訊息佇列。每一步都是 1MHz 寬，以 2400MHz 為基礎。
-:param power: (power) (default=6) 是一個從 0 到 7 (包含) 的整數值，表示無線電訊息時使用的訊號功率。
+:param power: (default=6) 是一個從 0 到 7 (包含) 的整數值，表示無線電訊息時使用的訊號功率。
 數值越高，訊號越強，但裝置消耗的功率越多。編號轉換為下列 dBm (分貝毫瓦) 數值列表中的位置：-30、-20、-16、-12、-8、-4、0、4。
-:param address: (address) (default=0x75626974) 任意名稱，表示為 32 位元地址，用於在硬體級別篩選傳入的資料套件，僅保留與您設定的地址相符的那些。
+:param address: (default=0x75626974) 任意名稱，表示為 32 位元地址，用於在硬體級別篩選傳入的資料套件，僅保留與您設定的地址相符的那些。
 其他 micro:bit 相關平台使用的預設設定，則是此處使用的預設設定。
-:param group: (group) (default=0) 篩選訊息時與 ``address`` 一起使用的 8 位元值 (0-255)。
+:param group: (default=0) 篩選訊息時與 ``address`` 一起使用的 8 位元值 (0-255)。
 從概念上講，"address" 就像一個家庭/辦公室地址，而 "group" 就像您要向該地址傳送訊息的人。
-:param data_rate: (data rate) (default=``radio.RATE_1MBIT``) 表示資料傳輸量發生的速度。
+:param data_rate: (default=``radio.RATE_1MBIT``) 表示資料傳輸量發生的速度。
 可以是 ``radio`` 模組中定義的下列常數之一：``RATE_250KBIT``、``RATE_1MBIT`` 或 ``RATE_2MBIT``。
 
 If ``config`` is not called then the defaults described above are assumed."""
     ...
 
 def reset() -> None:
-    """將設定重置為其預設值。 (reset)
+    """將設定重置為其預設值。
 
 Example: ``radio.reset()``
 
@@ -55,15 +55,15 @@ The defaults as as per the ``config`` function above."""
     ...
 
 def send_bytes(message: bytes) -> None:
-    """發送包含位元組的訊息。 (send bytes)
+    """發送包含位元組的訊息。
 
 Example: ``radio.send_bytes(b'hello')``
 
-:param message: (message) 要發送的位元組。"""
+:param message: 要發送的位元組。"""
     ...
 
 def receive_bytes() -> Optional[bytes]:
-    """接收訊息佇列中的下一則傳入訊息。 (receive bytes)
+    """接收訊息佇列中的下一則傳入訊息。
 
 Example: ``radio.receive_bytes()``
 
@@ -71,27 +71,27 @@ Example: ``radio.receive_bytes()``
     ...
 
 def receive_bytes_into(buffer: WriteableBuffer) -> Optional[int]:
-    """將訊息佇列中的下一則傳入訊息複製到緩衝區中。 (receive bytes into)
+    """將訊息佇列中的下一則傳入訊息複製到緩衝區中。
 
 Example: ``radio.receive_bytes_info(buffer)``
 
-:param buffer: (buffer) 將訊息佇列中的下一則傳入訊息複製到緩衝區中。
+:param buffer: 將訊息佇列中的下一則傳入訊息複製到緩衝區中。
 :return: ``None`` if there are no pending messages, otherwise it returns the length of the message (which might be more than the length of the buffer)."""
     ...
 
 def send(message: str) -> None:
-    """發送訊息字串。 (send)
+    """發送訊息字串。
 
 Example: ``radio.send('hello')``
 
 This is the equivalent of ``radio.send_bytes(bytes(message, 'utf8'))`` but with ``b'\x01\x00\x01'``
 prepended to the front (to make it compatible with other platforms that target the micro:bit).
 
-:param message: (message) 要發送的字串。"""
+:param message: 要發送的字串。"""
     ...
 
 def receive() -> Optional[str]:
-    """工作方式與 ``receive_bytes`` 完全相同，但會傳回發送的任何內容。 (receive)
+    """工作方式與 ``receive_bytes`` 完全相同，但會傳回發送的任何內容。
 
 Example: ``radio.receive()``
 
@@ -105,7 +105,7 @@ A ``ValueError`` exception is raised if conversion to string fails."""
     ...
 
 def receive_full() -> Optional[Tuple[bytes, int, int]]:
-    """工作方式與 ``receive_bytes`` 完全相同，但會傳回發送的任何內容。 (receive full)
+    """工作方式與 ``receive_bytes`` 完全相同，但會傳回發送的任何內容。
 
 Example: ``radio.receive_full()``
 

--- a/lang/zh-tw/typeshed/stdlib/random.pyi
+++ b/lang/zh-tw/typeshed/stdlib/random.pyi
@@ -1,69 +1,69 @@
-"""生成隨機數。 (random)"""
+"""生成隨機數。"""
 from typing import TypeVar, Sequence, Union, overload
 
 def getrandbits(n: int) -> int:
-    """生成具有 ``n`` 個隨機位元的整數。 (getrandbits)
+    """生成具有 ``n`` 個隨機位元的整數。
 
 Example: ``random.getrandbits(1)``
 
-:param n: (n) 介於 1-30 (包含) 之間的值。"""
+:param n: 介於 1-30 (包含) 之間的值。"""
     ...
 
 def seed(n: int) -> None:
-    """初始化隨機數生成器。 (seed)
+    """初始化隨機數生成器。
 
 Example: ``random.seed(0)``
 
-:param n: (n) 整數種子
+:param n: 整數種子
 
 This will give you reproducibly deterministic randomness from a given starting
 state (``n``)."""
     ...
 
 def randint(a: int, b: int) -> int:
-    """在 ``a`` 和 ``b`` (包含) 之間選擇一個隨機整數。 (randint)
+    """在 ``a`` 和 ``b`` (包含) 之間選擇一個隨機整數。
 
 Example: ``random.randint(0, 9)``
 
-:param a: (a) 範圍的起始值 (包含)
-:param b: (b) 範圍的結束值 (包含)
+:param a: 範圍的起始值 (包含)
+:param b: 範圍的結束值 (包含)
 
 Alias for ``randrange(a, b + 1)``."""
     ...
 
 @overload
 def randrange(stop: int) -> int:
-    """在零到 (但不包括) ``stop`` 之間隨機選擇一個整數。 (randrange)
+    """在零到 (但不包括) ``stop`` 之間隨機選擇一個整數。
 
 Example: ``random.randrange(10)``
 
-:param stop: (stop) 範圍的結束值 (排除)"""
+:param stop: 範圍的結束值 (排除)"""
     ...
 
 @overload
 def randrange(start: int, stop: int, step: int=1) -> int:
-    """從 ``range(start, stop, step)`` 中選擇一個隨機選擇的元素。 (randrange)
+    """從 ``range(start, stop, step)`` 中選擇一個隨機選擇的元素。
 
 Example: ``random.randrange(0, 10)``
 
-:param start: (start) 範圍的開始 (包含)
-:param stop: (stop) 範圍結束 (排除)
-:param step: (step) 步驟。"""
+:param start: 範圍的開始 (包含)
+:param stop: 範圍結束 (排除)
+:param step: 步驟。"""
     ...
 _T = TypeVar('_T')
 
 def choice(seq: Sequence[_T]) -> _T:
-    """從非空序列 ``seq`` 中選擇一個隨機元素。 (choice)
+    """從非空序列 ``seq`` 中選擇一個隨機元素。
 
 Example: ``random.choice([Image.HAPPY, Image.SAD])``
 
-:param seq: (seq) 序列
+:param seq: 序列
 
 If ``seq`` is  empty, raises ``IndexError``."""
     ...
 
 def random() -> float:
-    """在 [0.0, 1.0) 範圍內生成一個隨機浮點數。 (random)
+    """在 [0.0, 1.0) 範圍內生成一個隨機浮點數。
 
 Example: ``random.random()``
 
@@ -71,10 +71,10 @@ Example: ``random.random()``
     ...
 
 def uniform(a: float, b: float) -> float:
-    """傳回一個介於 ``a`` 和 ``b`` 之間的隨機浮點數。 (uniform)
+    """傳回一個介於 ``a`` 和 ``b`` 之間的隨機浮點數。
 
 Example: ``random.uniform(0, 9)``
 
-:param a: (a) 範圍的起始值 (包括)
-:param b: (b) 範圍的結束值 (包含)"""
+:param a: 範圍的起始值 (包括)
+:param b: 範圍的結束值 (包含)"""
     ...

--- a/lang/zh-tw/typeshed/stdlib/speech.pyi
+++ b/lang/zh-tw/typeshed/stdlib/speech.pyi
@@ -1,13 +1,13 @@
-"""讓 micro:bit 說話、唱歌和發出類似聲音的其他語音。 (speech)"""
+"""讓 micro:bit 說話、唱歌和發出類似聲音的其他語音。"""
 from typing import Optional
 from .microbit import MicroBitDigitalPin, pin0
 
 def translate(words: str) -> str:
-    """將英語單字翻譯成音素。 (translate)
+    """將英語單字翻譯成音素。
 
 Example: ``speech.translate('hello world')``
 
-:param words: (words) 英文單字字串。
+:param words: 英文單字字串。
 :return: A string containing a best guess at the appropriate phonemes to pronounce.
 The output is generated from this `text to phoneme translation table <https://github.com/s-macke/SAM/wiki/Text-to-phoneme-translation-table>`_.
 
@@ -19,17 +19,16 @@ See `the online documentation <https://microbit-micropython.readthedocs.io/en/v2
     ...
 
 def pronounce(phonemes: str, pitch: int=64, speed: int=72, mouth: int=128, throat: int=128, pin: Optional[MicroBitDigitalPin]=pin0) -> None:
-    """發音音素。 (pronounce)
+    """發音音素。
 
 Example: ``speech.pronounce(' /HEHLOW WERLD')``
 
-:param phonemes: (phonemes) 發音的音素字串
+:param phonemes: 發音的音素字串
 :param pitch: (間距) 代表聲音音高的數字
-:param speed: (speed) 代表聲音速度的數字
-:param mouth: (mouth) 一個代表聲音的嘴巴的數字
-:param throat: (throat) 代表聲音的喉嚨的數字
-:param pin: (引腳
-) 指定輸出引腳的可選引數可用於覆寫預設值 ``pin0``。
+:param speed: 代表聲音速度的數字
+:param mouth: 一個代表聲音的嘴巴的數字
+:param throat: 代表聲音的喉嚨的數字
+:param pin: (引腳) 指定輸出引腳的可選引數可用於覆寫預設值 ``pin0``。
 如果我們不想從引腳上播放任何聲音，可以使用 ``pin=None``。僅限 micro:bit。
 
 Override the optional pitch, speed, mouth and throat settings to change the
@@ -39,17 +38,16 @@ See `the online documentation <https://microbit-micropython.readthedocs.io/en/v2
     ...
 
 def say(words: str, pitch: int=64, speed: int=72, mouth: int=128, throat: int=128, pin: MicroBitDigitalPin=pin0) -> None:
-    """說英語單詞。 (say)
+    """說英語單詞。
 
 Example: ``speech.say('hello world')``
 
-:param words: (words) 要說的一串詞。
+:param words: 要說的一串詞。
 :param pitch: (間距) 代表聲音音高的數字
-:param speed: (speed) 代表聲音速度的數字
-:param mouth: (mouth) 一個代表聲音的嘴巴的數字
-:param throat: (throat) 代表聲音的喉嚨的數字
-:param pin: (引腳
-) 指定輸出引腳的可選引數可用於覆寫預設值 ``pin0``。
+:param speed: 代表聲音速度的數字
+:param mouth: 一個代表聲音的嘴巴的數字
+:param throat: 代表聲音的喉嚨的數字
+:param pin: (引腳) 指定輸出引腳的可選引數可用於覆寫預設值 ``pin0``。
 如果我們不想從引腳上播放任何聲音，可以使用 ``pin=None``。 僅限 micro:bit。
 
 The result is semi-accurate for English. Override the optional pitch, speed,
@@ -62,17 +60,16 @@ See `the online documentation <https://microbit-micropython.readthedocs.io/en/v2
     ...
 
 def sing(phonemes: str, pitch: int=64, speed: int=72, mouth: int=128, throat: int=128, pin: MicroBitDigitalPin=pin0) -> None:
-    """唱出音素。 (sing)
+    """唱出音素。
 
 Example: ``speech.sing(' /HEHLOW WERLD')``
 
-:param phonemes: (phonemes) 要唱的一串詞。
+:param phonemes: 要唱的一串詞。
 :param pitch: (間距) 代表聲音音高的數字
-:param speed: (speed) 代表聲音速度的數字
-:param mouth: (mouth) 一個代表聲音的嘴巴的數字
-:param throat: (throat) 代表聲音的喉嚨的數字
-:param pin: (引腳
-) 指定輸出引腳的可選引數可用於覆寫預設值 ``pin0``。
+:param speed: 代表聲音速度的數字
+:param mouth: 一個代表聲音的嘴巴的數字
+:param throat: 代表聲音的喉嚨的數字
+:param pin: (引腳) 指定輸出引腳的可選引數可用於覆寫預設值 ``pin0``。
 如果我們不想從引腳上播放任何聲音，可以使用 ``pin=None``。僅限 micro:bit。
 
 Override the optional pitch, speed, mouth and throat settings to change

--- a/lang/zh-tw/typeshed/stdlib/struct.pyi
+++ b/lang/zh-tw/typeshed/stdlib/struct.pyi
@@ -1,56 +1,56 @@
-"""拆包和解包原始資料類型。 (struct)"""
+"""拆包和解包原始資料類型。"""
 from _typeshed import ReadableBuffer, WriteableBuffer
 from typing import Any, Tuple, Union
 
 def calcsize(fmt: str) -> int:
-    """取得存儲特定 ``fmt`` 所需的位元組數。 (calcsize)
+    """取得存儲特定 ``fmt`` 所需的位元組數。
 
 Example: ``struct.calcsize('hf')``
 
-:param fmt: (fmt) 格式字串。
+:param fmt: 格式字串。
 :return The number of bytes needed to store such a value."""
     ...
 
 def pack(fmt: str, v1: Any, *vn: Any) -> bytes:
-    """根據格式字串打包數值。 (pack)
+    """根據格式字串打包數值。
 
 Example: ``struct.pack('hf', 1, 3.1415)``
 
-:param fmt: (fmt) 格式字串
-:param v1: (v1) 首位數值
-:param *vn: (*vn) 剩餘數值。
+:param fmt: 格式字串
+:param v1: 首位數值
+:param *vn: 剩餘數值。
 :return A bytes object encoding the values."""
     ...
 
 def pack_into(fmt: str, buffer: WriteableBuffer, offset: int, v1: Any, *vn: Any) -> None:
-    """根據格式字串打包數值。 (pack into)
+    """根據格式字串打包數值。
 
 Example: ``struct.pack_info('hf', buffer, 1, 3.1415)``
 
-:param fmt: (fmt) 格式字串
-:param buffer: (buffer) 要寫入的緩衝區。
-:param offset: (offset) 緩衝區的偏移量。 從緩衝區末尾開始計數可能為負數。
-:param v1: (v1) 首位數值
-:param *vn: (*vn) 剩餘數值"""
+:param fmt: 格式字串
+:param buffer: 要寫入的緩衝區。
+:param offset: 緩衝區的偏移量。 從緩衝區末尾開始計數可能為負數。
+:param v1: 首位數值
+:param *vn: 剩餘數值"""
     ...
 
 def unpack(fmt: str, data: ReadableBuffer) -> Tuple[Any, ...]:
-    """根據格式字串解包數值。 (unpack)
+    """根據格式字串解包數值。
 
 Example: ``v1, v2 = struct.unpack('hf', buffer)``
 
-:param fmt: (fmt) 格式字串
-:param data: (data) 資料。
+:param fmt: 格式字串
+:param data: 資料。
 :return: A tuple of the unpacked values."""
     ...
 
 def unpack_from(fmt: str, buffer: ReadableBuffer, offset: int=0) -> Tuple:
-    """根據格式字串解包數值。 (unpack from)
+    """根據格式字串解包數值。
 
 Example: ``v1, v2 = struct.unpack_from('hf', buffer)``
 
-:param fmt: (fmt) 格式字串
-:param buffer: (buffer) 要讀取的來源緩衝區。
-:param offset: (offset) 緩衝區的偏移量。 從緩衝區末尾開始計數可能為負數。
+:param fmt: 格式字串
+:param buffer: 要讀取的來源緩衝區。
+:param offset: 緩衝區的偏移量。 從緩衝區末尾開始計數可能為負數。
 :return: A tuple of the unpacked values."""
     ...

--- a/lang/zh-tw/typeshed/stdlib/sys.pyi
+++ b/lang/zh-tw/typeshed/stdlib/sys.pyi
@@ -1,36 +1,36 @@
-"""系統特定函式 (sys)"""
+"""系統特定函式"""
 from typing import Any, Dict, List, NoReturn, TextIO, Tuple
 
 def exit(retval: object=...) -> NoReturn:
-    """使用指定的退出代碼來終止當前程式。 (exit)
+    """使用指定的退出代碼來終止當前程式。
 
 Example: ``sys.exit(1)``
 
 This function raises a ``SystemExit`` exception. If an argument is given, its
 value given as an argument to ``SystemExit``.
 
-:param retval: (retval) 退出代碼或訊息。"""
+:param retval: 退出代碼或訊息。"""
     ...
 
 def print_exception(exc: Exception) -> None:
-    """輸出帶有回溯的異常。 (print exception)
+    """輸出帶有回溯的異常。
 
 Example: ``sys.print_exception(e)``
 
-:param exc: (exc) 輸出異常
+:param exc: 輸出異常
 
 This is simplified version of a function which appears in the
 ``traceback`` module in CPython."""
 argv: List[str]
-"""當前程式啟動時使用的可變引數列表。 (argv)"""
+"""當前程式啟動時使用的可變引數列表。"""
 byteorder: str
-"""系統的位元組順序 (``"little"`` 或 ``"big"``)。 (byteorder)"""
+"""系統的位元組順序 (``"little"`` 或 ``"big"``)。"""
 
 class _implementation:
     name: str
     version: Tuple[int, int, int]
 implementation: _implementation
-"""包含關於目前 Python 執行資訊的物件。 (implementation)
+"""包含關於目前 Python 執行資訊的物件。
 
 For MicroPython, it has following attributes:
 
@@ -46,7 +46,7 @@ bare minimum is implemented in MicroPython.
 """
 maxsize: int
 """
-本機整數類型在當前平台上可以保存的最大值，或 MicroPython 整數類型可表示的最大值，如果它小於平台最大值 (對於沒有 long int 支援的 MicroPython 連接埠，就是這種情況)。 (maxsize)
+本機整數類型在當前平台上可以保存的最大值，或 MicroPython 整數類型可表示的最大值，如果它小於平台最大值 (對於沒有 long int 支援的 MicroPython 連接埠，就是這種情況)。
 
 This attribute is useful for detecting "bitness" of a platform (32-bit vs
 64-bit, etc.). It's recommended to not compare this attribute to some
@@ -67,13 +67,13 @@ value directly, but instead count number of bits in it::
         # "> 32", "> 64" style of comparisons.
 """
 modules: Dict[str, Any]
-"""載入模組的字典。 (modules)
+"""載入模組的字典。 
 
 On some ports, it may not include builtin modules."""
 path: List[str]
-"""用於搜尋匯入模組的可變字典列表。 (path)"""
+"""用於搜尋匯入模組的可變字典列表。"""
 platform: str
-"""MicroPython 執行的平台。 (platform)
+"""MicroPython 執行的平台。 
 
 For OS/RTOS ports, this is usually an identifier of the OS, e.g. ``"linux"``.
 For baremetal ports it is an identifier of a board, e.g. ``"pyboard"`` for 
@@ -84,9 +84,9 @@ If you need to check whether your program runs on MicroPython (vs other
 Python implementation), use ``sys.implementation`` instead.
 """
 version: str
-"""此執行符合的 Python 語言版本，作為字串。 (version)"""
+"""此執行符合的 Python 語言版本，作為字串。"""
 version_info: Tuple[int, int, int]
-"""此執行符合的 Python 語言版本，作為整數元組。 (version info)
+"""此執行符合的 Python 語言版本，作為整數元組。
 
 Only the first three version numbers (major, minor, micro) are supported and
 they can be referenced only by index, not by name.

--- a/lang/zh-tw/typeshed/stdlib/time.pyi
+++ b/lang/zh-tw/typeshed/stdlib/time.pyi
@@ -1,29 +1,29 @@
-"""測量時間並為程式增加延遲。 (time)"""
+"""測量時間並為程式增加延遲。"""
 from typing import Union
 
 def sleep(seconds: Union[int, float]) -> None:
-    """延遲秒數。 (sleep)
+    """延遲秒數。
 
 Example: ``time.sleep(1)``
 
-:param seconds: (seconds) 睡眠的秒數。
+:param seconds: 睡眠的秒數。
 使用浮點數代替分數來計算秒數。"""
     ...
 
 def sleep_ms(ms: int) -> None:
-    """延遲指定的毫秒數。 (sleep ms)
+    """延遲指定的毫秒數。
 
 Example: ``time.sleep_ms(1_000_000)``
 
-:param ms: (ms) 延遲的毫秒數 (>= 0)。"""
+:param ms: 延遲的毫秒數 (>= 0)。"""
     ...
 
 def sleep_us(us: int) -> None:
-    """延遲指定的微秒數。 (sleep us)
+    """延遲指定的微秒數。
 
 Example: ``time.sleep_us(1000)``
 
-:param us: (us) 延遲的微秒數 (>= 0)。"""
+:param us: 延遲的微秒數 (>= 0)。"""
     ...
 
 def ticks_ms() -> int:
@@ -43,7 +43,7 @@ Example: ``time.ticks_us()``
     ...
 
 def ticks_add(ticks: int, delta: int) -> int:
-    """特定數字的偏移 tick 值，可以是正數或負數。 (ticks add)
+    """特定數字的偏移 tick 值，可以是正數或負數。
 
 Example: ``time.ticks_add(time.ticks_ms(), 200)``
 
@@ -51,8 +51,8 @@ Given a ticks value, this function allows to calculate ticks
 value delta ticks before or after it, following modular-arithmetic
 definition of tick values.
 
-:param ticks: (ticks) tick 值
-:param delta: (delta) 整數偏移量
+:param ticks: tick 值
+:param delta: 整數偏移量
 
 Example::
 


### PR DESCRIPTION
Translator behaviour has varied significantly here and we might revisit the value of these strings but for now at least avoid swathes of redundant English.