### PR TITLE
Add publishing scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,8 @@
 /api-ids.json
 /node_modules/
 *.rst
+.idea
+.DS_Store
+scripts/publish/dist
 /crowdin/*.json
 __pycache__

--- a/scripts/publish/README.md
+++ b/scripts/publish/README.md
@@ -1,0 +1,19 @@
+This directory contains scripts and templates for packaging stubs as wheels and publishing these.
+
+Preparation:
+
+* Optional: remove old wheels from dist (required if you want to regenerate wheels for the same version)
+* Create a virtual environment
+* install `build` and `twine`
+
+Building the wheels:
+
+```
+python build-wheels.py
+```
+
+Publishing the wheels:
+
+```
+python publish-wheels.py
+```

--- a/scripts/publish/build-wheels.py
+++ b/scripts/publish/build-wheels.py
@@ -1,0 +1,38 @@
+import shutil
+import subprocess
+import os.path
+import sys
+
+def copy_file(src_path, dest_path, **replacements):
+    with open(src_path, "tr") as src:
+        with open(dest_path, "tw") as dst:
+            content = src.read()
+            for key in replacements:
+                content = content.replace("{" + key + "}", replacements[key])
+            dst.write(content)
+
+
+dist_dir = os.path.abspath("dist")
+all_langs_dir = os.path.join("..", "..", "lang")
+template_files = ["pyproject.toml", "README.md"]
+for lang in os.listdir(all_langs_dir):
+    if lang == ".DS_Store":
+        continue
+
+    lang_dir = os.path.join(all_langs_dir, lang)
+    for name in template_files:
+        copy_file(os.path.join("templates", name), os.path.join(lang_dir, name), lang=lang)
+
+    copy_file("../../LICENSE.md", os.path.join(lang_dir, "LICENSE.md"))
+
+    subprocess.run([sys.executable, "-m", "build", "--wheel", "--outdir", "dist", lang_dir])
+
+    # clean up
+    for name in template_files + [
+            "LICENSE.md", "build", f"micropython_microbit_stubs_{lang.replace('-', '_')}.egg-info"]:
+        full_path = os.path.join(lang_dir, name)
+        if os.path.isdir(full_path):
+            shutil.rmtree(full_path)
+        else:
+            os.remove(full_path)
+

--- a/scripts/publish/publish-wheels.py
+++ b/scripts/publish/publish-wheels.py
@@ -1,0 +1,4 @@
+import subprocess
+import sys
+
+subprocess.run([sys.executable, "-m", "twine", "upload", "dist/*.whl", "-u", "__token__"])

--- a/scripts/publish/templates/README.md
+++ b/scripts/publish/templates/README.md
@@ -1,0 +1,9 @@
+# BBC micro:bit MicroPython typing stubs
+
+This package contains Python stub files for 
+[MicroPython for micro:bit V2](https://github.com/microbit-foundation/micropython-microbit-v2).
+
+The docstrings are given in language {lang}.
+
+As the package contains stdlib stubs, the _typeshed path_ of the program analyzer (e.g. MyPy or Pyright) 
+needs to be configured accordingly.

--- a/scripts/publish/templates/pyproject.toml
+++ b/scripts/publish/templates/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name            = "micropython-microbit-stubs-{lang}"
+version         = "0.0.1-b2"
+description     = "BBC micro:bit MicroPython type stubs (language: {lang})"
+readme          = "README.md"
+license         = "MIT AND Apache-2.0"
+license-files   = ["LICENSE.md"]
+urls            = {"Homepage" = "https://github.com/microbit-foundation/micropython-microbit-stubs"}
+classifiers = [
+    "Programming Language :: Python :: Implementation :: MicroPython",
+    "Typing :: Stubs Only",
+]
+
+[tool.setuptools]
+packages = ["stdlib"]
+
+package-dir = {"stdlib" = "typeshed/stdlib"}
+
+[tool.setuptools.package-data]
+"*" = ["**/*.pyi"]


### PR DESCRIPTION
This PR adds scripts for packaging the stubs into wheels and uploading it to PyPI.

This will solve #106

I already published the wheels to PyPI under my account (e.g. https://pypi.org/project/micropython-microbit-stubs-en/). If you are interested in managing the wheels yourself, I can transfer the packages to you.